### PR TITLE
Fix bugs, logical errors, and dead code across several modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
       hooks:
           - id: ty
             name: ty
+            args: [--all-extras]
 
 ci:
     skip: [ty]

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -385,7 +385,7 @@ def get_averageexcitation(
             .item()
         )
 
-        boltzfac_sum = energy_boltzfac_sum = (
+        boltzfac_sum = (
             ionlevels[levelnumber_sl:].select(pl.col("g") * (-pl.col("energy_ev") / k_b / T_exc).exp()).sum().item()
         )
         # adjust to the actual superlevel population from ARTIS

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -276,23 +276,19 @@ def generate_band_lightcurve_data(
                     average_over_theta=args.average_over_theta_angle,
                 )
 
+                # interpolate the coarser-sampled series onto the finer wavelength grid before multiplying
                 if len(wavelength_from_spectrum) > len(wavefilter):
-                    interpolate_fn = interp1d(x=wavefilter, y=transmission, bounds_error=False, fill_value=0.0)  # type: ignore[arg-type] # pyright: ignore[reportArgumentType] # pyrefly: ignore [bad-argument-type]
-                    wavefilter = np.linspace(
-                        np.min(wavelength_from_spectrum),
-                        int(np.max(wavelength_from_spectrum)),
-                        len(wavelength_from_spectrum),
-                    )
-                    transmission = interpolate_fn(wavefilter)
+                    interpolate_fn = interp1d(x=wavefilter, y=transmission, bounds_error=False, fill_value=0.0)
+                    integrand = flux * interpolate_fn(wavelength_from_spectrum)
+                    integration_grid = wavelength_from_spectrum
                 else:
                     interpolate_fn = interp1d(wavelength_from_spectrum, flux, bounds_error=False, fill_value=0.0)
-                    wavelength_from_spectrum = np.linspace(wavefilter_min, wavefilter_max, len(wavefilter))
-                    flux = interpolate_fn(wavelength_from_spectrum)
+                    integrand = interpolate_fn(wavefilter) * transmission
+                    integration_grid = wavefilter
 
-                weighted_flux_obs = abs(np.trapezoid(flux * transmission, wavelength_from_spectrum))  # pyright: ignore[reportArgumentType]
-                assert isinstance(weighted_flux_obs, float)
+                weighted_flux_obs = float(abs(np.trapezoid(integrand, integration_grid)))
                 phot_filtobs_sn: float | int = (
-                    0.0 if weighted_flux_obs == 0.0 else -2.5 * np.log10(weighted_flux_obs / zeropointenergyflux)
+                    0.0 if weighted_flux_obs == 0.0 else -2.5 * math.log10(weighted_flux_obs / zeropointenergyflux)
                 )
 
                 if phot_filtobs_sn != 0.0:

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -329,43 +329,45 @@ def make_flux_ratio_plot(args: argparse.Namespace) -> None:
         for ax in axes:
             ax.plot(arr_tdays, arr_floersfit, color="black", label="Flörs+2020 fit", lw=2.0)
 
-        femis = pd.read_csv(
+        floersmodelratiopath = Path(
             "/Users/luke/iCloud/Papers (first-author)/2022 Artis ionisation/"
             "generateplots/floers_model_NIR_VIS_ratio_20201126.csv"
         )
+        if floersmodelratiopath.is_file():
+            femis = pd.read_csv(floersmodelratiopath)
 
-        amodels: dict[str, tuple[list[int], list[float]]] = {}
-        for _index, row in femis.iterrows():
-            modelname = row.file.replace("fig-nne_Te_allcells-", "").replace(f"-{row.epoch}d.txt", "")
-            if modelname not in amodels:
-                amodels[modelname] = ([], [])
-            if int(row.epoch) != 263:
-                amodels[modelname][0].append(row.epoch)
-                amodels[modelname][1].append(row.NIR_VIS_ratio)
+            amodels: dict[str, tuple[list[int], list[float]]] = {}
+            for _index, row in femis.iterrows():
+                modelname = row.file.replace("fig-nne_Te_allcells-", "").replace(f"-{row.epoch}d.txt", "")
+                if modelname not in amodels:
+                    amodels[modelname] = ([], [])
+                if int(row.epoch) != 263:
+                    amodels[modelname][0].append(row.epoch)
+                    amodels[modelname][1].append(row.NIR_VIS_ratio)
 
-        # for amodelname, (xlist, ylist) in amodels.items():
-        for aindex, (amodelname, alabel) in enumerate([
-            ("w7", "W7")
-            # ("subch", "S0"),
-            # ('subch_shen2018', r'1M$_\odot$'),
-            # ('subch_shen2018_electronlossboost4x', '1M$_\odot$ (Shen+18) 4x e- loss'),
-            # ('subch_shen2018_electronlossboost8x', r'1M$_\odot$ heatboost8'),
-            # ('subch_shen2018_electronlossboost12x', '1M$_\odot$ (Shen+18) 12x e- loss'),
-        ]):
-            xlist, ylist = amodels[amodelname]
-            color = args.color[aindex] if aindex < len(args.color) else None
-            print(amodelname, xlist, ylist)
-            axis.plot(
-                xlist,
-                ylist,
-                color=color,
-                label="Flörs " + alabel,
-                marker="+",
-                markersize=10,
-                markeredgewidth=2,
-                lw=0,
-                alpha=0.8,
-            )
+            # for amodelname, (xlist, ylist) in amodels.items():
+            for aindex, (amodelname, alabel) in enumerate([
+                ("w7", "W7")
+                # ("subch", "S0"),
+                # ('subch_shen2018', r'1M$_\odot$'),
+                # ('subch_shen2018_electronlossboost4x', '1M$_\odot$ (Shen+18) 4x e- loss'),
+                # ('subch_shen2018_electronlossboost8x', r'1M$_\odot$ heatboost8'),
+                # ('subch_shen2018_electronlossboost12x', '1M$_\odot$ (Shen+18) 12x e- loss'),
+            ]):
+                xlist, ylist = amodels[amodelname]
+                color = args.color[aindex] if aindex < len(args.color) else None
+                print(amodelname, xlist, ylist)
+                axis.plot(
+                    xlist,
+                    ylist,
+                    color=color,
+                    label="Flörs " + alabel,
+                    marker="+",
+                    markersize=10,
+                    markeredgewidth=2,
+                    lw=0,
+                    alpha=0.8,
+                )
     m18_tdays = np.array([206, 229, 303, 339])
     m18_pew = {}
     # m18_pew[(26, 2, 12570)] = np.array([2383, 1941, 2798, 6770])

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -801,19 +801,11 @@ def make_3d_grid(
     modeldata: pd.DataFrame, vmax_cms: float
 ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
     grid = round(len(modeldata["inputcellid"]) ** (1.0 / 3.0))
-    xgrid = np.zeros(grid)
     vmax = vmax_cms / CLIGHT
-    i = 0
-    for _z in range(grid):
-        for _y in range(grid):
-            for nx in range(grid):
-                xgrid[nx] = -vmax + 2 * nx * vmax / grid
-                i += 1
+    xgrid = np.array([-vmax + 2 * nx * vmax / grid for nx in range(grid)])
 
     x, y, z = np.meshgrid(xgrid, xgrid, xgrid)
     grid_3d = np.array([xgrid, xgrid, xgrid])
-    # grid_Te = np.zeros((grid, grid, grid))
-    # print(grid_Te.shape)
     return grid_3d, x, y, z
 
 

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -170,7 +170,7 @@ def plot_last_emission_velocities_histogram(
     dfpackets_selected = dfpackets.filter(pl.col("t_arrive_d").is_between(timelow, timehigh, closed="right"))
 
     if costhetabin is not None:
-        dfpackets_selected = dfpackets.filter(pl.col("costhetabin") == costhetabin)
+        dfpackets_selected = dfpackets_selected.filter(pl.col("costhetabin") == costhetabin)
 
     weight_by_energy = True
     if weight_by_energy:
@@ -260,10 +260,11 @@ def get_reduced_packet_set(
         dfpackets_selected = dfpackets_selected.filter(
             (pl.col("lambda_rf") > lam_min) & (pl.col("lambda_rf") < lam_max)
         )
-    nphibins = at.get_viewingdirection_phibincount()
-    dfpackets_selected_dirbinned = dfpackets_selected.filter(pl.col("costhetabin") * nphibins == dirbin)
+    if dirbin >= 0:
+        nphibins = at.get_viewingdirection_phibincount()
+        dfpackets_selected = dfpackets_selected.filter(pl.col("costhetabin") * nphibins == dirbin)
 
-    return nprocs_read, dfpackets_selected_dirbinned
+    return nprocs_read, dfpackets_selected
 
 
 def packets_2d_hist_bin_and_ejecta_vel(
@@ -339,7 +340,7 @@ def packets_2d_hist_bin_and_ejecta_vel(
             * pl.col(f"{pos_type_str}em_time")
         ).alias("hollow_cyl_vol_em")
     ).collect()
-    solidanglefactor = at.get_viewingdirection_costhetabincount() if dirbin else 1.0
+    solidanglefactor = at.get_viewingdirection_costhetabincount() if dirbin >= 0 else 1.0
     energy_sum = float(dfpackets_selected["e_rf"].sum())
     print(f"Directional 4pi-equivalent bol. luminosity of {energy_sum / nprocs_read / Delta_t_secs * solidanglefactor}")
 
@@ -419,8 +420,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         message = "Wavelength mode requires both -wavelen and -binwidth to be provided."
         raise ValueError(message)
 
-    assert (args.dirbin % at.get_viewingdirection_phibincount()) == 0, (
-        "dirbin needs to be a multiple of 10 (to be improved)"
+    assert args.dirbin == -1 or (args.dirbin % at.get_viewingdirection_phibincount()) == 0, (
+        "dirbin needs to be -1 (isotropic) or a multiple of 10 (to be improved)"
     )
 
     packets_2d_hist_bin_and_ejecta_vel(

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -76,10 +76,7 @@ def plot_spherical(
 
     aggs = []
     if nnelement_vars := [var for var in plotvars if var.startswith("nnelement_")]:
-        aggs += [
-            ((pl.col(var) * pl.col("e_rf")).mean() / pl.col("e_rf").mean() / 29979245800).alias(var)
-            for var in nnelement_vars
-        ]
+        aggs += [((pl.col(var) * pl.col("e_rf")).mean() / pl.col("e_rf").mean()).alias(var) for var in nnelement_vars]
 
     if "emvelocityoverc" in plotvars:
         aggs.append(
@@ -314,7 +311,11 @@ def main(args: argparse.Namespace | None = None, argsraw: list[str] | None = Non
 
     at.plottools.set_mpl_style()
 
-    dfestimators = at.estimators.scan_estimators(modelpath=args.modelpath) if "temperature" in args.plotvars else None
+    dfestimators = (
+        at.estimators.scan_estimators(modelpath=args.modelpath)
+        if any(var in {"temperature", "temperature_sigma"} or var.startswith("nnelement_") for var in args.plotvars)
+        else None
+    )
 
     nprocs_read, dfpackets = at.packets.get_packets(
         args.modelpath, args.maxpacketfiles, packet_type="TYPE_ESCAPE", escape_type="TYPE_RPKT"

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -956,7 +956,7 @@ def make_emissionabsorption_plot(
 
     elif contributions_sorted_reduced:
         if args.showemission:
-            dfabsorptionspectra = pl.collect_all([
+            dfemissionspectra = pl.collect_all([
                 atspectra.get_dfspectrum_x_y_with_units(
                     pl.DataFrame({"f_lambda": x.array_flambda_emission, "lambda_angstroms": arraylambda_angstroms}),
                     xunit=args.xunit,
@@ -967,8 +967,8 @@ def make_emissionabsorption_plot(
             ])
             assert not any(x.color is None for x in contributions_sorted_reduced)
             stackplot = axis.stackplot(
-                dfabsorptionspectra[0]["x"],
-                [dfspec["y"] * scalefactor for dfspec in dfabsorptionspectra],
+                dfemissionspectra[0]["x"],
+                [dfspec["y"] * scalefactor for dfspec in dfemissionspectra],
                 colors=[x.color for x in contributions_sorted_reduced if x.color is not None],
                 linewidth=0,
             )

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -1087,7 +1087,7 @@ def get_flux_contributions(
 
                 if filterfunc:
                     array_fnu_emission = filterfunc(array_fnu_emission)
-                    if selectedcolumn <= nelements * maxion:
+                    if selectedcolumn < nelements * maxion:
                         array_fnu_absorption = filterfunc(array_fnu_absorption)
 
                 array_flambda_emission = array_fnu_emission * arraynu / arraylambda

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -163,7 +163,6 @@ def make_plot(
         print(figure_title)
         axes[0].set_title(figure_title, fontsize=10)
 
-    peak_y_value = -1
     yvalues_combined = np.zeros((len(temperature_list), len(xvalues)))
     for seriesindex, temperature in enumerate(temperature_list):
         serieslabel = "NLTE" if temperature == "NOTEMPNLTE" else f"LTE {temperature} = {vardict[temperature]:.0f} K"
@@ -173,13 +172,10 @@ def make_plot(
 
             axis.plot(xvalues, yvalues[seriesindex][ion_index], linewidth=1.5, label=serieslabel)
 
-            peak_y_value = max(yvalues[seriesindex][ion_index])
-
             axis.legend(loc="upper left", handlelength=1, frameon=False, numpoints=1, prop={"size": 8})
 
         if len(axes) > len(ionlist):
             axes[len(ionlist)].plot(xvalues, yvalues_combined[seriesindex], linewidth=1.5, label=serieslabel)
-            peak_y_value = max([peak_y_value] + yvalues_combined[seriesindex])
 
     axislabels = [
         f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[IonTuple(Z, ion_stage)]:.1e}/cm³)"
@@ -367,8 +363,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         if time_days != -1:
             figure_title += f" ({time_days:.1f}d)"
 
-        # -1 means use NLTE populations
-        temperature_list = ["Te", "TR", "NOTEMPNLTE"]
+        # NOTEMPNLTE means use NLTE populations
         temperature_list = ["NOTEMPNLTE"]
         vardict = {"Te": Te, "TR": TR}
     else:
@@ -512,13 +507,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
                     popcolumnname = f"upper_pop_lte_{T_exc:.0f}K"
                     if args.atomicdatabase == "artis":
                         K_B = 8.617333262145179e-05  # eV / K
-                        pldftransitions = ion["transitions"]
-                        assert isinstance(pldftransitions, pl.DataFrame)
                         ltepartfunc = (
-                            pldftransitions
-                            .select(pl.col("g") * (-pl.col("energy_ev") / K_B / T_exc).exp())
-                            .sum()
-                            .item()
+                            pldflevels.select(pl.col("g") * (-pl.col("energy_ev") / K_B / T_exc).exp()).sum().item()
                         )
                     else:
                         ltepartfunc = 1.0


### PR DESCRIPTION
- estimators.py: fix chained assignment that overwrote the energy-weighted Boltzmann sum with the unweighted sum, making the superlevel contribution in get_averageexcitation always equal to the superlevel population (average energy factor of 1)

- transitions.py: in the LTE/ARTIS-database branch, the LTE partition function was computed from the transitions table (which has no g/energy_ev columns) while clobbering the prepared transitions frame, crashing the default plottransitions invocation without a model. Compute it from the ion's levels table instead. Also remove a dead temperature_list assignment and unused peak_y_value bookkeeping that performed element-wise list+array addition instead of a max

- plotspherical.py: nnelement_* directional averages were divided by the speed of light (copy-paste from the velocity aggregations) while labelled as /cm3; also fetch estimator data when temperature_sigma or nnelement_* variables are plotted, not just temperature

- lightcurve.py: in generate_band_lightcurve_data, filter transmission and spectrum flux were multiplied on mismatched wavelength grids (one interpolated onto a uniform grid, the other left on its own non-uniform grid). Interpolate the coarser series onto the finer grid and integrate on that same grid. This also stops mutating wavefilter/transmission inside the timestep loop, which corrupted subsequent timesteps

- packetsplots.py: the costhetabin filter restarted from the unfiltered packets frame, discarding the arrival-time selection; dirbin truthiness treated bin 0 as isotropic and bin -1 (isotropic) as directional for the solid angle factor; allow dirbin=-1 (the documented default) through the direction filter and CLI assertion

- packets.py: replace pointless O(n^3) loop in make_3d_grid that repeatedly rewrote the same 1D axis values

- spectra.py: fix boundary inconsistency (<= vs <) in the bound-bound column check used when applying the filter function

- linefluxes.py: skip the Floers model ratio overlay when the hardcoded local CSV path does not exist instead of crashing
