### PR TITLE
Add -labelfontsize command line argument for light curve plots

### DIFF
--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -909,7 +909,8 @@ def make_band_lightcurves_plot(
     outputfolder: Path | str,
     args: argparse.Namespace,
 ) -> None:
-    args.labelfontsize = 22  # TODO: make command line arg
+    if args.labelfontsize is None:
+        args.labelfontsize = 22
     fig, ax = create_axes(args)
 
     plotkwargs: dict[str, t.Any] = {}
@@ -1048,7 +1049,8 @@ def colour_evolution_plot(
     outputfolder: str | Path,
     args: argparse.Namespace,
 ) -> None:
-    args.labelfontsize = 24  # TODO: make command line arg
+    if args.labelfontsize is None:
+        args.labelfontsize = 24
     angle_counter = 0
     color_list = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
 
@@ -1600,6 +1602,13 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("-ncolslegend", type=int, default=1, help="Number of columns in legend")
 
     parser.add_argument("--legendframeon", action="store_true", help="Frame on in legend")
+
+    parser.add_argument(
+        "-labelfontsize",
+        type=float,
+        default=None,
+        help="Font size for axis labels. Defaults to 22 for band light curves and 24 for colour evolution plots",
+    )
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1607,7 +1607,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         "-labelfontsize",
         type=float,
         default=None,
-        help="Font size for axis labels. Defaults to 22 for band light curves and 24 for colour evolution plots",
+        help="Base font size for plot text (axis labels, tick labels, legend). Defaults to 22 for band light curves and 24 for colour evolution plots",
     )
 
 


### PR DESCRIPTION
Replaces the hardcoded axis label font sizes in make_band_lightcurves_plot
and colour_evolution_plot with a -labelfontsize CLI argument. The per-plot
defaults (22 for band light curves, 24 for colour evolution) are preserved
when the argument is not supplied.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HKU1oPcGUCTu7YqhhNNqCA