### PR TITLE
Fix spectra plotting from specpol.out file

### DIFF
--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -467,6 +467,9 @@ def get_spectrum(
         arr_tdelta = at.get_timestep_times(modelpath, loc="delta")
 
         try:
+            specdata[dirbin] = specdata[dirbin].with_columns([
+                pl.col(col).cast(pl.Float64) for col in specdata[dirbin].columns
+            ])
             arr_f_nu = specdata[dirbin].select(
                 pl.sum_horizontal(
                     pl.col(specdata[dirbin].columns[timestep + 1]) * arr_tdelta[timestep]
@@ -576,7 +579,7 @@ def get_specpol_data(
         )
 
         print(f"Reading {specfilename}")
-        specdata = pl.read_csv(specfilename, separator=" ", has_header=True)
+        specdata = pl.read_csv(specfilename, separator=" ", has_header=True, infer_schema=False)
 
     return split_dataframe_stokesparams(specdata)
 

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -467,9 +467,6 @@ def get_spectrum(
         arr_tdelta = at.get_timestep_times(modelpath, loc="delta")
 
         try:
-            specdata[dirbin] = specdata[dirbin].with_columns([
-                pl.col(col).cast(pl.Float64) for col in specdata[dirbin].columns
-            ])
             arr_f_nu = specdata[dirbin].select(
                 pl.sum_horizontal(
                     pl.col(specdata[dirbin].columns[timestep + 1]) * arr_tdelta[timestep]
@@ -580,6 +577,7 @@ def get_specpol_data(
 
         print(f"Reading {specfilename}")
         specdata = pl.read_csv(specfilename, separator=" ", has_header=True, infer_schema=False)
+        specdata = specdata.with_columns(pl.all().cast(pl.Float64))
 
     return split_dataframe_stokesparams(specdata)
 

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -329,7 +329,7 @@ def read_spec(modelpath: Path, printwarningsonly: bool = False) -> pl.DataFrame:
     print(f"Reading {specfilename}")
 
     return (
-        pl.read_csv(at.zopenpl(specfilename), separator=" ", infer_schema_length=0, truncate_ragged_lines=True)
+        pl.read_csv(at.zopenpl(specfilename), separator=" ", infer_schema=False, truncate_ragged_lines=True)
         .with_columns(pl.all().cast(pl.Float64))
         .rename({"0": "nu"})
     )
@@ -345,7 +345,7 @@ def read_spec_res(modelpath: Path) -> dict[int, pl.DataFrame]:
     )
 
     print(f"Reading {specfilename} (in read_spec_res)")
-    res_specdata_in = pl.read_csv(at.zopenpl(specfilename), separator=" ", has_header=False, infer_schema_length=0)
+    res_specdata_in = pl.read_csv(at.zopenpl(specfilename), separator=" ", has_header=False, infer_schema=False)
 
     # drop last column of nulls (caused by trailing space on each line)
     if res_specdata_in[res_specdata_in.columns[-1]].is_null().all():
@@ -576,8 +576,9 @@ def get_specpol_data(
         )
 
         print(f"Reading {specfilename}")
-        specdata = pl.read_csv(specfilename, separator=" ", has_header=True, infer_schema=False)
-        specdata = specdata.with_columns(pl.all().cast(pl.Float64))
+        specdata = pl.read_csv(specfilename, separator=" ", has_header=True, infer_schema=False).with_columns(
+            pl.all().cast(pl.Float64)
+        )
 
     return split_dataframe_stokesparams(specdata)
 


### PR DESCRIPTION
-The infer schema option used by polars when reading specpol.out was incorrectly inferring values as int64 (when they  should have been floats) as many of the previous values in the column were 0.

-data types for all columns in specdata data were assumed to be str which was causing issues when trying to operate on the columns so have set the data type to float64 for all the columns instead 


