### PR TITLE
Update decayproducts.py

### DIFF
--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -74,7 +74,7 @@ def get_nuc_data(nuc_dataset: str):
                 },
             )
             if len(dfnuc) > 0:
-                dfnuc = dfnuc.loc[dfnuc['p_energy'] == 0]
+                dfnuc = dfnuc.loc[dfnuc["p_energy"] == 0]
                 tau_s = dfnuc.iloc[0]["half_life_sec"] / math.log(2)
                 # tau_s = hrow["tau[s]"]
                 Q_MeV = dfnuc.iloc[0]["q"] / 1000

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -74,6 +74,7 @@ def get_nuc_data(nuc_dataset: str):
                 },
             )
             if len(dfnuc) > 0:
+                dfnuc = dfnuc.loc[dfnuc['p_energy'] == 0]
                 tau_s = dfnuc.iloc[0]["half_life_sec"] / math.log(2)
                 # tau_s = hrow["tau[s]"]
                 Q_MeV = dfnuc.iloc[0]["q"] / 1000


### PR DESCRIPTION
Wrong ensdf data was caused by keeping transitions with p_energy greater than 0. Should be excluded according to the documentation and I overlooked the corresponding part of the query in my original script.