### PR TITLE
Extension of AT2017gfo spectra meta files

### DIFF
--- a/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57988.990_Phase+6.40d.dat.meta.yml
+++ b/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57988.990_Phase+6.40d.dat.meta.yml
@@ -1,7 +1,7 @@
 ---
 dist_mpc: 40
-label: AT2017gfo +5.40d
-t: 5.40
+label: AT2017gfo +6.40d
+t: 6.40
 e_bminusv: 0.11 # smartt 2017
 r_v: 3.1
 z: 0.009727

--- a/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57990.000_Phase+7.40d.dat.meta.yml
+++ b/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57990.000_Phase+7.40d.dat.meta.yml
@@ -1,7 +1,7 @@
 ---
 dist_mpc: 40
-label: AT2017gfo +5.40d
-t: 5.40
+label: AT2017gfo +7.40d
+t: 7.40
 e_bminusv: 0.11 # smartt 2017
 r_v: 3.1
 z: 0.009727

--- a/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57991.000_Phase+8.40d.dat.meta.yml
+++ b/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57991.000_Phase+8.40d.dat.meta.yml
@@ -1,7 +1,7 @@
 ---
 dist_mpc: 40
-label: AT2017gfo +5.40d
-t: 5.40
+label: AT2017gfo +8.40d
+t: 8.40
 e_bminusv: 0.11 # smartt 2017
 r_v: 3.1
 z: 0.009727

--- a/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57992.000_Phase+9.40d.dat.meta.yml
+++ b/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57992.000_Phase+9.40d.dat.meta.yml
@@ -1,7 +1,7 @@
 ---
 dist_mpc: 40
-label: AT2017gfo +5.40d
-t: 5.40
+label: AT2017gfo +9.40d
+t: 9.40
 e_bminusv: 0.11 # smartt 2017
 r_v: 3.1
 z: 0.009727

--- a/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57993.000_Phase+10.40d.dat.meta.yml
+++ b/artistools/data/refspectra/AT2017gfo_ENGRAVE_v1.0_XSHOOTER_MJD-57993.000_Phase+10.40d.dat.meta.yml
@@ -1,7 +1,7 @@
 ---
 dist_mpc: 40
-label: AT2017gfo +5.40d
-t: 5.40
+label: AT2017gfo +10.40d
+t: 10.40
 e_bminusv: 0.11 # smartt 2017
 r_v: 3.1
 z: 0.009727


### PR DESCRIPTION
Added meta files for the reference spectra of AT2017gfo at later times (after 5.4 days). The meta file for 5.4 days also contained a typo which is fixed with this commit.