### PR TITLE
Add cell merging to e2e mapping

### DIFF
--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -457,12 +457,12 @@ def create_ARTIS_modelfile(
     at.inputmodel.save_modeldata(dfmodel=dfmodel, modelmeta=modelmeta, outpath=outputpath)
 
 
-def get_old_cell_indices(red_fact: int, new_r: int, new_z: int, N_cell_r_old: int) -> npt.NDArray[np.int64]:
+def get_old_cell_indices(red_fact: int, new_r: int, new_z: int, N_cell_r_old: int) -> list[int]:
     # function to get old grid indices for a given new grid index
     old_r_indices = np.arange(red_fact * (new_r - 1) + 1, red_fact * new_r + 1)
     old_z_indices = np.arange(red_fact * (new_z - 1), red_fact * new_z) * N_cell_r_old
     indices = np.add.outer(old_r_indices, old_z_indices).flatten().tolist()
-    return np.array(sorted(np.int64(x) for x in indices))
+    return sorted(int(x) for x in indices)
 
 
 def remap_mass_weighted_quantity(


### PR DESCRIPTION
Add an option to the script which merges a square number of cells after the main script is run. Main purpose: If some potentially critical mass fractions are not properly mapped by eg. 25x50 cells, the consistency in mass fractions can be improved by mapping to 100x200 cells first and then merging cells in the ARTIS model to downgrade to a 25x50 model again, now with more consistent mass fractions.