### PR TITLE
Fix RuntimeWarning  on import

### DIFF
--- a/artistools/estimators/__init__.py
+++ b/artistools/estimators/__init__.py
@@ -15,3 +15,4 @@ from .estimators import read_estimators
 from .estimators import read_estimators_from_file
 from .plotestimators import addargs
 from .plotestimators import main
+from .plotestimators import main as plot

--- a/artistools/estimators/__init__.py
+++ b/artistools/estimators/__init__.py
@@ -1,5 +1,5 @@
 """Artistools - estimators related functions."""
-from .__main__ import main
+
 from .estimators import apply_filters
 from .estimators import get_averaged_estimators
 from .estimators import get_averageexcitation
@@ -14,4 +14,4 @@ from .estimators import parse_estimfile
 from .estimators import read_estimators
 from .estimators import read_estimators_from_file
 from .plotestimators import addargs
-from .plotestimators import main as plot
+from .plotestimators import main

--- a/artistools/estimators/__main__.py
+++ b/artistools/estimators/__main__.py
@@ -1,9 +1,4 @@
-from .plotestimators import main as plot
-
-
-def main() -> None:
-    plot()
-
+from .plotestimators import main
 
 if __name__ == "__main__":
     main()

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -17,6 +17,7 @@ from .lightcurve import read_reflightcurve_band_data
 from .lightcurve import readfile
 from .plotlightcurve import addargs
 from .plotlightcurve import main
+from .plotlightcurve import main as plot
 from .viewingangleanalysis import calculate_peak_time_mag_deltam15
 from .viewingangleanalysis import lightcurve_polyfit
 from .viewingangleanalysis import make_peak_colour_viewing_angle_plot

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -1,5 +1,4 @@
 """Artistools - light curve functions."""
-from .__main__ import main
 from .lightcurve import bolometric_magnitude
 from .lightcurve import evaluate_magnitudes
 from .lightcurve import generate_band_lightcurve_data
@@ -17,7 +16,7 @@ from .lightcurve import read_hesma_lightcurve
 from .lightcurve import read_reflightcurve_band_data
 from .lightcurve import readfile
 from .plotlightcurve import addargs
-from .plotlightcurve import main as plot
+from .plotlightcurve import main
 from .viewingangleanalysis import calculate_peak_time_mag_deltam15
 from .viewingangleanalysis import lightcurve_polyfit
 from .viewingangleanalysis import make_peak_colour_viewing_angle_plot

--- a/artistools/lightcurve/__main__.py
+++ b/artistools/lightcurve/__main__.py
@@ -1,8 +1,8 @@
-from .plotlightcurve import main as plot
+import artistools.lightcurve.plotlightcurve
 
 
 def main() -> None:
-    plot()
+    artistools.lightcurve.plotlightcurve.main()
 
 
 if __name__ == "__main__":

--- a/artistools/nltepops/__init__.py
+++ b/artistools/nltepops/__init__.py
@@ -8,3 +8,4 @@ from .nltepops import texifyconfiguration
 from .nltepops import texifyterm
 from .plotnltepops import addargs
 from .plotnltepops import main
+from .plotnltepops import main as plot

--- a/artistools/nltepops/__init__.py
+++ b/artistools/nltepops/__init__.py
@@ -1,5 +1,5 @@
 """Artistools - non-LTE population functions."""
-from .__main__ import main
+
 from .nltepops import add_lte_pops
 from .nltepops import read_file
 from .nltepops import read_file_filtered
@@ -7,4 +7,4 @@ from .nltepops import read_files
 from .nltepops import texifyconfiguration
 from .nltepops import texifyterm
 from .plotnltepops import addargs
-from .plotnltepops import main as plot
+from .plotnltepops import main

--- a/artistools/nonthermal/__init__.py
+++ b/artistools/nonthermal/__init__.py
@@ -1,7 +1,6 @@
 """Artistools - spectra related functions."""
 import artistools.nonthermal.solvespencerfanocmd
 
-from .__main__ import main
 from ._nonthermal_core import analyse_ntspectrum
 from ._nonthermal_core import ar_xs
 from ._nonthermal_core import calculate_frac_heating
@@ -43,4 +42,4 @@ from ._nonthermal_core import sfmatrix_add_ionization_shell
 from ._nonthermal_core import solve_spencerfano_differentialform
 from ._nonthermal_core import workfunction_tests
 from .plotnonthermal import addargs
-from .plotnonthermal import main as plot
+from .plotnonthermal import main

--- a/artistools/nonthermal/__init__.py
+++ b/artistools/nonthermal/__init__.py
@@ -43,3 +43,4 @@ from ._nonthermal_core import solve_spencerfano_differentialform
 from ._nonthermal_core import workfunction_tests
 from .plotnonthermal import addargs
 from .plotnonthermal import main
+from .plotnonthermal import main as plot

--- a/artistools/spectra/__init__.py
+++ b/artistools/spectra/__init__.py
@@ -1,7 +1,5 @@
 """Artistools - spectra related functions."""
-from .__main__ import main
-from .plotspectra import addargs
-from .plotspectra import main as plot
+from .plotspectra import main
 from .spectra import get_exspec_bins
 from .spectra import get_flux_contributions
 from .spectra import get_flux_contributions_from_packets

--- a/artistools/spectra/__init__.py
+++ b/artistools/spectra/__init__.py
@@ -1,5 +1,6 @@
 """Artistools - spectra related functions."""
 from .plotspectra import main
+from .plotspectra import main as plot
 from .spectra import get_exspec_bins
 from .spectra import get_flux_contributions
 from .spectra import get_flux_contributions_from_packets

--- a/artistools/spectra/__main__.py
+++ b/artistools/spectra/__main__.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-from .plotspectra import main as plot
-
-
-def main() -> None:
-    plot()
-
+from .plotspectra import main
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ disable = """
     line-too-long,
     protected-access,
     redefined-outer-name,
+    reimported,
     too-many-arguments,
     too-many-branches,
     too-many-lines,


### PR DESCRIPTION
Fixes issue in artis CI:
/opt/hostedtoolcache/Python/3.10.11/x64/lib/python3.10/runpy.py:126: RuntimeWarning: 'artistools.lightcurve.__main__' found in sys.modules after import of package 'artistools.lightcurve', but prior to execution of 'artistools.lightcurve.__main__'; this may result in unpredictable behaviour