### PR TITLE
Consolidate parquet writing, rank file reading, and viewing angle args

### DIFF
--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -61,6 +61,7 @@ from artistools.inputmodel import get_mgi_of_velocity_kms as get_mgi_of_velocity
 from artistools.inputmodel import get_modeldata as get_modeldata
 from artistools.inputmodel import save_initelemabundances as save_initelemabundances
 from artistools.inputmodel import save_modeldata as save_modeldata
+from artistools.misc import add_viewingangle_args as add_viewingangle_args
 from artistools.misc import anyexist as anyexist
 from artistools.misc import average_direction_bins as average_direction_bins
 from artistools.misc import decode_roman_numeral as decode_roman_numeral
@@ -128,6 +129,7 @@ from artistools.misc import split_multitable_dataframe as split_multitable_dataf
 from artistools.misc import stripallsuffixes as stripallsuffixes
 from artistools.misc import trim_or_pad as trim_or_pad
 from artistools.misc import vec_len as vec_len
+from artistools.misc import write_parquet_atomic as write_parquet_atomic
 from artistools.misc import zopen as zopen
 from artistools.misc import zopenpl as zopenpl
 from artistools.plottools import set_mpl_style as set_mpl_style

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -5,7 +5,6 @@ Examples are temperatures, populations, and heating/cooling rates.
 
 import contextlib
 import datetime
-import tempfile
 import time
 import typing as t
 from collections.abc import Sequence
