### PR TITLE
Remove -refspecfiles and -modelpath from plotartisspectra

### DIFF
--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -367,6 +367,7 @@ def make_spectrum_plot(speclist, axes, filterfunc, args, scale_to_peak=None):
 
 def make_emissionabsorption_plot(modelpath, axis, filterfunc, args=None, scale_to_peak=None):
     """Plot the emission and absorption by ion for an ARTIS model."""
+    print(modelpath)
     arraynu = at.get_nu_grid(modelpath)
 
     (timestepmin, timestepmax, args.timemin, args.timemax) = at.get_time_range(
@@ -474,14 +475,15 @@ def make_emissionabsorption_plot(modelpath, axis, filterfunc, args=None, scale_t
 
     ymaxrefall = 0.
     plotkwargs = {}
-    for index, filepath in enumerate(args.specpath[1:]):
-        assert not (Path(filepath).is_dir() or Path(filepath).name == 'spec.out')
+    for index, filepath in enumerate(args.specpath):
+        if Path(filepath).is_dir() or Path(filepath).name == 'spec.out':
+            continue
         if index < len(args.color):
             plotkwargs['color'] = args.color[index]
 
         supxmin, supxmax = axis.get_xlim()
         plotobj, serieslabel, ymaxref = plot_reference_spectrum(
-            filename, axis, supxmin, supxmax,
+            filepath, axis, supxmin, supxmax,
             filterfunc, scale_to_peak, scaletoreftime=args.scaletoreftime, **plotkwargs)
         ymaxrefall = max(ymaxrefall, ymaxref)
 

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -965,11 +965,6 @@ def main(args=None, argsraw=None, **kwargs):
         args.multispecplot = True
         args.timedays = args.timedayslist[0]
 
-    requiredlength = len(args.specpath)
-
-    args.color, args.label, args.linestyle, args.dashes = at.trim_or_pad(
-        requiredlength, args.color, args.label, args.linestyle, args.dashes)
-
     args.color, args.label, args.linestyle, args.dashes, args.linewidth = at.trim_or_pad(
         len(args.specpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth)
 

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -757,7 +757,7 @@ def addargs(parser):
     parser.add_argument('-label', default=[], nargs='*',
                         help='List of series label overrides')
 
-    parser.add_argument('-color', '-colors', dest='color', default=[f'C{i}' for i in range(10)], nargs='*',
+    parser.add_argument('-color', '-colors', dest='color', default=[], nargs='*',
                         help='List of line colors')
 
     parser.add_argument('-linestyle', default=[], nargs='*',
@@ -966,6 +966,20 @@ def main(args=None, argsraw=None, **kwargs):
     if args.timedayslist:
         args.multispecplot = True
         args.timedays = args.timedayslist[0]
+
+    if not args.color:
+        args.color = []
+        artismodelcolors = [f'C{i}' for i in range(10)]
+        refspeccolors = ['0.0', '0.3', '0.5', '0.7']
+        refspecnum = 0
+        artismodelnum = 0
+        for filepath in args.specpath:
+            if Path(filepath).is_dir() or Path(filepath).name == 'spec.out':
+                args.color.append(artismodelcolors[artismodelnum])
+                artismodelnum += 1
+            else:
+                args.color.append(refspeccolors[refspecnum])
+                refspecnum += 1
 
     args.color, args.label, args.linestyle, args.dashes, args.linewidth = at.trim_or_pad(
         len(args.specpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth)

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -476,8 +476,8 @@ def make_emissionabsorption_plot(modelpath, axis, filterfunc, args=None, scale_t
     plotkwargs = {}
     for index, filepath in enumerate(args.specpath[1:]):
         assert not (Path(filepath).is_dir() or Path(filepath).name == 'spec.out')
-        if index < len(args.colors):
-            plotkwargs['color'] = args.colors[index]
+        if index < len(args.color):
+            plotkwargs['color'] = args.color[index]
 
         supxmin, supxmax = axis.get_xlim()
         plotobj, serieslabel, ymaxref = plot_reference_spectrum(
@@ -755,7 +755,7 @@ def addargs(parser):
     parser.add_argument('-label', default=[], nargs='*',
                         help='List of series label overrides')
 
-    parser.add_argument('-color', default=[f'C{i}' for i in range(10)], nargs='*',
+    parser.add_argument('-color', '-colors', dest='color', default=[f'C{i}' for i in range(10)], nargs='*',
                         help='List of line colors')
 
     parser.add_argument('-linestyle', default=[], nargs='*',

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -17,7 +17,7 @@ at.enable_diskcache = False
 
 
 def test_spectraplot():
-    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=outputpath, timemin=290, timemax=320)
+    at.spectra.main(argsraw=[], specpath=[modelpath, 'sn2011fe_PTF11kly_20120822_norm.txt'], outputfile=outputpath, timemin=290, timemax=320)
 
 
 def test_spectra_frompackets():

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -17,25 +17,25 @@ at.enable_diskcache = False
 
 
 def test_spectraplot():
-    at.spectra.main(argsraw=[], modelpath=modelpath, outputfile=outputpath, timemin=290, timemax=320)
+    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=outputpath, timemin=290, timemax=320)
 
 
 def test_spectra_frompackets():
-    at.spectra.main(argsraw=[], modelpath=modelpath, outputfile=os.path.join(outputpath, 'spectrum_from_packets.pdf'),
+    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=os.path.join(outputpath, 'spectrum_from_packets.pdf'),
                     timemin=290, timemax=320, frompackets=True)
 
 
 def test_spectra_outputtext():
-    at.spectra.main(argsraw=[], modelpath=modelpath, output_spectra=True)
+    at.spectra.main(argsraw=[], specpath=modelpath, output_spectra=True)
 
 
 def test_spectraemissionplot():
-    at.spectra.main(argsraw=[], modelpath=modelpath, outputfile=outputpath, timemin=290, timemax=320,
+    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=outputpath, timemin=290, timemax=320,
                     emissionabsorption=True)
 
 
 def test_spectraemissionplot_nostack():
-    at.spectra.main(argsraw=[], modelpath=modelpath, outputfile=outputpath, timemin=290, timemax=320,
+    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=outputpath, timemin=290, timemax=320,
                     emissionabsorption=True, nostack=True)
 
 
@@ -94,5 +94,5 @@ def test_spectra_get_flux_contributions():
 
 def test_spectra_timeseries_subplots():
     timedayslist = [295, 300]
-    at.spectra.main(argsraw=[], modelpath=modelpath, outputfile=outputpath,
+    at.spectra.main(argsraw=[], specpath=modelpath, outputfile=outputpath,
                     timedayslist=timedayslist, multispecplot=True)


### PR DESCRIPTION
A better way than specifying ARTIS model paths and reference spectra separately is to use the single list of spectra in the specpath default positional argument and autodetect whether each item is a valid ARTIS folder, or else a valid reference spectrum path. The enables all spectra to be plotted in any order (compared to ref spectra either all before or all after ARTIS paths using --refspecafterartis) and with a single list of colors, labels, and line properties.