### PR TITLE
Add regression tests for data readers and band magnitudes

### DIFF
--- a/artistools/atomic/test_atomic.py
+++ b/artistools/atomic/test_atomic.py
@@ -1,5 +1,6 @@
 import math
 
+import numpy as np
 import polars as pl
 import pytest
 
@@ -21,4 +22,29 @@ def test_get_levels() -> None:
 
 @pytest.mark.benchmark
 def test_get_ionrecombratecalibration() -> None:
-    at.atomic.get_ionrecombratecalibration(modelpath=modelpath)
+    recombination_rates = at.atomic.get_ionrecombratecalibration(modelpath=modelpath)
+
+    assert len(recombination_rates) == 55
+    assert {(26, 2), (26, 3), (26, 4), (26, 5)} <= recombination_rates.keys()
+    assert all(
+        dataframe.shape == (81, 4)
+        and dataframe.columns == ["log10T_e", "rrc_low_n", "rrc_total", "T_e"]
+        and dataframe["log10T_e"].is_sorted()
+        for dataframe in recombination_rates.values()
+    )
+
+    fe2_rates = recombination_rates[26, 2]
+    assert fe2_rates["log10T_e"].to_list() == pytest.approx(np.arange(1.0, 9.1, 0.1))
+    assert fe2_rates["T_e"].to_list() == pytest.approx(10 ** fe2_rates["log10T_e"].to_numpy())
+    assert fe2_rates.row(0, named=True) == pytest.approx({
+        "log10T_e": 1.0,
+        "rrc_low_n": 1.7009e-11,
+        "rrc_total": 3.4763e-11,
+        "T_e": 10.0,
+    })
+    assert fe2_rates.row(40, named=True) == pytest.approx({
+        "log10T_e": 5.0,
+        "rrc_low_n": 9.9265e-13,
+        "rrc_total": 7.3507e-12,
+        "T_e": 1.0e5,
+    })

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -180,12 +180,19 @@ def get_from_packets(
 
 def generate_band_lightcurve_data(
     modelpath: Path | str,
-    args: argparse.Namespace,
+    args: argparse.Namespace | None = None,
     dirbin: int = -1,
     modelnumber: int | None = None,  # ruff:ignore[unused-function-argument]
+    **kwargs: t.Any,
 ) -> dict[str, t.Any]:
     """Integrate spectra to get band magnitude vs time. Method adapted from https://github.com/cinserra/S3/blob/master/src/s3/SMS.py."""
     from scipy.interpolate import interp1d
+
+    if args is not None and kwargs:
+        msg = "Specify either args or keyword options, not both"
+        raise TypeError(msg)
+    if args is None:
+        args = argparse.Namespace(**kwargs)
 
     if args.plotvspecpol and Path(modelpath, "vpkt.txt").is_file():
         print("Found vpkt.txt, using virtual packets")
@@ -383,8 +390,17 @@ def get_spectrum_in_filter_range(
 
 
 def get_band_lightcurve(
-    band_lightcurve_data: dict[str, Sequence[tuple[float, float]]], band_name: str, args: argparse.Namespace
+    band_lightcurve_data: dict[str, Sequence[tuple[float, float]]],
+    band_name: str,
+    args: argparse.Namespace | None = None,
+    **kwargs: t.Any,
 ) -> tuple[Sequence[float], npt.NDArray[np.floating]]:
+    if args is not None and kwargs:
+        msg = "Specify either args or keyword options, not both"
+        raise TypeError(msg)
+    if args is None:
+        args = argparse.Namespace(**kwargs)
+
     times, brightness_in_mag = zip(
         *[
             (time, brightness)

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -193,7 +193,13 @@ def generate_band_lightcurve_data(
         raise TypeError(msg)
     if args is None:
         args = argparse.Namespace(**kwargs)
-
+        args.plotvspecpol = getattr(args, "plotvspecpol", False)
+        args.plotviewingangle = getattr(args, "plotviewingangle", False)
+        args.filter = getattr(args, "filter", None)
+        args.timemin = getattr(args, "timemin", None)
+        args.timemax = getattr(args, "timemax", None)
+        args.average_over_phi_angle = getattr(args, "average_over_phi_angle", False)
+        args.average_over_theta_angle = getattr(args, "average_over_theta_angle", False)
     if args.plotvspecpol and Path(modelpath, "vpkt.txt").is_file():
         print("Found vpkt.txt, using virtual packets")
         stokes_params = (

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1,9 +1,11 @@
 import typing as t
+from operator import itemgetter
 from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
 import numpy as np
+import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import artistools as at
@@ -62,6 +64,76 @@ def test_lightcurve_plot_frompackets(mockplot: t.Any, benchmark: BenchmarkFixtur
 
 def test_band_lightcurve_plot() -> None:
     at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["B"], outputfile=outputpath)
+
+
+def test_band_magnitude_calculations() -> None:
+    band_magnitude_data = at.lightcurve.generate_band_lightcurve_data(
+        modelpath,
+        plotvspecpol=False,
+        plotviewingangle=False,
+        filter=["bol", "U", "B", "V", "I"],
+        timemin=290.0,
+        timemax=300.0,
+        average_over_phi_angle=False,
+        average_over_theta_angle=False,
+    )
+
+    expected_summary = {
+        "bol": ((290.381, -12.522955565351443), (299.309, -12.290504747994545), -12.486325221679541),
+        "U": ((290.381, -11.72755172004823), (299.309, -10.940395871435907), -11.552651445171437),
+        "B": ((290.381, -12.80311303703452), (299.309, -12.468614058886018), -12.729462436319448),
+        "V": ((290.381, -13.134615284653417), (299.309, -12.922527436514791), -13.018633619232805),
+        "I": ((290.381, -12.353784741224969), (299.309, -12.099751514986119), -12.443177921324608),
+    }
+    expected_brightest = {
+        "bol": (291.359, -12.572391488690043),
+        "U": (298.303, -11.927722052704134),
+        "B": (298.303, -12.885253294760465),
+        "V": (293.327, -13.166532931259166),
+        "I": (295.307, -12.701305015349229),
+    }
+
+    assert band_magnitude_data.keys() == expected_summary.keys()
+    for band_name, (expected_first, expected_last, expected_mean) in expected_summary.items():
+        magnitudes = band_magnitude_data[band_name]
+        assert len(magnitudes) == 10
+        assert magnitudes[0] == pytest.approx(expected_first)
+        assert magnitudes[-1] == pytest.approx(expected_last)
+        assert np.mean([magnitude for _, magnitude in magnitudes]) == pytest.approx(expected_mean)
+        assert min(magnitudes, key=itemgetter(1)) == pytest.approx(expected_brightest[band_name])
+
+
+def test_band_magnitude_selection_and_colour() -> None:
+    band_magnitude_data = at.lightcurve.generate_band_lightcurve_data(
+        modelpath,
+        plotvspecpol=False,
+        plotviewingangle=False,
+        filter=["B", "V"],
+        timemin=290.0,
+        timemax=300.0,
+        average_over_phi_angle=False,
+        average_over_theta_angle=False,
+    )
+
+    times, b_magnitudes = at.lightcurve.get_band_lightcurve(band_magnitude_data, "B", timemin=293.0, timemax=296.0)
+
+    assert times == pytest.approx([293.327, 294.315, 295.307])
+    assert b_magnitudes == pytest.approx([-12.708765155582157, -12.656976514620492, -12.794116835974194])
+
+    colour_times, b_minus_v = at.lightcurve.get_colour_delta_mag(band_magnitude_data, ["B", "V"])
+    assert colour_times == pytest.approx([time for time, _ in band_magnitude_data["B"]])
+    assert b_minus_v == pytest.approx([
+        0.33150224761889824,
+        0.2741971168171453,
+        0.23314295407410945,
+        0.4577677756770093,
+        0.34487289523804776,
+        0.0984198887313692,
+        0.2854667714378305,
+        0.38998118936833315,
+        0.022447612542014994,
+        0.4539133776287727,
+    ])
 
 
 def test_band_lightcurve_peakmag_risetime_plot() -> None:

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -2,6 +2,7 @@ import math
 
 import numpy as np
 import polars as pl
+import pytest
 
 import artistools as at
 
@@ -54,7 +55,53 @@ def test_directionbins() -> None:
 
 
 def test_get_virtual_packets() -> None:
-    _, dfvpkt = at.packets.get_virtual_packets(modelpath=at.get_path("testdata") / "vpktcontrib", maxpacketfiles=2)
+    nprocs_read, dfvpkt = at.packets.get_virtual_packets(
+        modelpath=at.get_path("testdata") / "vpktcontrib", maxpacketfiles=2
+    )
+    dfvpkt = dfvpkt.collect()
 
-    npkts_total = dfvpkt.select(pl.len()).collect().item()
-    assert npkts_total == 13783
+    assert nprocs_read == 2
+    assert dfvpkt.height == 13783
+    assert dfvpkt.columns == [
+        "emissiontype",
+        "trueemissiontype",
+        "absorption_type",
+        "absorption_freq",
+        "dir0_t_arrive_d",
+        "dir0_nu_rf",
+        "dir0_e_rf_0",
+        "dir0_e_rf_1",
+        "dir0_e_rf_2",
+        "dir1_t_arrive_d",
+        "dir1_nu_rf",
+        "dir1_e_rf_0",
+        "dir1_e_rf_1",
+        "dir1_e_rf_2",
+        "dir2_t_arrive_d",
+        "dir2_nu_rf",
+        "dir2_e_rf_0",
+        "dir2_e_rf_1",
+        "dir2_e_rf_2",
+        "mpirank",
+        "type_id",
+        "escape_type_id",
+    ]
+    assert dfvpkt.schema["emissiontype"] == pl.Int32
+    assert dfvpkt.schema["dir0_t_arrive_d"] == pl.Float32
+    assert dfvpkt.schema["dir0_e_rf_0"] == pl.Float64
+    assert dfvpkt.schema["mpirank"] == pl.Int32
+    assert dfvpkt["dir0_t_arrive_d"].is_sorted()
+    assert dfvpkt["type_id"].unique().to_list() == [32]
+    assert dfvpkt["escape_type_id"].unique().to_list() == [11]
+    assert dfvpkt["dir0_t_arrive_d"].min() == pytest.approx(-1.0)
+    assert dfvpkt["dir0_t_arrive_d"].max() == pytest.approx(145.587997)
+
+    rank_summary = (
+        dfvpkt
+        .group_by("mpirank")
+        .agg(pl.len().alias("packet_count"), pl.col("dir0_e_rf_0").sum().alias("energy_sum"))
+        .sort("mpirank")
+    )
+    assert rank_summary["mpirank"].to_list() == [0, 1]
+    assert rank_summary["packet_count"].to_list() == [9402, 4381]
+    assert rank_summary["energy_sum"].to_list() == pytest.approx([5.56564454996292e44, 1.8265647804307455e44])


### PR DESCRIPTION
This pull request adds comprehensive new tests and improves flexibility in several functions by supporting both argument objects and keyword arguments. The main changes include enhanced test coverage for lightcurve and packet data processing, stricter validation of data structures and contents, and improved API ergonomics for band lightcurve functions.

**Testing improvements:**

* [`artistools/lightcurve/test_lightcurve.py`](diffhunk://#diff-36170e8f962589acd70e77078393f536f62686e7f36941541a3825f1ce86ee3dR69-R138): Added two new tests—`test_band_magnitude_calculations` and `test_band_magnitude_selection_and_colour`—that verify the correctness of band magnitude calculations, selection, and color differences, including detailed assertions on values and means.
* [`artistools/packets/test_packets.py`](diffhunk://#diff-c8155dcb1b768c140b826e78f8c60cf5dcf113946c17768299afea3278d3bbcdL57-R107): Expanded the `test_get_virtual_packets` test to validate the number of processes read, dataframe shape, column names, schema types, sorting, uniqueness, value ranges, and grouped energy sums, providing much more thorough coverage.
* [`artistools/atomic/test_atomic.py`](diffhunk://#diff-56a9bfd96621b2a99c8123d823b898f7b9ab9471de2d31a9828689091714a328L24-R50): Enhanced the `test_get_ionrecombratecalibration` test to check the structure, keys, and contents of the returned recombination rates, including value and shape assertions.

**API and argument handling improvements:**

* [`artistools/lightcurve/lightcurve.py`](diffhunk://#diff-649266588617812b1cb2776fe8d5806c6b3e68ccc34ffdc23b512fae735a4df2L183-R202): Updated `generate_band_lightcurve_data` and `get_band_lightcurve` to accept either an `argparse.Namespace` or keyword arguments, with checks to prevent mixing both, improving flexibility and usability. [[1]](diffhunk://#diff-649266588617812b1cb2776fe8d5806c6b3e68ccc34ffdc23b512fae735a4df2L183-R202) [[2]](diffhunk://#diff-649266588617812b1cb2776fe8d5806c6b3e68ccc34ffdc23b512fae735a4df2L386-R409)

**Dependency management:**

* Added missing imports for `pytest` and `numpy` in test files to ensure all dependencies are explicitly declared. [[1]](diffhunk://#diff-56a9bfd96621b2a99c8123d823b898f7b9ab9471de2d31a9828689091714a328R3) [[2]](diffhunk://#diff-36170e8f962589acd70e77078393f536f62686e7f36941541a3825f1ce86ee3dR2-R8) [[3]](diffhunk://#diff-c8155dcb1b768c140b826e78f8c60cf5dcf113946c17768299afea3278d3bbcdR5)

These changes collectively improve test reliability, code flexibility, and maintainability.