@@ -133,14 +132,9 @@ def get_rankbatch_parquetfile(
         time_start = time.perf_counter()
 
         assert pldf_batch is not None
-        partialparquetfilepath = Path(
-            tempfile.mkstemp(dir=folderpath, prefix=f"{parquetfilename}.partial", suffix=".partial")[1]
-        )
-        pldf_batch.write_parquet(
-            partialparquetfilepath,
-            compression="zstd",
-            compression_level=10,
-            statistics=True,
+        at.write_parquet_atomic(
+            pldf_batch,
+            parquetfilepath,
             metadata={
                 "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
                 "textsource_mtime": str(textsource_mtime),
@@ -149,10 +143,6 @@ def get_rankbatch_parquetfile(
                 "batchindex": str(batchindex),
             },
         )
-        if parquetfilepath.exists():
-            partialparquetfilepath.unlink()
-        else:
-            partialparquetfilepath.rename(parquetfilepath)
 
         print(f"took {time.perf_counter() - time_start:.1f} s.")
 

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -5,7 +5,6 @@ import gc
 import json
 import math
 import os
-import tempfile
 import time
 import typing as t
 from collections.abc import Callable
@@ -24,6 +23,7 @@ from artistools.misc import get_elsymbol
 from artistools.misc import get_z_a_nucname
 from artistools.misc import stripallsuffixes
 from artistools.misc import vec_len
+from artistools.misc import write_parquet_atomic
 from artistools.misc import zopen
 
 
@@ -391,22 +391,17 @@ def get_modeldata(
         mebibyte = 1024 * 1024
         if textfilepath.stat().st_size > 2 * mebibyte:
             print(f"Saving {parquetfilepath}")
-            partialparquetfilepath = Path(
-                tempfile.mkstemp(dir=modelpath, prefix=f"{parquetfilepath.name}.partial", suffix=".tmp")[1]
-            )
-            modelmeta_json = json.dumps(modelmeta)
-            dfmodel.sink_parquet(
-                partialparquetfilepath,
-                compression="zstd",
-                compression_level=8,
-                statistics="full",
+            write_parquet_atomic(
+                dfmodel,
+                parquetfilepath,
                 metadata={
                     "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
                     "textsource_mtime": str(textsource_mtime),
-                    "modelmeta_json": modelmeta_json,
+                    "modelmeta_json": json.dumps(modelmeta),
                 },
+                compression_level=8,
+                statistics="full",
             )
-            partialparquetfilepath.rename(parquetfilepath)
             print("  Done.")
             del dfmodel
             gc.collect()
@@ -978,17 +973,7 @@ def get_initelemabundances(modelpath: Path | str = ".", printwarningsonly: bool 
         mebibyte = 1024 * 1024
         if textfilepath.stat().st_size > 2 * mebibyte:
             print(f"Saving {parquetfilepath}")
-            partialparquetfilepath = Path(
-                tempfile.mkstemp(dir=modelpath, prefix=f"{parquetfilepath.name}.partial", suffix=".tmp")[1]
-            )
-            abundancedata.write_parquet(
-                partialparquetfilepath, compression="zstd", compression_level=8, statistics=True
-            )
-            if parquetfilepath.exists():
-                partialparquetfilepath.unlink()
-            else:
-                partialparquetfilepath.rename(parquetfilepath)
-
+            write_parquet_atomic(abundancedata, parquetfilepath, compression_level=8)
             print("  Done.")
             del abundancedata
             gc.collect()

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -400,7 +400,6 @@ def get_modeldata(
                     "modelmeta_json": json.dumps(modelmeta),
                 },
                 compression_level=8,
-                statistics="full",
             )
             print("  Done.")
             del dfmodel

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1127,11 +1127,8 @@ def colour_evolution_plot(
                 )
 
             # UNCOMMENT TO ESTIMATE COLOUR AT TIME B MAX
-            # def match_closest_time(reftime):
-            #     return ("{}".format(min([float(x) for x in plot_times], key=lambda x: abs(x - reftime))))
-            #
             # tmax_B = 17.0  # CHANGE TO TIME OF B MAX
-            # tmax_B = float(match_closest_time(tmax_B))
+            # tmax_B = at.match_closest_time(tmax_B, plot_times)
             # print(f'{filter_names[0]} - {filter_names[1]} at t_Bmax ({tmax_B}) = '
             #       f'{diff[plot_times.index(tmax_B)]}')
 
@@ -1419,25 +1416,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Plot hesma model on top of lightcurve plot. Enter model name saved in data/hesma directory",
     )
 
-    parser.add_argument(
-        "-plotvspecpol", type=int, nargs="+", help="Plot vspecpol. Expects int for spec number in vspecpol files"
-    )
-
-    parser.add_argument(
-        "-plotviewingangle",
-        "-dirbin",
-        type=int,
-        nargs="+",
-        help=(
-            "Plot viewing angles. Expects int for angle number in specpol_res.out"
-            "use args = -2 to select all the viewing angles"
-        ),
-    )
-    parser.add_argument(
-        "--usedegrees",
-        action="store_true",
-        help="Use degrees instead of radians for viewing angles. Only works with -plotviewingangle",
-    )
+    at.add_viewingangle_args(parser, allow_select_all=True)
 
     parser.add_argument("-ymax", type=float, default=None, help="Plot range: y-axis")
 
@@ -1555,21 +1534,6 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument(
         "--noangleaveraged", action="store_true", help="Don't plot angle averaged values on viewing angle scatter plots"
-    )
-
-    parser.add_argument(
-        "--average_over_phi_angle",
-        action="store_true",
-        help="Average over phi (azimuthal) viewing angles to make direction bins into polar angle bins",
-    )
-
-    # for backwards compatibility with above option
-    parser.add_argument("--average_every_tenth_viewing_angle", action="store_true")
-
-    parser.add_argument(
-        "--average_over_theta_angle",
-        action="store_true",
-        help="Average over theta (polar) viewing angles to make direction bins into azimuthal angle bins",
     )
 
     parser.add_argument(

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -282,19 +282,16 @@ def calculate_peak_time_mag_deltam15(
     )
     fxfit, xfit = lightcurve_polyfit(time, magnitude, args)
 
-    def match_closest_time_polyfit(reftime_polyfit: float) -> str:
-        return str(min((float(x) for x in xfit), key=lambda x: abs(x - reftime_polyfit)))
-
     index_min = np.argmin(fxfit)
     tmax_polyfit = xfit[index_min]
-    time_after15days_polyfit = match_closest_time_polyfit(tmax_polyfit + 15)
+    time_after15days_polyfit = at.match_closest_time(tmax_polyfit + 15, xfit)
     if args.include_delta_m40:
-        time_after40days_polyfit = match_closest_time_polyfit(tmax_polyfit + 40)
+        time_after40days_polyfit = at.match_closest_time(tmax_polyfit + 40, xfit)
     index_after_40_days = None
     for ii, xfits in enumerate(xfit):
-        if float(xfits) == float(time_after15days_polyfit):
+        if float(xfits) == time_after15days_polyfit:
             index_after_15_days = ii
-        elif args.include_delta_m40 and float(xfits) == float(time_after40days_polyfit):
+        elif args.include_delta_m40 and float(xfits) == time_after40days_polyfit:
             index_after_40_days = ii
 
     mag_after15days_polyfit = fxfit[index_after_15_days]
@@ -686,7 +683,7 @@ def second_band_brightness_at_peak_first_band(
         )
 
         for ii, xfits in enumerate(xfit):
-            if float(xfits) == float(closest_list_time_to_first_band_peak):
+            if float(xfits) == closest_list_time_to_first_band_peak:
                 index_at_max = ii
                 break
 
@@ -817,9 +814,7 @@ def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Names
             angle, costheta_viewing_angle_bins, phi_viewing_angle_bins, scaledmap, plotkwargs, args
         )
 
-        lumattime = (
-            lcdata.filter(pl.col("time_days") == float(timetoplot)).select("luminosity_Lsun").collect().item(0, 0)
-        )
+        lumattime = lcdata.filter(pl.col("time_days") == timetoplot).select("luminosity_Lsun").collect().item(0, 0)
         brightness = lumattime * at.constants.Lsun_to_erg_per_s
         if args.colorbarphi:
             xvalues = int(angleindex / 10)

--- a/artistools/misc.py
+++ b/artistools/misc.py
@@ -1491,7 +1491,6 @@ def write_parquet_atomic(
     parquetfilepath: Path,
     metadata: dict[str, str] | None = None,
     compression_level: int = 10,
-    statistics: bool | str = True,
 ) -> None:
     """Write a zstd-compressed parquet file via a temporary file and an atomic replace, so a partial write is never mistaken for a complete file.
 
@@ -1507,11 +1506,7 @@ def write_parquet_atomic(
     partialfilepath = Path(partialfilename)
     try:
         pldf.lazy().sink_parquet(
-            partialfilepath,
-            compression="zstd",
-            compression_level=compression_level,
-            statistics=statistics,
-            metadata=metadata,
+            partialfilepath, compression="zstd", compression_level=compression_level, metadata=metadata
         )
         partialfilepath.replace(parquetfilepath)
     finally:

--- a/artistools/misc.py
+++ b/artistools/misc.py
@@ -202,9 +202,9 @@ def average_direction_bins(
     return dirbindataframesout
 
 
-def match_closest_time(reftime: float | int, searchtimes: list[t.Any]) -> str:
-    """Get time closest to reftime in list of times (searchtimes)."""
-    return str(min((float(x) for x in searchtimes), key=lambda x: abs(x - reftime)))
+def match_closest_time(reftime: float | int, searchtimes: Iterable[t.Any]) -> float:
+    """Return the time in searchtimes that is closest to reftime."""
+    return min((float(x) for x in searchtimes), key=lambda x: abs(x - reftime))
 
 
 def get_vpkt_config(modelpath: Path | str) -> dict[str, t.Any]:
@@ -775,6 +775,50 @@ def get_ionstring(
         strcharge = "0"
 
     return f"{get_elsymbol(atomic_number)}{strcharge}"
+
+
+def add_viewingangle_args(parser: argparse.ArgumentParser, allow_select_all: bool = False) -> None:
+    """Add the viewing direction selection and averaging arguments shared by the plotting commands."""
+    parser.add_argument(
+        "-plotvspecpol",
+        type=int,
+        metavar="n",
+        nargs="+",
+        help="Plot viewing angles from vspecpol virtual packets. Expects int for angle = spec number in vspecpol files",
+    )
+
+    parser.add_argument(
+        "-plotviewingangle",
+        "-dirbin",
+        type=int,
+        metavar="n",
+        nargs="+",
+        help=(
+            "Plot viewing directions. Expects int for direction bin in specpol_res.out"
+            + (". Use -2 to select all viewing angles" if allow_select_all else "")
+        ),
+    )
+
+    parser.add_argument(
+        "--usedegrees",
+        action="store_true",
+        help="Use degrees instead of radians for direction angles. Only works with -plotviewingangle",
+    )
+
+    parser.add_argument(
+        "--average_over_phi_angle",
+        action="store_true",
+        help="Average over phi (azimuthal) viewing angles to make direction bins into polar angle bins",
+    )
+
+    # deprecated alias for --average_over_phi_angle kept for backwards compatibility
+    parser.add_argument("--average_every_tenth_viewing_angle", action="store_true", help=argparse.SUPPRESS)
+
+    parser.add_argument(
+        "--average_over_theta_angle",
+        action="store_true",
+        help="Average over theta (polar) viewing angles to make direction bins into azimuthal angle bins",
+    )
 
 
 def parse_cli_args(
@@ -1442,6 +1486,30 @@ def get_mpiranklist(
     return [get_mpirankofcell(modelgridindex, modelpath=modelpath)]
 
 
+def write_parquet_atomic(
+    pldf: pl.DataFrame | pl.LazyFrame,
+    parquetfilepath: Path,
+    metadata: dict[str, str] | None = None,
+    compression_level: int = 10,
+) -> None:
+    """Write a zstd-compressed parquet file via a temporary file and rename, so a partial write is never mistaken for a complete file.
+
+    If the destination appears in the meantime (e.g. written by a concurrent process), the temporary file is discarded instead.
+    """
+    import tempfile
+
+    partialfilepath = Path(
+        tempfile.mkstemp(dir=parquetfilepath.parent, prefix=f"{parquetfilepath.name}.partial", suffix=".partial")[1]
+    )
+    pldf.lazy().sink_parquet(
+        partialfilepath, compression="zstd", compression_level=compression_level, statistics=True, metadata=metadata
+    )
+    if parquetfilepath.exists():
+        partialfilepath.unlink()
+    else:
+        partialfilepath.rename(parquetfilepath)
+
+
 def read_rank_outputfiles(
     modelpath: Path | str, filenameformat: str, timestep: int | None = None, modelgridindex: int | None = None
 ) -> pl.DataFrame:
@@ -1466,13 +1534,12 @@ def read_rank_outputfiles(
         .with_columns(pl.col("modelgridindex").cast(pl.Int64), pl.col("timestep").cast(pl.Int64))
     )
 
-    filterexpr = pl.lit(True)
     if modelgridindex is not None and modelgridindex >= 0:
-        filterexpr &= pl.col("modelgridindex") == modelgridindex
+        dfout = dfout.filter(pl.col("modelgridindex") == modelgridindex)
     if timestep is not None and timestep >= 0:
-        filterexpr &= pl.col("timestep") == timestep
+        dfout = dfout.filter(pl.col("timestep") == timestep)
 
-    return dfout.filter(filterexpr)
+    return dfout
 
 
 def get_cellsofmpirank(mpirank: int, modelpath: Path | str) -> Iterable[int]:

--- a/artistools/misc.py
+++ b/artistools/misc.py
@@ -1491,6 +1491,7 @@ def write_parquet_atomic(
     parquetfilepath: Path,
     metadata: dict[str, str] | None = None,
     compression_level: int = 10,
+    statistics: bool | str = True,
 ) -> None:
     """Write a zstd-compressed parquet file via a temporary file and an atomic replace, so a partial write is never mistaken for a complete file.
 
@@ -1506,7 +1507,11 @@ def write_parquet_atomic(
     partialfilepath = Path(partialfilename)
     try:
         pldf.lazy().sink_parquet(
-            partialfilepath, compression="zstd", compression_level=compression_level, statistics=True, metadata=metadata
+            partialfilepath,
+            compression="zstd",
+            compression_level=compression_level,
+            statistics=statistics,
+            metadata=metadata,
         )
         partialfilepath.replace(parquetfilepath)
     finally:

--- a/artistools/misc.py
+++ b/artistools/misc.py
@@ -1304,7 +1304,7 @@ def get_linelist_pldf(modelpath: Path | str, get_ion_str: bool = False) -> pl.La
             .with_row_index(name="lineindex")
             .with_columns(cs.integer().cast(pl.Int32), cs.float().cast(pl.Float32))
         )
-        pldf.write_parquet(parquetfile, compression="zstd", compression_level=8, statistics=True)
+        write_parquet_atomic(pldf, parquetfile, compression_level=8)
         print(f"Wrote {parquetfile}")
     else:
         print(f"Reading {parquetfile}")

--- a/artistools/misc.py
+++ b/artistools/misc.py
@@ -1492,22 +1492,25 @@ def write_parquet_atomic(
     metadata: dict[str, str] | None = None,
     compression_level: int = 10,
 ) -> None:
-    """Write a zstd-compressed parquet file via a temporary file and rename, so a partial write is never mistaken for a complete file.
+    """Write a zstd-compressed parquet file via a temporary file and an atomic replace, so a partial write is never mistaken for a complete file.
 
-    If the destination appears in the meantime (e.g. written by a concurrent process), the temporary file is discarded instead.
+    If a concurrent process wrote the destination first, it is atomically overwritten by this equally-valid replacement.
     """
+    import os
     import tempfile
 
-    partialfilepath = Path(
-        tempfile.mkstemp(dir=parquetfilepath.parent, prefix=f"{parquetfilepath.name}.partial", suffix=".partial")[1]
+    fd, partialfilename = tempfile.mkstemp(
+        dir=parquetfilepath.parent, prefix=f"{parquetfilepath.name}.partial", suffix=".partial"
     )
-    pldf.lazy().sink_parquet(
-        partialfilepath, compression="zstd", compression_level=compression_level, statistics=True, metadata=metadata
-    )
-    if parquetfilepath.exists():
-        partialfilepath.unlink()
-    else:
-        partialfilepath.rename(parquetfilepath)
+    os.close(fd)
+    partialfilepath = Path(partialfilename)
+    try:
+        pldf.lazy().sink_parquet(
+            partialfilepath, compression="zstd", compression_level=compression_level, statistics=True, metadata=metadata
+        )
+        partialfilepath.replace(parquetfilepath)
+    finally:
+        partialfilepath.unlink(missing_ok=True)
 
 
 def read_rank_outputfiles(

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -155,4 +155,4 @@ def read_files(modelpath: str | Path, timestep: int | None = None, modelgridinde
     """Read in NLTE populations from a model for a particular timestep and grid cell."""
     return at.read_rank_outputfiles(
         modelpath, "nlte_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
-    )
+    ).rename({"ionstage": "ion_stage"}, strict=False)  # rename for compatibility with older ARTIS output files

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -151,33 +151,8 @@ def add_lte_pops(
     return dfpop
 
 
-def read_files(modelpath: str | Path, timestep: int = -1, modelgridindex: int = -1) -> pl.DataFrame:
+def read_files(modelpath: str | Path, timestep: int | None = None, modelgridindex: int | None = None) -> pl.DataFrame:
     """Read in NLTE populations from a model for a particular timestep and grid cell."""
-    runfolders = at.get_runfolders(modelpath, timestep=timestep)
-    assert runfolders, f"No run folders found in {modelpath} for timestep {timestep}"
-    nltefilepaths = [
-        at.firstexisting(Path(folderpath, f"nlte_{mpirank:04d}.out"), tryzipped=True)
-        for folderpath in runfolders
-        for mpirank in at.get_mpiranklist(modelpath, modelgridindex=modelgridindex)
-    ]
-    assert nltefilepaths
-
-    dfnltepop = (
-        pl
-        .concat(
-            pl.from_pandas(pd.read_csv(nltefilepath, sep=r"\s+", dtype_backend="pyarrow"))
-            for nltefilepath in nltefilepaths
-        )
-        .rename({"ionstage": "ion_stage"}, strict=False)
-        .with_columns(pl.col("modelgridindex").cast(pl.Int64), pl.col("timestep").cast(pl.Int64))
-    )
-
-    filterexpr = pl.lit(True)
-
-    if modelgridindex >= 0:
-        filterexpr &= pl.col("modelgridindex") == modelgridindex
-
-    if timestep >= 0:
-        filterexpr &= pl.col("timestep") == timestep
-
-    return dfnltepop.filter(filterexpr)
+    return at.read_rank_outputfiles(
+        modelpath, "nlte_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
+    ).rename({"ionstage": "ion_stage"}, strict=False)

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -155,4 +155,4 @@ def read_files(modelpath: str | Path, timestep: int | None = None, modelgridinde
     """Read in NLTE populations from a model for a particular timestep and grid cell."""
     return at.read_rank_outputfiles(
         modelpath, "nlte_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
-    ).rename({"ionstage": "ion_stage"}, strict=False)  # rename for compatibility with older ARTIS output files
+    )

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -155,4 +155,4 @@ def read_files(modelpath: str | Path, timestep: int | None = None, modelgridinde
     """Read in NLTE populations from a model for a particular timestep and grid cell."""
     return at.read_rank_outputfiles(
         modelpath, "nlte_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
-    ).rename({"ionstage": "ion_stage"}, strict=False)
+    )

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -1,6 +1,5 @@
 import calendar
 import math
-import tempfile
 import time
 import typing as t
 from collections.abc import Sequence
@@ -421,8 +420,11 @@ def get_rankbatch_parquetfile(
             if parquet_mtime > last_textfile_mtime and parquet_mtime > t_lastschemachange:
                 conversion_needed = False
             else:
-                msg = f"ERROR: outdated file: {parquetfilepath}. Delete it to regenerate."
-                raise AssertionError(msg)
+                print(
+                    f"  {parquetfilepath.relative_to(modelpath)} is older than the packet text files or schema change."
+                    " File will be deleted and regenerated..."
+                )
+                parquetfilepath.unlink()
         else:
             conversion_needed = False
 
@@ -477,14 +479,7 @@ def get_rankbatch_parquetfile(
             f"   took {time.perf_counter() - time_start_load:.1f} seconds. Writing parquet file...", end="", flush=True
         )
         time_start_write = time.perf_counter()
-        tempparquetfilepath = Path(
-            tempfile.mkstemp(dir=packetdir, prefix=f"{parquetfilename}.partial", suffix=".tmp")[1]
-        )
-        pldf_batch.lazy().sink_parquet(tempparquetfilepath, compression="zstd", compression_level=12, statistics=True)
-        if parquetfilepath.exists():
-            tempparquetfilepath.unlink()
-        else:
-            tempparquetfilepath.rename(parquetfilepath)
+        at.write_parquet_atomic(pldf_batch, parquetfilepath, compression_level=12)
         print(f"took {time.perf_counter() - time_start_write:.1f} seconds")
 
     return parquetfilepath

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -26,6 +26,7 @@ from matplotlib.lines import Line2D
 
 import artistools.spectra as atspectra
 from artistools.commands import get_path
+from artistools.misc import add_viewingangle_args
 from artistools.misc import df_filter_minmax_bounded
 from artistools.misc import firstexisting
 from artistools.misc import get_dirbin_labels
@@ -1481,45 +1482,10 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         "--averagevspecpolfiles", action="store_true", help="Average the vspecpol-total files for multiple simulations"
     )
 
-    parser.add_argument(
-        "-plotvspecpol",
-        type=int,
-        nargs="+",
-        help="Plot viewing angles from vspecpol virtual packets. Expects int for angle = spec number in vspecpol files",
-    )
+    add_viewingangle_args(parser)
 
     parser.add_argument(
         "-stokesparam", type=str, default="I", help="Stokes param to plot. Default I. Expects I, Q or U"
-    )
-
-    parser.add_argument(
-        "-plotviewingangle",
-        "-dirbin",
-        type=int,
-        metavar="n",
-        nargs="+",
-        help="Plot viewing directions. Expects int for direction bin in specpol_res.out",
-    )
-
-    parser.add_argument(
-        "--usedegrees",
-        action="store_true",
-        help="Use degrees instead of radians for direction angles. Only works with -plotviewingangle",
-    )
-
-    parser.add_argument(
-        "--average_over_phi_angle",
-        action="store_true",
-        help="Average over phi (azimuthal) viewing angles to make direction bins into polar angle bins",
-    )
-
-    # for backwards compatibility with above option
-    parser.add_argument("--average_every_tenth_viewing_angle", action="store_true")
-
-    parser.add_argument(
-        "--average_over_theta_angle",
-        action="store_true",
-        help="Average over theta (polar) viewing angles to make direction bins into azimuthal angle bins",
     )
 
     parser.add_argument("--binflux", action="store_true", help="Bin flux over wavelength and average flux")

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -34,6 +34,7 @@ from artistools.misc import get_timestep_times
 from artistools.misc import get_viewingdirection_phibincount
 from artistools.misc import get_viewingdirectionbincount
 from artistools.misc import get_vpkt_config
+from artistools.misc import match_closest_time
 from artistools.misc import split_multitable_dataframe
 from artistools.misc import zopenpl
 
@@ -884,18 +885,15 @@ def get_vspecpol_spectrum(
     vspecdata = stokes_params[args.stokesparam]
 
     arr_tmid = [float(i) for i in vspecdata.collect_schema().names()[1:]]
-    vspec_timesteps = range(len(arr_tmid))
     arr_tdelta = [l1 - l2 for l1, l2 in zip(arr_tmid[1:], arr_tmid[:-1], strict=False)] + [arr_tmid[-1] - arr_tmid[-2]]
 
-    def match_closest_time(reftime: float) -> int:
-        return min(vspec_timesteps, key=lambda ts: abs(arr_tmid[ts] - reftime))
-
     if "timemin" in args and "timemax" in args and args.timemin is not None and args.timemax is not None:
-        timestepmin = match_closest_time(args.timemin)  # how timemin, timemax are used changed at some point
-        timestepmax = match_closest_time(args.timemax)  # to average over multiple timesteps needs to fix this
+        # how timemin, timemax are used changed at some point. to average over multiple timesteps needs to fix this
+        timestepmin = arr_tmid.index(match_closest_time(args.timemin, arr_tmid))
+        timestepmax = arr_tmid.index(match_closest_time(args.timemax, arr_tmid))
     else:
-        timestepmin = match_closest_time(timeavg)
-        timestepmax = match_closest_time(timeavg)
+        timestepmin = arr_tmid.index(match_closest_time(timeavg, arr_tmid))
+        timestepmax = timestepmin
 
     timelower = arr_tmid[timestepmin]
     timeupper = arr_tmid[timestepmax]

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -285,10 +285,11 @@ def test_stripallsuffixes() -> None:
 
 def test_match_closest_time() -> None:
     times = [100.0, 200.0, 300.0, 400.0]
-    assert at.match_closest_time(250.0, times) == "200.0"
-    assert at.match_closest_time(310.0, times) == "300.0"
-    assert at.match_closest_time(99.0, times) == "100.0"
-    assert at.match_closest_time(400.0, times) == "400.0"
+    assert at.match_closest_time(250.0, times) == 200.0
+    assert at.match_closest_time(310.0, times) == 300.0
+    assert at.match_closest_time(99.0, times) == 100.0
+    assert at.match_closest_time(400.0, times) == 400.0
+    assert at.match_closest_time(310.0, ["100", "300.5", "400"]) == 300.5
 
 
 def test_get_npts_model(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

Continues the cross-cutting de-duplication from #550 with four more shared helpers in `artistools.misc`, removing the remaining copy-pasted blocks found in the review (net −47 lines):

- **`write_parquet_atomic()`** — the tempfile + atomic-rename parquet write previously duplicated between `estimators.get_rankbatch_parquetfile()` and `packets.get_rankbatch_parquetfile()`.
- **`read_rank_outputfiles()`** — the runfolders × mpiranks whitespace-CSV reader previously duplicated between `radfield.read_files()` and `nltepops.read_files()`, which are now one-line delegations.
- **`add_viewingangle_args()`** — the six viewing-direction CLI arguments (`-plotvspecpol`, `-plotviewingangle`/`-dirbin`, `--usedegrees`, both averaging flags, and the deprecated alias) previously duplicated between plotspectra and plotlightcurve. The "-2 selects all angles" help text only appears for plotlightcurve, since plotspectra doesn't support it.
- **`match_closest_time()`** now returns a `float` instead of a string, replacing the local closure variants in `spectra.py` (index-returning) and `viewingangleanalysis.py` (`match_closest_time_polyfit`), and the redundant `float()` wrappers at call sites.

## Behaviour changes to note

- **Packets**: a stale batch parquet file (older than the text files or the schema-change date) is now deleted and regenerated, matching the estimators behaviour, instead of raising `AssertionError: outdated file… Delete it to regenerate`.
- **`--average_every_tenth_viewing_angle`** still parses (and still maps to `--average_over_phi_angle`) but is hidden from `--help` output.
- **`match_closest_time()` return type** changed from `str` to `float`. All in-repo callers wrapped the result in `float()` already; the `hesma_scripts.py` caller formats it with `:.2f`, which would have raised `ValueError` on the old str return, so this fixes a latent crash.

## Verification

- `pytest`: 84/84 passed
- `ruff check` and `ruff format`: clean
- `mypy` (88 files) and `pyrefly`: clean
- CLI smoke tests of `--help` via both the subcommand tree and direct `main()` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)