### PR TITLE
Fix RuntimeWarning about artistools.__main__

### DIFF
--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -25,8 +25,7 @@ from artistools import radfield as radfield
 from artistools import spectra as spectra
 from artistools import transitions as transitions
 from artistools import writecomparisondata as writecomparisondata
-from artistools.__main__ import addargs as addargs
-from artistools.__main__ import main as main
+from artistools.commands import addargs as addargs
 from artistools.configuration import get_config as get_config
 from artistools.configuration import set_config as set_config
 from artistools.estimators import read_estimators as read_estimators

--- a/artistools/__main__.py
+++ b/artistools/__main__.py
@@ -1,59 +1,24 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
-import importlib
 import typing as t
 
 import argcomplete
 
-from artistools.commands import CommandType
-from artistools.commands import subcommandtree as atdictcommands
+from artistools.commands import addsubparsers
+from artistools.commands import subcommandtree
 from artistools.misc import CustomArgHelpFormatter
-
-
-def addsubparsers(
-    parser: argparse.ArgumentParser, parentcommand: str, subcommandtree: CommandType, depth: int = 1
-) -> None:
-    def func(args: t.Any) -> None:
-        parser.print_help()
-
-    parser.set_defaults(func=func)
-    subparsers = parser.add_subparsers(dest=f"{parentcommand} command", required=False)
-
-    for subcommand, subcommands in subcommandtree.items():
-        strhelp: str | None
-        if isinstance(subcommands, dict):
-            strhelp = "command group"
-            submodule = None
-        else:
-            submodulename, funcname = subcommands
-            namestr = f"artistools.{submodulename.removeprefix('artistools.')}" if submodulename else "artistools"
-            submodule = importlib.import_module(namestr, package="artistools")
-            func = getattr(submodule, funcname)
-            strhelp = func.__doc__
-
-        subparser = subparsers.add_parser(subcommand, help=strhelp, formatter_class=CustomArgHelpFormatter)
-
-        if submodule:
-            submodule.addargs(subparser)
-            subparser.set_defaults(func=func)
-        else:
-            assert not isinstance(subcommands, tuple)
-            addsubparsers(parser=subparser, parentcommand=subcommand, subcommandtree=subcommands, depth=depth + 1)
-
-
-def addargs(parser: argparse.ArgumentParser) -> None:
-    pass
 
 
 def main(args: argparse.Namespace | None = None, argsraw: t.Sequence[str] | None = None, **kwargs: t.Any) -> None:
     """Parse and run artistools commands."""
     parser = argparse.ArgumentParser(
+        prog="artistools",
         formatter_class=CustomArgHelpFormatter,
         description="Artistools base command.",
     )
     parser.set_defaults(func=None)
 
-    addsubparsers(parser, "artistools", atdictcommands)
+    addsubparsers(parser, "artistools", subcommandtree)
 
     argcomplete.autocomplete(parser)
     if args is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ readme = {file = "README.md", content-type='text/markdown'}
 Repository ="https://www.github.com/artis-mcrt/artistools"
 
 [project.scripts]
-at = 'artistools:main'
-artistools = 'artistools:main'
+at = 'artistools.__main__:main'
+artistools = 'artistools.__main__:main'
 makeartismodel1dslicefromcone = 'artistools.inputmodel.slice1dfromconein3dmodel:main'
 makeartismodel = 'artistools.inputmodel.makeartismodel:main'
 plotartisdensity = 'artistools.inputmodel.plotdensity:main'


### PR DESCRIPTION
Fix RuntimeWarning: 'artistools.__main__' found in sys.modules after import of package 'artistools', but prior to execution of 'artistools.__main__'; this may result in unpredictable behaviour