### PR TITLE
Added Python requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/artis-mcrt/artistools/badge)](https://www.codefactor.io/repository/github/artis-mcrt/artistools)
 
 ## Installation
+Requires Python >= 3.9  
+
 First clone the repository, for example:
 ```sh
 git clone https://github.com/artis-mcrt/artistools.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dynamic = ["version", "dependencies", "entry-points", "readme"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 #[project.scripts]
 #atcompletions = "artistoolscompletions.sh"


### PR DESCRIPTION
Added a comment to README that Python >= 3.9 is required. (Typing on default generics, e.g. collections.defaultdict, is only available since 3.9/ [PEP 585](https://peps.python.org/pep-0585/) )