### PR TITLE
Update inputmodel_misc.py

### DIFF
--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -213,9 +213,11 @@ def read_modelfile_text(
 
         dfmodel = pl.from_pandas(dfmodelpd).lazy()
 
-    dfmodel = dfmodel.rename({"velocity_outer": "vel_r_max_kmps"}, strict=False)
+    if "velocity_outer" in dfmodel.columns:
+        dfmodel = dfmodel.rename({"velocity_outer": "vel_r_max_kmps"}, strict=False)
 
-    dfmodel = dfmodel.rename({"cellYe": "Ye"}, strict=False)
+    if "cellYe" in dfmodel.columns:
+        dfmodel = dfmodel.rename({"cellYe": "Ye"}, strict=False)
 
     if modelmeta["dimensions"] == 1:
         vmax_kmps = dfmodel.select(pl.col("vel_r_max_kmps").max()).collect().item()


### PR DESCRIPTION
Catch polars column-not-found error: In the current main branch, the code crashed in line 221 for a 1D model because for some strange reason it was apparently searching for a column "velocity_outer". But the column was never named like this anyway, so line 216 is - at least for the 1D model - superfluous.