### PR TITLE
Rename flux functions to luminosity and fix direction binning edge cases

### DIFF
--- a/artistools/estimators/__init__.py
+++ b/artistools/estimators/__init__.py
@@ -5,6 +5,7 @@ __all__ = ["plot"]
 from artistools.estimators import estimators_classic as estimators_classic
 from artistools.estimators import plot3destimators_classic as plot3destimators_classic
 from artistools.estimators import plotestimators as plotestimators
+from artistools.estimators.estimators import add_derived_estimator_columns as add_derived_estimator_columns
 from artistools.estimators.estimators import get_averageexcitation as get_averageexcitation
 from artistools.estimators.estimators import get_rankbatch_parquetfile as get_rankbatch_parquetfile
 from artistools.estimators.estimators import get_units_string as get_units_string

--- a/artistools/estimators/__init__.py
+++ b/artistools/estimators/__init__.py
@@ -7,7 +7,9 @@ from artistools.estimators import plot3destimators_classic as plot3destimators_c
 from artistools.estimators import plotestimators as plotestimators
 from artistools.estimators.estimators import add_derived_estimator_columns as add_derived_estimator_columns
 from artistools.estimators.estimators import get_averageexcitation as get_averageexcitation
-from artistools.estimators.estimators import get_rankbatch_parquetfile as get_rankbatch_parquetfile
+from artistools.estimators.estimators import (
+    get_estimators_rankbatch_parquetfile as get_estimators_rankbatch_parquetfile,
+)
 from artistools.estimators.estimators import get_units_string as get_units_string
 from artistools.estimators.estimators import get_variablelongunits as get_variablelongunits
 from artistools.estimators.estimators import get_variableunits as get_variableunits

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -72,7 +72,7 @@ def get_units_string(variable: str) -> str:
     return f" [{units}]" if (units := get_variableunits(variable)) else ""
 
 
-def get_rankbatch_parquetfile(
+def get_estimators_rankbatch_parquetfile(
     folderpath: Path | str,
     batch_mpiranks: Sequence[int],
     batchindex: int,
@@ -264,7 +264,7 @@ def scan_estimators(
     runfolders = at.get_runfolders(modelpath, timesteps=match_timestep)
     if runfolders:
         parquetfiles = [
-            get_rankbatch_parquetfile(
+            get_estimators_rankbatch_parquetfile(
                 modelpath=modelpath,
                 folderpath=runfolder,
                 batch_mpiranks=mpiranks,

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -187,6 +187,30 @@ def join_cell_modeldata(
     ), modelmeta
 
 
+def add_derived_estimator_columns(pldflazy: pl.LazyFrame) -> pl.LazyFrame:
+    """Add quantities derived from the estimator columns that were read from file."""
+    colnames = pldflazy.collect_schema().names()
+
+    if "heating_gamma/gamma_dep" in colnames:
+        pldflazy = pldflazy.with_columns(gamma_dep=pl.col("heating_gamma") / pl.col("heating_gamma/gamma_dep"))
+
+    if "deposition_gamma" in colnames:
+        # sum up the gamma, elec, positron, alpha deposition contributions
+        pldflazy = pldflazy.with_columns(total_dep=pl.sum_horizontal(cs.starts_with("deposition_")))
+    elif "heating_heating_dep/total_dep" in colnames:
+        # for older files with no deposition data, take heating part of deposition and heating fraction
+        pldflazy = pldflazy.with_columns(total_dep=pl.col("heating_dep") / pl.col("heating_heating_dep/total_dep"))
+
+    if any(col.startswith("nnelement_") for col in colnames):
+        # only fill the nnelement columns: a missing number density means zero, but every other column (Te, TR, nne,
+        # ...) must keep its nulls so that missing data isn't silently read as a real zero
+        pldflazy = pldflazy.with_columns(cs.starts_with("nnelement_").fill_null(0)).with_columns(
+            nntot=pl.sum_horizontal(cs.starts_with("nnelement_"))
+        )
+
+    return pldflazy
+
+
 def scan_estimators(
     modelpath: Path | str = ".",
     modelgridindex: int | Sequence[int] | None = None,
@@ -281,20 +305,7 @@ def scan_estimators(
     if match_timestep is not None:
         pldflazy = pldflazy.filter(pl.col("timestep").is_in(match_timestep))
 
-    colnames = pldflazy.collect_schema().names()
-    # add some derived quantities
-    if "heating_gamma/gamma_dep" in colnames:
-        pldflazy = pldflazy.with_columns(gamma_dep=pl.col("heating_gamma") / pl.col("heating_gamma/gamma_dep"))
-
-    if "deposition_gamma" in colnames:
-        # sum up the gamma, elec, positron, alpha deposition contributions
-        pldflazy = pldflazy.with_columns(total_dep=pl.sum_horizontal(cs.starts_with("deposition_")))
-    elif "heating_heating_dep/total_dep" in colnames:
-        # for older files with no deposition data, take heating part of deposition and heating fraction
-        pldflazy = pldflazy.with_columns(total_dep=pl.col("heating_dep") / pl.col("heating_heating_dep/total_dep"))
-
-    if any(col.startswith("nnelement_") for col in colnames):
-        pldflazy = pldflazy.with_columns(nntot=pl.sum_horizontal(cs.starts_with("nnelement_"))).fill_null(0)
+    pldflazy = add_derived_estimator_columns(pldflazy)
 
     if join_modeldata:
         pldflazy, _ = join_cell_modeldata(estimators=pldflazy, modelpath=modelpath, verbose=verbose)

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -333,3 +333,39 @@ def test_estimator_timeevolution() -> None:
         modelgridindex=0,
         x="time",
     )
+
+
+def test_add_derived_estimator_columns_preserves_nulls() -> None:
+    """Missing nnelement values count as zero, but a null in any other column must not become a real zero."""
+    pldf = pl.LazyFrame({
+        "timestep": [0, 1],
+        "modelgridindex": [0, 0],
+        "Te": [5000.0, None],
+        "nne": [None, 1.0e8],
+        "nnelement_Fe": [2.0, None],
+        "nnelement_Ni": [3.0, 4.0],
+    })
+
+    dfout = at.estimators.add_derived_estimator_columns(pldf).collect()
+
+    # nnelement nulls are filled with zero and summed into nntot
+    assert dfout["nnelement_Fe"].to_list() == [2.0, 0.0]
+    assert dfout["nntot"].to_list() == [5.0, 4.0]
+
+    # every other column keeps its nulls
+    assert dfout["Te"].to_list() == [5000.0, None]
+    assert dfout["nne"].to_list() == [None, 1.0e8]
+
+
+def test_add_derived_estimator_columns_total_dep() -> None:
+    pldf = pl.LazyFrame({
+        "timestep": [0],
+        "deposition_gamma": [1.0],
+        "deposition_positron": [2.0],
+        "deposition_alpha": [4.0],
+    })
+
+    dfout = at.estimators.add_derived_estimator_columns(pldf).collect()
+
+    assert dfout["total_dep"].to_list() == [7.0]
+    assert "nntot" not in dfout.columns

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -706,16 +706,16 @@ def add_derived_cols_to_modeldata(
 def get_cell_angle(dfmodel: pd.DataFrame) -> pd.DataFrame:
     """Get angle between origin to cell midpoint and the syn_dir axis.
 
-    Note that the "phi" column here does not use the same convention as the "phi" column added to packets by
-    artistools.packets.add_packet_directions_lazypolars(): the two branches of the testphi test are swapped, so this
-    phi is mirrored (2 pi - phi) relative to the packet one. Each is self-consistent with its own binning, but the
-    two are not interchangeable.
+    The azimuthal angle is named phi_mirrored rather than phi because it is measured in the opposite sense to the
+    "phi" column that add_packet_directions_lazypolars() adds to packets: the two branches of the testphi test are
+    swapped, giving phi_mirrored == 2 pi - phi. Each is self-consistent with its own binning, but the two are not
+    interchangeable.
     """
     syn_dir = np.array([0.0, 0.0, 1.0])
     xhat = np.array([1.0, 0.0, 0.0])
 
     cos_theta = np.zeros(len(dfmodel))
-    phi = np.zeros(len(dfmodel))
+    phi_mirrored = np.zeros(len(dfmodel))
     for i, (_, cell) in enumerate(dfmodel.iterrows()):
         mid_point = [cell["pos_x_mid"], cell["pos_y_mid"], cell["pos_z_mid"]]
         cos_theta[i] = (np.dot(mid_point, syn_dir)) / (vec_len(mid_point) * vec_len(syn_dir))
@@ -726,10 +726,10 @@ def get_cell_angle(dfmodel: pd.DataFrame) -> pd.DataFrame:
 
         vec3 = np.cross(vec2, syn_dir)
         testphi = np.dot(vec1, vec3)
-        phi[i] = math.acos(cosphi) if testphi > 0 else (math.acos(-cosphi) + np.pi)
+        phi_mirrored[i] = math.acos(cosphi) if testphi > 0 else (math.acos(-cosphi) + np.pi)
 
     dfmodel.loc[:, "cos_theta"] = cos_theta
-    dfmodel.loc[:, "phi"] = phi
+    dfmodel.loc[:, "phi_mirrored"] = phi_mirrored
     cos_bins = [-1, -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1]  # including end bin
     labels = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
     # assert at.get_viewingdirection_costhetabincount() == 10
@@ -753,7 +753,7 @@ def get_cell_angle(dfmodel: pd.DataFrame) -> pd.DataFrame:
     ]
     # reorderphibins = {5: 9, 6: 8, 7: 7, 8: 6, 9: 5}
     labels = [0, 1, 2, 3, 4, 9, 8, 7, 6, 5]
-    dfmodel.loc[:, "phi_bin"] = pd.cut(dfmodel["phi"], phibins, labels=labels)
+    dfmodel.loc[:, "phi_bin"] = pd.cut(dfmodel["phi_mirrored"], phibins, labels=labels)
 
     return dfmodel
 

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -481,6 +481,18 @@ def get_empty_3d_model(
     return dfmodel, modelmeta
 
 
+def min_abs_coordinate(ax: str) -> pl.Expr:
+    """Get the smallest |coordinate| reached anywhere inside a cell along axis ax.
+
+    A cell that straddles the axis (pos_min < 0 < pos_max) contains the origin plane, so its closest approach to that
+    plane is zero rather than min(|pos_min|, |pos_max|).
+    """
+    pos_min = pl.col(f"pos_{ax}_min")
+    pos_max = pl.col(f"pos_{ax}_max")
+
+    return pl.when(pos_min * pos_max < 0.0).then(pl.lit(0.0)).otherwise(pl.min_horizontal(pos_min.abs(), pos_max.abs()))
+
+
 def add_derived_cols_to_modeldata(
     dfmodel: pl.DataFrame | pl.LazyFrame,
     derived_cols: Sequence[str],
@@ -497,7 +509,11 @@ def add_derived_cols_to_modeldata(
     keep_all = any(c.lower() == "all" for c in derived_cols)
 
     if "logrho" not in dfmodel.collect_schema().names() and "rho" in dfmodel.collect_schema().names():
-        dfmodel = dfmodel.with_columns(logrho=pl.col("rho").log10())
+        # clamp at -99 to match save_modeldata(), which treats -99 as the empty-cell marker. A plain log10() would give
+        # -inf for rho == 0, which cannot be written to model.txt
+        dfmodel = dfmodel.with_columns(
+            logrho=pl.when(pl.col("rho") > 0).then(pl.max_horizontal(-99, pl.col("rho").log10())).otherwise(-99.0)
+        )
 
     if "rho" not in dfmodel.collect_schema().names() and "logrho" in dfmodel.collect_schema().names():
         dfmodel = dfmodel.with_columns(
@@ -550,10 +566,7 @@ def add_derived_cols_to_modeldata(
             # add a 3D radius column
             axes.append("r")
             dfmodel = dfmodel.with_columns(
-                pos_r_min=(
-                    pl.col("pos_rcyl_min").pow(2)
-                    + pl.min_horizontal(pl.col("pos_z_min").abs(), pl.col("pos_z_max").abs()).pow(2)
-                ).sqrt(),
+                pos_r_min=(pl.col("pos_rcyl_min").pow(2) + min_abs_coordinate("z").pow(2)).sqrt(),
                 pos_r_mid=(pl.col("pos_rcyl_mid").pow(2) + pl.col("pos_z_mid").pow(2)).sqrt(),
                 pos_r_max=(
                     pl.col("pos_rcyl_max").pow(2)
@@ -611,9 +624,7 @@ def add_derived_cols_to_modeldata(
             # xyz positions can be negative, so the min xyz side of the cube can have a larger radius than the max side
             dfmodel = dfmodel.with_columns(
                 pos_r_min=(
-                    pl.min_horizontal(pl.col("pos_x_min").abs(), pl.col("pos_x_max").abs()).pow(2)
-                    + pl.min_horizontal(pl.col("pos_y_min").abs(), pl.col("pos_y_max").abs()).pow(2)
-                    + pl.min_horizontal(pl.col("pos_z_min").abs(), pl.col("pos_z_max").abs()).pow(2)
+                    min_abs_coordinate("x").pow(2) + min_abs_coordinate("y").pow(2) + min_abs_coordinate("z").pow(2)
                 ).sqrt(),
                 pos_r_mid=(pl.col("pos_x_mid").pow(2) + pl.col("pos_y_mid").pow(2) + pl.col("pos_z_mid").pow(2)).sqrt(),
                 pos_r_max=(
@@ -638,12 +649,11 @@ def add_derived_cols_to_modeldata(
             )
 
     assert axes
-    # get total kinetic energy from orthogonal components
-    # all coord system also have a radial component calculated, so ignore this
+    # get total kinetic energy from orthogonal components. Every coordinate system also gets a radial component, which
+    # would double-count the orthogonal ones, so only use "r" for 1D models where it is the sole axis
+    orthogonal_axes = ["r"] if dimensions == 1 else [ax for ax in axes if ax != "r"]
     dfmodel = dfmodel.with_columns(
-        kinetic_en_erg=(
-            pl.sum_horizontal(pl.col(f"kinetic_en_erg_{ax}") for ax in axes if (ax != "r" or dimensions == 1))
-        )
+        kinetic_en_erg=(pl.sum_horizontal(pl.col(f"kinetic_en_erg_{ax}") for ax in orthogonal_axes))
     )
 
     for col in dfmodel.collect_schema().names():
@@ -653,8 +663,8 @@ def add_derived_cols_to_modeldata(
     if "rho" in dfmodel.collect_schema().names() and "volume" in dfmodel.collect_schema().names():
         dfmodel = dfmodel.with_columns(mass_g=(pl.col("rho") * pl.col("volume")))
 
-    # add vel_*_on_c scaled velocities
-    dfmodel = dfmodel.with_columns((cs.starts_with("vel_") / C_cm_per_s).name.suffix("_on_c"))
+    # add vel_*_on_c scaled velocities. The vel_*_kmps columns are in km/s instead of cm/s, so exclude them here
+    dfmodel = dfmodel.with_columns(((cs.starts_with("vel_") - cs.ends_with("_kmps")) / C_cm_per_s).name.suffix("_on_c"))
 
     if unknown_cols := [
         col
@@ -694,7 +704,13 @@ def add_derived_cols_to_modeldata(
 
 
 def get_cell_angle(dfmodel: pd.DataFrame) -> pd.DataFrame:
-    """Get angle between origin to cell midpoint and the syn_dir axis."""
+    """Get angle between origin to cell midpoint and the syn_dir axis.
+
+    Note that the "phi" column here does not use the same convention as the "phi" column added to packets by
+    artistools.packets.add_packet_directions_lazypolars(): the two branches of the testphi test are swapped, so this
+    phi is mirrored (2 pi - phi) relative to the packet one. Each is self-consistent with its own binning, but the
+    two are not interchangeable.
+    """
     syn_dir = np.array([0.0, 0.0, 1.0])
     xhat = np.array([1.0, 0.0, 0.0])
 

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -60,6 +60,13 @@ def test_get_cell_angle() -> None:
     )
     at.inputmodel.inputmodel_misc.get_cell_angle(modeldata)
     assert "cos_bin" in modeldata
+    assert "phi_bin" in modeldata
+
+    # the azimuth is measured in the opposite sense to the packet "phi", so it must not be named "phi"
+    assert "phi_mirrored" in modeldata
+    assert "phi" not in modeldata
+    assert modeldata["phi_mirrored"].min() >= 0.0
+    assert modeldata["phi_mirrored"].max() <= 2 * math.pi
 
 
 def test_downscale_3dmodel() -> None:

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1581,3 +1581,53 @@ def test_dimension_reduce(outputdimensions: int, benchmark: BenchmarkFixture) ->
                 (dfmodel3d_pl["mass_g"] * dfmodel3d_pl[col]).sum(),
                 rel_tol=1e-5,
             )
+
+
+def test_pos_r_min_straddling_cells() -> None:
+    """A cell that straddles a coordinate plane reaches zero along that axis, so pos_r_min must account for it."""
+    # an odd ncoordgrid puts a cell centred on the origin, and rings of cells straddling each coordinate plane
+    ncoordgrid = 5
+    dfmodel, modelmeta = at.inputmodel.get_empty_3d_model(ncoordgrid=ncoordgrid, vmax=1e9, t_model_init_days=1.0)
+
+    dfmodel = at.inputmodel.add_derived_cols_to_modeldata(dfmodel, derived_cols=["ALL"], modelmeta=modelmeta).collect()
+
+    for ax in ("x", "y", "z"):
+        straddles = (dfmodel[f"pos_{ax}_min"] < 0) & (dfmodel[f"pos_{ax}_max"] > 0)
+        assert straddles.any(), f"expected some cells straddling the {ax} plane"
+
+    straddles_all = (
+        ((dfmodel["pos_x_min"] < 0) & (dfmodel["pos_x_max"] > 0))
+        & ((dfmodel["pos_y_min"] < 0) & (dfmodel["pos_y_max"] > 0))
+        & ((dfmodel["pos_z_min"] < 0) & (dfmodel["pos_z_max"] > 0))
+    )
+    # the cell containing the origin has zero closest approach
+    assert dfmodel.filter(straddles_all)["pos_r_min"].to_list() == pytest.approx([0.0])
+
+    # pos_r_min can never exceed the distance to any corner of its own cell, nor pos_r_mid
+    assert (dfmodel["pos_r_min"] <= dfmodel["pos_r_mid"] * (1.0 + 1e-9)).all()
+    assert (dfmodel["pos_r_min"] <= dfmodel["pos_r_max"]).all()
+
+
+def test_min_abs_coordinate() -> None:
+    dfpos = pl.DataFrame({"pos_x_min": [-3.0, 1.0, -5.0, 0.0], "pos_x_max": [-1.0, 4.0, 2.0, 3.0]})
+
+    result = dfpos.select(at.inputmodel.inputmodel_misc.min_abs_coordinate("x")).to_series().to_list()
+
+    # entirely negative -> 1, entirely positive -> 1, straddling -> 0, touching the plane -> 0
+    assert result == pytest.approx([1.0, 1.0, 0.0, 0.0])
+
+
+def test_vel_on_c_excludes_kmps_columns() -> None:
+    """The vel_*_kmps columns are in km/s, so they must not be divided by c as if they were cm/s."""
+    dfmodel, _modelmeta = at.inputmodel.get_modeldata(modelpath, derived_cols=["velocity"])
+    dfmodel = dfmodel.collect()
+
+    assert "vel_r_max_kmps" in dfmodel.columns
+    assert "vel_r_max_kmps_on_c" not in dfmodel.columns
+    assert "vel_r_max_on_c" in dfmodel.columns
+
+    # vel_r_max is in cm/s, so its fraction of c must stay below 1 for a physical model
+    assert dfmodel["vel_r_max_on_c"].to_numpy().max() < 1.0
+    assert dfmodel["vel_r_max_on_c"].to_numpy() == pytest.approx(
+        dfmodel["vel_r_max_kmps"].to_numpy() * 1e5 / at.constants.C_cm_per_s
+    )

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -77,6 +77,8 @@ def get_from_packets(
 
     vpkt_config = at.get_vpkt_config(modelpath) if directionbins_are_vpkt_observers else None
     assert not directionbins_are_vpkt_observers or pellet_nucname is None  # we don't track which pellet led to vpkts
+    # only set for real packets, where the escape times are measured at the model surface
+    escapesurfacegamma: float | None = None
     if directionbins_are_vpkt_observers:
         nprocs_read, dfpackets = at.packets.get_virtual_packets(modelpath, maxpacketfiles=maxpacketfiles)
     else:
@@ -141,7 +143,7 @@ def get_from_packets(
             .drop("e_rf_sum", f"{timecol}_bin")
         )
 
-        if "t_arrive_cmf_d" in pldfpackets_dirbin.collect_schema().names():
+        if escapesurfacegamma is not None and "t_arrive_cmf_d" in pldfpackets_dirbin.collect_schema().names():
             lcdata[dirbin] = (
                 lcdata[dirbin]
                 .join(

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -96,8 +96,9 @@ def parse_directionbin_args(modelpath: Path | str, args: argparse.Namespace) -> 
                 assert dirbin % at.get_viewingdirection_phibincount() == 0 or dirbin == -1
 
         if args.average_over_theta_angle:
+            # averaging over theta leaves one bin per phi index
             for dirbin in dirbin_definition:
-                assert dirbin < at.get_viewingdirection_costhetabincount() or dirbin == -1
+                assert dirbin < at.get_viewingdirection_phibincount() or dirbin == -1
 
     return dirbins, dirbin_definition
 

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -36,7 +36,7 @@ class FeatureTuple(t.NamedTuple):
     lowerlevelindices: Sequence[int]
 
 
-def get_line_fluxes_from_packets(
+def get_line_luminosities_from_packets(
     emtypecolumn: str,
     emfeatures: Sequence[FeatureTuple],
     modelpath: Path | str,
@@ -46,8 +46,7 @@ def get_line_fluxes_from_packets(
 ) -> pl.DataFrame:
     """Get the emission line luminosities of the requested features vs time.
 
-    Despite the "flux" naming (kept for backwards compatibility of the returned column names), the values are
-    luminosities in [erg/s]: they are not divided by 4 pi d^2 for any observer distance.
+    The returned values are luminosities in [erg/s]: they are not divided by 4 pi d^2 for any observer distance.
     """
     if arr_tstart is None:
         arr_tstart = at.get_timestep_times(modelpath, loc="start")
@@ -90,7 +89,7 @@ def get_line_fluxes_from_packets(
     return pl.DataFrame(dictlcdata)
 
 
-def get_line_fluxes_from_pops(
+def get_line_luminosities_from_pops(
     emfeatures: Sequence[FeatureTuple],
     modelpath: Path | str,
     arr_tstart: Sequence[float] | None = None,
@@ -113,7 +112,7 @@ def get_line_fluxes_from_pops(
 
     dictlcdata = {"time": arr_tmid}
     for feature in emfeatures:
-        fluxdata = np.zeros_like(arr_tmid, dtype=float)
+        lumdata = np.zeros_like(arr_tmid, dtype=float)
 
         dfnltepops = (
             at.nltepops
@@ -168,7 +167,7 @@ def get_line_fluxes_from_pops(
                     #       f' km/s shell_vol: {shell_volumes[modelgridindex] + unaccounted_shellvol} cm3'
                     #       f' n_level {levelpop} cm-3 shell_Lum {l} erg/s')
 
-                    fluxdata[timeindex] += (
+                    lumdata[timeindex] += (
                         delta_ergs * A_val * levelpop * (shell_volumes[modelgridindex] + unaccounted_shellvol)
                     )
 
@@ -177,7 +176,7 @@ def get_line_fluxes_from_pops(
                     print(f"No data for cells {unaccounted_shells} (expected for empty cells)")
                 assert len(unaccounted_shells) < len(modeldata.index)  # must be data for at least one shell
 
-        dictlcdata[feature.colname] = fluxdata
+        dictlcdata[feature.colname] = lumdata
 
     return pl.DataFrame(dictlcdata)
 
@@ -210,7 +209,7 @@ def get_closelines(
 
     dflinelistclosematches = lzdflinelistclosematches.collect()
 
-    colname = f"flux_{at.get_ionstring(atomic_number, ion_stage, sep='')}_{approxlambdalabel}"
+    colname = f"lum_{at.get_ionstring(atomic_number, ion_stage, sep='')}_{approxlambdalabel}"
     featurelabel = f"{at.get_ionstring(atomic_number, ion_stage)} {approxlambdalabel} Å"
     lowestlambda = dflinelistclosematches["lambda_angstroms"].min()
     assert isinstance(lowestlambda, float | np.floating)
@@ -247,7 +246,7 @@ def get_labelandlineindices(modelpath: Path | str, emfeaturesearch: Sequence[t.A
     return labelandlineindices
 
 
-def make_flux_ratio_plot(args: argparse.Namespace) -> None:
+def make_luminosity_ratio_plot(args: argparse.Namespace) -> None:
     # font = {'size': 16}
     # matplotlib.rc('font', **font)
     nrows = 1
@@ -278,11 +277,11 @@ def make_flux_ratio_plot(args: argparse.Namespace) -> None:
         emfeatures = get_labelandlineindices(modelpath, tuple(args.emfeaturesearch))
 
         dflcdata = (
-            get_line_fluxes_from_pops(
+            get_line_luminosities_from_pops(
                 emfeatures, modelpath, arr_tstart=args.timebins_tstart, arr_tend=args.timebins_tend
             )
             if args.frompops
-            else get_line_fluxes_from_packets(
+            else get_line_luminosities_from_packets(
                 args.emtypecolumn,
                 emfeatures,
                 modelpath,
@@ -817,7 +816,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     if args.plotemittingregions:
         make_emitting_regions_plot(args)
     else:
-        make_flux_ratio_plot(args)
+        make_luminosity_ratio_plot(args)
 
 
 if __name__ == "__main__":

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -44,6 +44,11 @@ def get_line_fluxes_from_packets(
     arr_tstart: Sequence[float] | None = None,
     arr_tend: Sequence[float] | None = None,
 ) -> pl.DataFrame:
+    """Get the emission line luminosities of the requested features vs time.
+
+    Despite the "flux" naming (kept for backwards compatibility of the returned column names), the values are
+    luminosities in [erg/s]: they are not divided by 4 pi d^2 for any observer distance.
+    """
     if arr_tstart is None:
         arr_tstart = at.get_timestep_times(modelpath, loc="start")
     if arr_tend is None:
@@ -135,6 +140,14 @@ def get_line_fluxes_from_pops(
             ):
                 unaccounted_shellvol = 0.0  # account for the volume of empty shells
                 unaccounted_shells: list[int] = []
+                # the transition data is the same for every cell, so look it up once. An IndexError here is a missing
+                # transition rather than an empty cell, and must not be silently absorbed below
+                A_val = ion.transitions.query("upper == @upperlevelindex and lower == @lowerlevelindex").iloc[0].A
+
+                delta_ergs = (
+                    ion.levels.iloc[upperlevelindex].energy_ev - ion.levels.iloc[lowerlevelindex].energy_ev
+                ) * EV_to_erg
+
                 for modelgridindex in modeldata.index:
                     try:
                         levelpop = dfnltepops.filter(
@@ -144,29 +157,22 @@ def get_line_fluxes_from_pops(
                             & (pl.col("ion_stage") == feature.ion_stage)
                             & (pl.col("level") == upperlevelindex)
                         )["n_NLTE"].item(0)
-
-                        A_val = (
-                            ion.transitions.query("upper == @upperlevelindex and lower == @lowerlevelindex").iloc[0].A
-                        )
-
-                        delta_ergs = (
-                            ion.levels.iloc[upperlevelindex].energy_ev - ion.levels.iloc[lowerlevelindex].energy_ev
-                        ) * EV_to_erg
-
-                        # l = delta_ergs * A_val * levelpop * (shell_volumes[modelgridindex] + unaccounted_shellvol)
-                        # print(f'  {modelgridindex} outer_velocity {modeldata.vel_r_max_kmps.to_numpy()[modelgridindex]}'
-                        #       f' km/s shell_vol: {shell_volumes[modelgridindex] + unaccounted_shellvol} cm3'
-                        #       f' n_level {levelpop} cm-3 shell_Lum {l} erg/s')
-
-                        fluxdata[timeindex] += (
-                            delta_ergs * A_val * levelpop * (shell_volumes[modelgridindex] + unaccounted_shellvol)
-                        )
-
-                        unaccounted_shellvol = 0.0
-
                     except IndexError:
+                        # no population data for this cell, so roll its volume into the next one that has data
                         unaccounted_shellvol += shell_volumes[modelgridindex]
                         unaccounted_shells.append(modelgridindex)
+                        continue
+
+                    # l = delta_ergs * A_val * levelpop * (shell_volumes[modelgridindex] + unaccounted_shellvol)
+                    # print(f'  {modelgridindex} outer_velocity {modeldata.vel_r_max_kmps.to_numpy()[modelgridindex]}'
+                    #       f' km/s shell_vol: {shell_volumes[modelgridindex] + unaccounted_shellvol} cm3'
+                    #       f' n_level {levelpop} cm-3 shell_Lum {l} erg/s')
+
+                    fluxdata[timeindex] += (
+                        delta_ergs * A_val * levelpop * (shell_volumes[modelgridindex] + unaccounted_shellvol)
+                    )
+
+                    unaccounted_shellvol = 0.0
                 if unaccounted_shells:
                     print(f"No data for cells {unaccounted_shells} (expected for empty cells)")
                 assert len(unaccounted_shells) < len(modeldata.index)  # must be data for at least one shell

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -33,7 +33,6 @@ def average_direction_bins(
     """Average dict of direction-binned polars DataFrames according to the phi or theta angle."""
     dirbincount = get_viewingdirectionbincount()
     nphibins = get_viewingdirection_phibincount()
-    ncosthetabins = get_viewingdirection_costhetabincount()
 
     if overangle not in {"phi", "theta"}:
         msg = "overangle must be 'phi' or 'theta'"
@@ -45,10 +44,10 @@ def average_direction_bins(
     dirbindataframesout: dict[int, pl.LazyFrame] = {}
 
     for start_bin in start_bin_range:
+        # dirbin == costheta_index * nphibins + phi_index, so the bins sharing a costheta index are contiguous, while
+        # the bins sharing a phi index are nphibins apart
         contribbins = list(
-            range(start_bin, start_bin + nphibins)
-            if overangle == "phi"
-            else range(start_bin, dirbincount, ncosthetabins)
+            range(start_bin, start_bin + nphibins) if overangle == "phi" else range(start_bin, dirbincount, nphibins)
         )
 
         dirbindataframesout[start_bin] = dirbindataframes[start_bin].lazy()

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -131,7 +131,7 @@ def firstexisting_or_none(
 
 
 def stripallsuffixes(f: Path) -> Path:
-    """Take a file path (e.g. packets00_0000.out.gz) and return the Path with no suffixes (e.g. packets)."""
+    """Take a file path (e.g. packets00_0000.out.gz) and return the Path with no suffixes (e.g. packets00_0000)."""
     f_nosuffixes = Path(f)
     for _ in f.suffixes:
         f_nosuffixes = f_nosuffixes.with_suffix("")  # each call removes only one suffix

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 import artistools as at
+from artistools.misc import dirbins
 
 
 def _write_timesteps_out(modeldir: Path) -> None:
@@ -276,8 +277,8 @@ def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatc
     nphibins = 4
     ncosthetabins = 3
 
-    monkeypatch.setattr(at.misc.dirbins, "get_viewingdirection_phibincount", lambda: nphibins)
-    monkeypatch.setattr(at.misc.dirbins, "get_viewingdirection_costhetabincount", lambda: ncosthetabins)
+    monkeypatch.setattr(dirbins, "get_viewingdirection_phibincount", lambda: nphibins)
+    monkeypatch.setattr(dirbins, "get_viewingdirection_costhetabincount", lambda: ncosthetabins)
 
     # dirbin == costheta_index * nphibins + phi_index, and each frame carries its own dirbin as the value
     dirbindataframes = {
@@ -286,14 +287,14 @@ def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatc
     }
 
     # averaging over theta collapses each phi index over all costheta rings: bins p, p + nphibins, p + 2 * nphibins
-    averaged = at.misc.dirbins.average_direction_bins(dirbindataframes, overangle="theta")
+    averaged = dirbins.average_direction_bins(dirbindataframes, overangle="theta")
     assert sorted(averaged.keys()) == [0, 1, 2, 3]
     for phibin in range(nphibins):
         expected = sum(phibin + n * nphibins for n in range(ncosthetabins)) / ncosthetabins
         assert averaged[phibin].collect()["value"].to_list() == pytest.approx([expected, expected])
 
     # averaging over phi collapses each contiguous run of nphibins bins
-    averaged_phi = at.misc.dirbins.average_direction_bins(dirbindataframes, overangle="phi")
+    averaged_phi = dirbins.average_direction_bins(dirbindataframes, overangle="phi")
     assert sorted(averaged_phi.keys()) == [0, 4, 8]
     for start_bin in (0, 4, 8):
         expected = sum(start_bin + n for n in range(nphibins)) / nphibins

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -269,3 +269,32 @@ def test_get_deposition(tmp_path: Path) -> None:
 
     with pytest.raises(AssertionError, match="Deposition times do not match"):
         at.get_deposition(baddir).collect()
+
+
+def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Averaging must group bins by the phi bin count, which is only distinguishable when the two counts differ."""
+    nphibins = 4
+    ncosthetabins = 3
+
+    monkeypatch.setattr(at.misc.dirbins, "get_viewingdirection_phibincount", lambda: nphibins)
+    monkeypatch.setattr(at.misc.dirbins, "get_viewingdirection_costhetabincount", lambda: ncosthetabins)
+
+    # dirbin == costheta_index * nphibins + phi_index, and each frame carries its own dirbin as the value
+    dirbindataframes = {
+        dirbin: pl.DataFrame({"timestep": [0, 1], "value": [float(dirbin), float(dirbin)]})
+        for dirbin in range(nphibins * ncosthetabins)
+    }
+
+    # averaging over theta collapses each phi index over all costheta rings: bins p, p + nphibins, p + 2 * nphibins
+    averaged = at.misc.dirbins.average_direction_bins(dirbindataframes, overangle="theta")
+    assert sorted(averaged.keys()) == [0, 1, 2, 3]
+    for phibin in range(nphibins):
+        expected = sum(phibin + n * nphibins for n in range(ncosthetabins)) / ncosthetabins
+        assert averaged[phibin].collect()["value"].to_list() == pytest.approx([expected, expected])
+
+    # averaging over phi collapses each contiguous run of nphibins bins
+    averaged_phi = at.misc.dirbins.average_direction_bins(dirbindataframes, overangle="phi")
+    assert sorted(averaged_phi.keys()) == [0, 4, 8]
+    for start_bin in (0, 4, 8):
+        expected = sum(start_bin + n for n in range(nphibins)) / nphibins
+        assert averaged_phi[start_bin].collect()["value"].to_list() == pytest.approx([expected, expected])

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -287,12 +287,8 @@ def get_escaped_arrivalrange(modelpath: Path | str) -> tuple[int, float | int | 
     # find the last possible escape time and subtract the largest possible travel time (observer time correction)
     try:
         depdata = get_deposition(modelpath=modelpath)  # use this file to find the last computed timestep
-        nts_last = (
-            depdata
-            .select(pl.col("timestep").max() if "timestep" in depdata.collect_schema().names() else (pl.len() - 1))
-            .collect()
-            .item()
-        )
+        # get_deposition() always provides a timestep column, adding a row index if the file has no such column
+        nts_last = depdata.select(pl.col("timestep").max()).collect().item()
     except FileNotFoundError:
         print("WARNING: No deposition.out file found. Assuming all timesteps have been computed")
         nts_last = len(t_end) - 1

--- a/artistools/nonthermal/leptontransport.py
+++ b/artistools/nonthermal/leptontransport.py
@@ -3,12 +3,14 @@ import math
 import matplotlib.pyplot as plt
 import numpy as np
 
+from artistools.constants import K_B_ev_per_K as CONST_KB  # Boltzmann constant [eV / K]
+
+# this module works in SI units, so these have no artistools.constants equivalent
 CONST_EV_IN_J = 1.602176634e-19  # 1 eV [J]
 
 CONST_RE = 2.8179403262e-15  # classical electron radius [m]
 CONST_ME = 9.10938356e-31  # mass of electron [kg]
 CONST_C = 299792458  # [m / s]
-CONST_KB = 8.617333262145e-5  # Boltzmann constant [eV / K]
 
 
 def calculate_dE_on_dx_plasma(energy: float | int, n_e_free: float) -> float:

--- a/artistools/nonthermal/leptontransport.py
+++ b/artistools/nonthermal/leptontransport.py
@@ -5,7 +5,8 @@ import numpy as np
 
 from artistools.constants import K_B_ev_per_K as CONST_KB  # Boltzmann constant [eV / K]
 
-# this module works in SI units, so these have no artistools.constants equivalent
+# CONST_KB above is shared with the rest of artistools. The constants below stay local because this module works in
+# SI units (J, m, kg, s), which artistools.constants does not provide
 CONST_EV_IN_J = 1.602176634e-19  # 1 eV [J]
 
 CONST_RE = 2.8179403262e-15  # classical electron radius [m]

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -389,7 +389,7 @@ def get_vpackets_text_columns(vpacketsfiletext: Path) -> list[str]:
     return firstline.lstrip("#").split()
 
 
-def get_rankbatch_parquetfile(
+def get_packets_rankbatch_parquetfile(
     modelpath: Path | str, batch_mpiranks: Sequence[int], batchindex: int, virtual: bool
 ) -> Path:
     """Get the path to a parquet file containing packets for a specific batch of MPI ranks. If the file does not exists or is outdated, generate it first from the text files."""
@@ -517,7 +517,9 @@ def get_packets_batch_parquet_paths(
             print(f"Reading packets from {nprocs} ranks")
 
     parquetpacketsfiles = [
-        get_rankbatch_parquetfile(modelpath, batch_mpiranks=batch_mpiranks, batchindex=batchindex, virtual=virtual)
+        get_packets_rankbatch_parquetfile(
+            modelpath, batch_mpiranks=batch_mpiranks, batchindex=batchindex, virtual=virtual
+        )
         for batchindex, batch_mpiranks in mpirank_groups
     ]
     assert bool(parquetpacketsfiles)

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -139,7 +139,9 @@ def add_derived_columns_lazy(
 
     if dfmodel is None:
         assert modelpath is not None, "modelpath must be provided if dfmodel is not provided"
-        dfmodel, modelmeta = at.get_modeldata(modelpath=modelpath)
+        dfmodel, modelmeta_read = at.get_modeldata(modelpath=modelpath)
+        if modelmeta is None:
+            modelmeta = modelmeta_read
 
     dfpackets = dfpackets.lazy()
 
@@ -412,6 +414,8 @@ def get_rankbatch_parquetfile(
     conversion_needed = True
     if parquetfilepath.is_file():
         parquet_mtime = parquetfilepath.stat().st_mtime
+        # only the last rank's file is checked, on the assumption that a run writes all of its ranks together. An
+        # individually-updated earlier file will not invalidate the cached parquet
         if text_filepath := at.firstexisting_or_none(
             text_filenames[-1], folder=modelpath, tryzipped=True, search_subfolders=True
         ):
@@ -472,7 +476,10 @@ def get_rankbatch_parquetfile(
 
             pldf_batch = add_packet_directions_lazypolars(pldf_batch)
             pldf_batch = bin_packet_directions_polars(
-                pldf_batch, nphibins=10, ncosthetabins=10, phibintype="phibinhistoricaldescendingdiscont"
+                pldf_batch,
+                nphibins=at.get_viewingdirection_phibincount(),
+                ncosthetabins=at.get_viewingdirection_costhetabincount(),
+                phibintype="phibinhistoricaldescendingdiscont",
             )
 
         print(
@@ -524,10 +531,8 @@ def get_virtual_packets(modelpath: str | Path, maxpacketfiles: int | None = None
     )
 
     nbatches_read = len(vpacketparquetfiles)
-    packetsdatasize_gb = nbatches_read * Path(vpacketparquetfiles[0]).stat().st_size / 1024 / 1024 / 1024
-    print(
-        f"  data size is {packetsdatasize_gb:.1f} GB ({nbatches_read} batches * size of {vpacketparquetfiles[0].parts[-1]})"
-    )
+    packetsdatasize_gb = sum(f.stat().st_size for f in vpacketparquetfiles) / 1024 / 1024 / 1024
+    print(f"  total parquet size is {packetsdatasize_gb:.1f} GB (from {nbatches_read} batches)")
 
     # add some extra columns to imitate the real packets
     dfpackets = pl.scan_parquet(vpacketparquetfiles).with_columns(
@@ -609,10 +614,13 @@ def get_directionbin(
         vec3 = np.cross(vec2, syn_dir)
         testphi = np.dot(vec1, vec3)
 
-        phibin = (
+        # acos(cosphi) + pi reaches exactly 2 pi when cosphi == -1, which would otherwise land in the first phi bin of
+        # the next costheta ring, so clamp to the last bin
+        phibin = min(
             int(math.acos(cosphi) / 2.0 / math.pi * nphibins)
             if testphi > 0
-            else int((math.acos(cosphi) + math.pi) / 2.0 / math.pi * nphibins)
+            else int((math.acos(cosphi) + math.pi) / 2.0 / math.pi * nphibins),
+            nphibins - 1,
         )
 
     return (costhetabin * nphibins) + phibin
@@ -661,9 +669,10 @@ def add_packet_directions_lazypolars(dfpackets: pl.LazyFrame | pl.DataFrame) -> 
 
         vec3 = np.cross(vec2, syn_dir)  # -xhat if syn_dir is zhat
 
-        # arr_testphi = np.dot(arr_vec1, vec3)
+        # arr_testphi = np.dot(arr_vec1, vec3). vec1 was already normalised by dirmag above, and only the sign of
+        # testphi is used, so there is no further division here (matching get_directionbin)
         dfpackets = dfpackets.with_columns(
-            ((pl.col("vec1_x") * vec3[0] + pl.col("vec1_y") * vec3[1] + pl.col("vec1_z") * vec3[2]) / pl.col("dirmag"))
+            (pl.col("vec1_x") * vec3[0] + pl.col("vec1_y") * vec3[1] + pl.col("vec1_z") * vec3[2])
             .cast(pl.Float32)
             .alias("testphi")
         )
@@ -704,21 +713,28 @@ def bin_packet_directions_polars(
     )
 
     if phibintype == "phibinmonotonicasc":
+        # phi reaches exactly 2 pi when cosphi == 1 and testphi > 0, so clamp to the last bin
         dfpackets = dfpackets.with_columns(
-            (pl.col("phi") / 2.0 / math.pi * nphibins).fill_nan(0.0).cast(pl.Int32).alias("phibinmonotonicasc")
+            pl.min_horizontal(
+                (pl.col("phi") / 2.0 / math.pi * nphibins).fill_nan(0.0).cast(pl.Int32), nphibins - 1
+            ).alias("phibinmonotonicasc")
         )
     else:
         # for historical consistency, this binning method decreases phi angle with increasing bin index
+        # acos(cosphi) + pi reaches exactly 2 pi when cosphi == -1, which would otherwise land in the first phi bin of
+        # the next costheta ring, so clamp to the last bin
         dfpackets = dfpackets.with_columns(
-            (
-                pl
-                .when(pl.col("testphi") > 0)
-                .then(pl.col("cosphi").arccos() / (2 * math.pi) * nphibins)
-                .otherwise((pl.col("cosphi").arccos() + math.pi) / (2 * math.pi) * nphibins)
-            )
-            .fill_nan(0)
-            .cast(pl.Int32)
-            .alias("phibin")
+            pl.min_horizontal(
+                (
+                    pl
+                    .when(pl.col("testphi") > 0)
+                    .then(pl.col("cosphi").arccos() / (2 * math.pi) * nphibins)
+                    .otherwise((pl.col("cosphi").arccos() + math.pi) / (2 * math.pi) * nphibins)
+                )
+                .fill_nan(0)
+                .cast(pl.Int32),
+                nphibins - 1,
+            ).alias("phibin")
         ).with_columns((pl.col("costhetabin") * nphibins + pl.col("phibin")).cast(pl.Int32).alias("dirbin"))
 
     return dfpackets

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -9,6 +9,7 @@ import numpy as np
 import polars as pl
 
 import artistools as at
+from artistools.constants import c_ang_per_s
 from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 
@@ -61,7 +62,7 @@ def get_reduced_packet_set(
     slice before filtering to the requested escape-angle bins.
     """
     nprocs_read, dfpackets_selected = get_required_packets(modelpath, Z, ion_stage, srII_triplet=srII_triplet)
-    dfpackets_selected = dfpackets_selected.with_columns((CLIGHT * 1e8 / pl.col("nu_rf")).alias("lambda_rf"))
+    dfpackets_selected = dfpackets_selected.with_columns((c_ang_per_s / pl.col("nu_rf")).alias("lambda_rf"))
 
     if wavelen is not None and binwidth is not None:
         lam_min = wavelen - binwidth / 2
@@ -97,7 +98,8 @@ def packets_2d_hist_bin_and_ejecta_vel(
 
     # Step 1) collect packets IDs and select according to arrival time
     Z_list = [Z] if Z else list(range(1, 101))
-    ion_stage_list = [at.decode_roman_numeral(ion_stage_str)] if ion_stage_str else list(range(1, 5))
+    # the "all ions" case must cover every ion stage, otherwise the allions_ output filename is a lie
+    ion_stage_list = [at.decode_roman_numeral(ion_stage_str)] if ion_stage_str else list(range(1, 102))
 
     nprocs_read, dfpackets = get_reduced_packet_set(
         modelpath, dirbin, Z_list, ion_stage_list, wavelen=wavelen, binwidth=binwidth, srII_triplet=srIItriplet

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -54,6 +54,69 @@ def test_directionbins() -> None:
         assert phibinuppers[pkt["phibin"]] >= pkt["phi_defined"] or pktdir_is_along_zaxis
 
 
+def test_directionbins_unequal_bincounts() -> None:
+    """Check the dirbin layout when the phi and costheta bin counts differ.
+
+    The default configuration uses 10 of each, which hides any confusion between the two counts.
+    """
+    nphibins = 8
+    ncosthetabins = 4
+    syn_dir = (0, 0, 1)
+
+    testdirections = pl.DataFrame({
+        "phi_defined": np.linspace(0.05, 2 * math.pi, nphibins * 3, endpoint=False).tolist()
+    }).join(
+        pl.DataFrame({"costheta_defined": np.linspace(-0.99, 0.99, ncosthetabins * 3, endpoint=True).tolist()}),
+        how="cross",
+    )
+
+    testdirections = testdirections.with_columns(
+        dirx=((1.0 - pl.col("costheta_defined").pow(2)).sqrt() * pl.col("phi_defined").cos()),
+        diry=((1.0 - pl.col("costheta_defined").pow(2)).sqrt() * pl.col("phi_defined").sin()),
+        dirz=pl.col("costheta_defined"),
+    )
+
+    testdirections = at.packets.add_packet_directions_lazypolars(testdirections).collect()
+    testdirections = at.packets.bin_packet_directions_polars(
+        testdirections, nphibins=nphibins, ncosthetabins=ncosthetabins
+    ).collect()
+
+    for pkt in testdirections.iter_rows(named=True):
+        assert 0 <= pkt["phibin"] < nphibins
+        assert 0 <= pkt["costhetabin"] < ncosthetabins
+        assert 0 <= pkt["dirbin"] < nphibins * ncosthetabins
+
+        # dirbin packs the costheta index in the high part and the phi index in the low part
+        assert pkt["dirbin"] == pkt["costhetabin"] * nphibins + pkt["phibin"]
+
+        assert pkt["dirbin"] == at.packets.get_directionbin(
+            pkt["dirx"], pkt["diry"], pkt["dirz"], nphibins=nphibins, ncosthetabins=ncosthetabins, syn_dir=syn_dir
+        )
+
+
+@pytest.mark.parametrize("nphibins", [4, 10])
+def test_directionbins_phibin_upper_edge(nphibins: int) -> None:
+    """A direction with diry == 0 and dirx < 0 gives acos(cosphi) + pi == 2 pi, which must not overflow the ring."""
+    ncosthetabins = 10
+    dirx, diry, dirz = -1.0, 0.0, 0.0
+
+    dirbin = at.packets.get_directionbin(
+        dirx, diry, dirz, nphibins=nphibins, ncosthetabins=ncosthetabins, syn_dir=(0, 0, 1)
+    )
+    assert dirbin % nphibins == nphibins - 1
+    assert dirbin < nphibins * ncosthetabins
+
+    dfpackets = at.packets.add_packet_directions_lazypolars(
+        pl.DataFrame({"dirx": [dirx], "diry": [diry], "dirz": [dirz]})
+    )
+    binned = at.packets.bin_packet_directions_polars(
+        dfpackets, nphibins=nphibins, ncosthetabins=ncosthetabins
+    ).collect()
+
+    assert binned["phibin"].item() == nphibins - 1
+    assert binned["dirbin"].item() == dirbin
+
+
 def test_get_virtual_packets() -> None:
     nprocs_read, dfvpkt = at.packets.get_virtual_packets(
         modelpath=at.get_path("testdata") / "vpktcontrib", maxpacketfiles=2

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -921,6 +921,25 @@ def get_vspecpol_spectrum(
     )
 
 
+def get_emabs_timeblock_count(dfemabs: pl.DataFrame, n_nu: int, n_timesteps: int, emabsfilename: str) -> int:
+    """Get the number of time blocks per frequency bin in an emission or absorption file.
+
+    These files store one row per (frequency, time) pair with time varying fastest, so this is the stride between
+    consecutive rows of the same frequency bin. Polarisation files hold the I, Q, and U components, giving three time
+    blocks per timestep instead of one.
+    """
+    nrows = dfemabs.height
+    assert nrows % n_nu == 0, f"{emabsfilename}: row count {nrows} is not a multiple of the {n_nu} frequency bins"
+
+    n_timeblocks = nrows // n_nu
+    assert n_timeblocks in {n_timesteps, 3 * n_timesteps}, (
+        f"{emabsfilename}: got {n_timeblocks} time blocks per frequency bin, expected {n_timesteps} timesteps"
+        f" or {3 * n_timesteps} for a polarisation file"
+    )
+
+    return n_timeblocks
+
+
 @lru_cache(maxsize=4)
 def get_flux_contributions(
     modelpath: Path,
@@ -965,11 +984,11 @@ def get_flux_contributions(
 
     emissiondata: dict[int, pl.DataFrame] = {}
     absorptiondata: dict[int, pl.DataFrame] = {}
+    # the row stride of each frame, derived from that frame alone so that emission and absorption (and separate
+    # direction bins) can never pick up each other's value
+    emission_timeblocks: dict[int, int] = {}
+    absorption_timeblocks: dict[int, int] = {}
     maxion: int | None = None
-
-    # emission and absorption files store one row per (frequency, time) pair, with time varying fastest. Polarisation
-    # files hold the I, Q, and U components, so each frequency is followed by three times as many rows.
-    n_timeblocks = len(arr_tmid)
     polarisation_notified = False
 
     for dbin in dbinlist:
@@ -981,14 +1000,14 @@ def get_flux_contributions(
 
             emissionfilename = firstexisting(emissionfilenames, folder=modelpath, tryzipped=True)
 
-            if "pol" in str(emissionfilename):
-                if not polarisation_notified:
-                    print("This artis run contains polarisation data")
-                    polarisation_notified = True
-                # File contains I, Q and U and so times are repeated 3 times
-                n_timeblocks = 3 * len(arr_tmid)
-
             emissiondata[dbin] = read_emission_absorption_file(emissionfilename).collect()
+            emission_timeblocks[dbin] = get_emabs_timeblock_count(
+                emissiondata[dbin], len(arraynu), len(arr_tmid), str(emissionfilename)
+            )
+
+            if emission_timeblocks[dbin] > len(arr_tmid) and not polarisation_notified:
+                print("This artis run contains polarisation data")
+                polarisation_notified = True
 
             maxion_float = (
                 (len(emissiondata[dbin].collect_schema().names()) - 1) / 2.0 / nelements
@@ -1003,9 +1022,6 @@ def get_flux_contributions(
             else:
                 assert maxion == int(maxion_float)
 
-            # check that the row count is product of time blocks and frequency bins found in spec.out
-            assert emissiondata[dbin].select(pl.len()).item() == len(arraynu) * n_timeblocks
-
         if getabsorption:
             absorptionfilenames = ["absorption.out", "absorptionpol.out"]
             if dbin != -1:
@@ -1013,13 +1029,15 @@ def get_flux_contributions(
 
             absorptionfilename = firstexisting(absorptionfilenames, folder=modelpath, tryzipped=True)
 
-            if "pol" in str(absorptionfilename):
-                if not polarisation_notified:
-                    print("This artis run contains polarisation data")
-                    polarisation_notified = True
-                n_timeblocks = 3 * len(arr_tmid)
-
             absorptiondata[dbin] = read_emission_absorption_file(absorptionfilename).collect()
+            absorption_timeblocks[dbin] = get_emabs_timeblock_count(
+                absorptiondata[dbin], len(arraynu), len(arr_tmid), str(absorptionfilename)
+            )
+
+            if absorption_timeblocks[dbin] > len(arr_tmid) and not polarisation_notified:
+                print("This artis run contains polarisation data")
+                polarisation_notified = True
+
             absorption_maxion_float = len(absorptiondata[dbin].collect_schema().names()) / nelements
             assert absorption_maxion_float.is_integer()
             absorption_maxion = int(absorption_maxion_float)
@@ -1031,7 +1049,6 @@ def get_flux_contributions(
                 )
             else:
                 assert absorption_maxion == maxion
-            assert absorptiondata[dbin].select(pl.len()).item() == len(arraynu) * n_timeblocks
 
     array_flambda_emission_total = np.zeros_like(arraylambda, dtype=float)
     contribution_list = []
@@ -1057,7 +1074,7 @@ def get_flux_contributions(
                 if getemission:
                     array_fnu_emission = weighted_average_spectra([
                         (
-                            emissiondata[dbin][timestep::n_timeblocks, selectedcolumn].to_numpy(),
+                            emissiondata[dbin][timestep :: emission_timeblocks[dbin], selectedcolumn].to_numpy(),
                             arr_tdelta[timestep] / len(dbinlist),
                         )
                         for timestep in range(timestepmin, timestepmax + 1)
@@ -1069,7 +1086,7 @@ def get_flux_contributions(
                 if absorptiondata and selectedcolumn < nelements * maxion:  # bound-bound process
                     array_fnu_absorption = weighted_average_spectra([
                         (
-                            absorptiondata[dbin][timestep::n_timeblocks, selectedcolumn].to_numpy(),
+                            absorptiondata[dbin][timestep :: absorption_timeblocks[dbin], selectedcolumn].to_numpy(),
                             arr_tdelta[timestep] / len(dbinlist),
                         )
                         for timestep in range(timestepmin, timestepmax + 1)

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -59,8 +59,8 @@ def timeshift_fluxscale_co56law(scaletoreftime: float | int | None, spectime: fl
 def get_dfspectrum_x_y_with_units(
     dfspectrum: pl.DataFrame | pl.LazyFrame, xunit: str, yvariable: str, fluxdistance_mpc: float | int
 ) -> pl.LazyFrame:
-    h_ev_s = 4.1356677e-15  # Planck's constant [eV s]
     from artistools.constants import h_erg_s
+    from artistools.constants import h_ev_s
     from artistools.constants import megaparsec_to_cm
 
     dfspectrum = dfspectrum.lazy()
@@ -317,7 +317,7 @@ def convert_xunit_aliases_to_canonical(xunit: str) -> str:
 def convert_angstroms_to_unit[T: (float, npt.NDArray[np.floating])](value_angstroms: T, new_units: str) -> T:
     """Convert a wavelength in angstroms to a different unit, either length, frequency, or energy."""
     hc_ev_angstroms = const.h_ev_s * const.c_ang_per_s  # [eV angstroms]
-    hc_erg_angstroms = hc_ev_angstroms * 1.60218e-12  # [erg angstroms]
+    hc_erg_angstroms = hc_ev_angstroms * const.EV_to_erg  # [erg angstroms]
     match new_units.lower():
         case "erg":
             return hc_erg_angstroms / value_angstroms  # ty:ignore[invalid-return-type]
@@ -346,6 +346,8 @@ def convert_unit_to_angstroms[T: (float, npt.NDArray[np.floating])](value: T, ol
     h = const.h_ev_s
     hc_ev_angstroms = h * c  # [eV angstroms]
     match old_units.lower():
+        case "erg":
+            return hc_ev_angstroms * const.EV_to_erg / value  # ty:ignore[invalid-return-type]
         case "ev":
             return hc_ev_angstroms / value  # ty:ignore[invalid-return-type]
         case "kev":
@@ -964,6 +966,12 @@ def get_flux_contributions(
     emissiondata: dict[int, pl.DataFrame] = {}
     absorptiondata: dict[int, pl.DataFrame] = {}
     maxion: int | None = None
+
+    # emission and absorption files store one row per (frequency, time) pair, with time varying fastest. Polarisation
+    # files hold the I, Q, and U components, so each frequency is followed by three times as many rows.
+    n_timeblocks = len(arr_tmid)
+    polarisation_notified = False
+
     for dbin in dbinlist:
         if getemission:
             emissionfilenames = ["emission.out", "emissionpol.out"] if use_lastemissiontype else ["emissiontrue.out"]
@@ -974,9 +982,11 @@ def get_flux_contributions(
             emissionfilename = firstexisting(emissionfilenames, folder=modelpath, tryzipped=True)
 
             if "pol" in str(emissionfilename):
-                print("This artis run contains polarisation data")
+                if not polarisation_notified:
+                    print("This artis run contains polarisation data")
+                    polarisation_notified = True
                 # File contains I, Q and U and so times are repeated 3 times
-                arr_tmid = list(np.tile(np.array(arr_tmid), 3))
+                n_timeblocks = 3 * len(arr_tmid)
 
             emissiondata[dbin] = read_emission_absorption_file(emissionfilename).collect()
 
@@ -993,15 +1003,21 @@ def get_flux_contributions(
             else:
                 assert maxion == int(maxion_float)
 
-            # check that the row count is product of timesteps and frequency bins found in spec.out
-            assert emissiondata[dbin].select(pl.len()).item() == len(arraynu) * len(arr_tmid)
+            # check that the row count is product of time blocks and frequency bins found in spec.out
+            assert emissiondata[dbin].select(pl.len()).item() == len(arraynu) * n_timeblocks
 
         if getabsorption:
             absorptionfilenames = ["absorption.out", "absorptionpol.out"]
-            if directionbin is not None:
+            if dbin != -1:
                 absorptionfilenames = [x.replace(".out", f"_res_{dbin:02d}.out") for x in absorptionfilenames]
 
             absorptionfilename = firstexisting(absorptionfilenames, folder=modelpath, tryzipped=True)
+
+            if "pol" in str(absorptionfilename):
+                if not polarisation_notified:
+                    print("This artis run contains polarisation data")
+                    polarisation_notified = True
+                n_timeblocks = 3 * len(arr_tmid)
 
             absorptiondata[dbin] = read_emission_absorption_file(absorptionfilename).collect()
             absorption_maxion_float = len(absorptiondata[dbin].collect_schema().names()) / nelements
@@ -1015,7 +1031,7 @@ def get_flux_contributions(
                 )
             else:
                 assert absorption_maxion == maxion
-            assert absorptiondata[dbin].select(pl.len()).item() == len(arraynu) * len(arr_tmid)
+            assert absorptiondata[dbin].select(pl.len()).item() == len(arraynu) * n_timeblocks
 
     array_flambda_emission_total = np.zeros_like(arraylambda, dtype=float)
     contribution_list = []
@@ -1041,7 +1057,7 @@ def get_flux_contributions(
                 if getemission:
                     array_fnu_emission = weighted_average_spectra([
                         (
-                            emissiondata[dbin][timestep :: len(arr_tmid), selectedcolumn].to_numpy(),
+                            emissiondata[dbin][timestep::n_timeblocks, selectedcolumn].to_numpy(),
                             arr_tdelta[timestep] / len(dbinlist),
                         )
                         for timestep in range(timestepmin, timestepmax + 1)
@@ -1053,7 +1069,7 @@ def get_flux_contributions(
                 if absorptiondata and selectedcolumn < nelements * maxion:  # bound-bound process
                     array_fnu_absorption = weighted_average_spectra([
                         (
-                            absorptiondata[dbin][timestep :: len(arr_tmid), selectedcolumn].to_numpy(),
+                            absorptiondata[dbin][timestep::n_timeblocks, selectedcolumn].to_numpy(),
                             arr_tdelta[timestep] / len(dbinlist),
                         )
                         for timestep in range(timestepmin, timestepmax + 1)

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -286,3 +286,14 @@ def test_spectra_timeseries_subplots() -> None:
 
 def test_writespectra() -> None:
     at.spectra.writespectra.main(argsraw=[], modelpath=modelpath)
+
+
+@pytest.mark.parametrize("xunit", ["angstroms", "nm", "micron", "hz", "ev", "kev", "mev", "erg"])
+def test_xunit_conversion_roundtrip(xunit: str) -> None:
+    """Every unit accepted by convert_angstroms_to_unit must also be invertible by convert_unit_to_angstroms."""
+    arr_lambda = np.array([1.0, 100.0, 5000.0, 1e5])
+
+    arr_converted = at.spectra.convert_angstroms_to_unit(arr_lambda, xunit)
+    arr_roundtrip = at.spectra.convert_unit_to_angstroms(arr_converted, xunit)
+
+    assert arr_roundtrip == pytest.approx(arr_lambda, rel=1e-9)

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -10,6 +10,7 @@ import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import artistools as at
+from artistools.spectra import spectra as atspectra
 
 modelpath = at.get_path("testdata") / "testmodel"
 outputpath = at.get_path("testoutput")
@@ -297,3 +298,25 @@ def test_xunit_conversion_roundtrip(xunit: str) -> None:
     arr_roundtrip = at.spectra.convert_unit_to_angstroms(arr_converted, xunit)
 
     assert arr_roundtrip == pytest.approx(arr_lambda, rel=1e-9)
+
+
+def test_get_emabs_timeblock_count() -> None:
+    """The row stride must come from each file's own size, not from shared state."""
+    n_nu, n_timesteps = 5, 4
+
+    # a normal file has one time block per timestep, a polarisation file has three (I, Q, U)
+    dfplain = pl.DataFrame({"col": range(n_nu * n_timesteps)})
+    dfpol = pl.DataFrame({"col": range(n_nu * n_timesteps * 3)})
+
+    assert atspectra.get_emabs_timeblock_count(dfplain, n_nu, n_timesteps, "emission.out") == n_timesteps
+    assert atspectra.get_emabs_timeblock_count(dfpol, n_nu, n_timesteps, "emissionpol.out") == 3 * n_timesteps
+
+    # a row count that is not a whole number of frequency bins is rejected
+    dfragged = pl.DataFrame({"col": range(n_nu * n_timesteps + 1)})
+    with pytest.raises(AssertionError, match="not a multiple"):
+        atspectra.get_emabs_timeblock_count(dfragged, n_nu, n_timesteps, "emission.out")
+
+    # so is a whole-multiple count that matches neither the plain nor the polarisation layout
+    dfwrong = pl.DataFrame({"col": range(n_nu * n_timesteps * 2)})
+    with pytest.raises(AssertionError, match="time blocks per frequency bin"):
+        atspectra.get_emabs_timeblock_count(dfwrong, n_nu, n_timesteps, "emission.out")


### PR DESCRIPTION
## Summary
This PR refactors emission line flux calculations to use more accurate terminology (luminosity instead of flux), fixes critical edge cases in direction binning for packets, and improves handling of coordinate systems in model data.

## Key Changes

### Terminology Updates
- Renamed `get_line_fluxes_from_packets()` → `get_line_luminosities_from_packets()` with clarifying docstring that values are in [erg/s] without distance scaling
- Renamed `get_line_fluxes_from_pops()` → `get_line_luminosities_from_pops()`
- Renamed `make_flux_ratio_plot()` → `make_luminosity_ratio_plot()`
- Updated column naming from `flux_*` to `lum_*` in output data
- Renamed internal variables from `fluxdata` to `lumdata` for consistency

### Direction Binning Fixes
- Fixed phi bin overflow when `cosphi == -1` (acos reaches exactly 2π) by clamping to `nphibins - 1`
- Fixed phi bin overflow when `cosphi == 1` in monotonic ascending mode
- Added comprehensive test coverage for unequal phi/costheta bin counts
- Added test for edge case where direction lands exactly at phi upper boundary
- Updated packet direction binning to use configurable bin counts instead of hardcoded 10x10

### Model Data Improvements
- Added `min_abs_coordinate()` helper function to correctly handle cells straddling coordinate planes (where min/max cross zero)
- Fixed `pos_r_min` calculation for 3D models to account for cells that straddle coordinate planes
- Fixed `logrho` calculation to clamp at -99 (empty cell marker) instead of producing -inf for zero density
- Fixed kinetic energy calculation to avoid double-counting radial component in multi-dimensional models
- Fixed `vel_*_on_c` scaling to exclude `vel_*_kmps` columns (which are in km/s, not cm/s)
- Added `phi_mirrored` column naming in `get_cell_angle()` to clarify it's opposite sense from packet phi

### Code Refactoring
- Extracted transition data lookup outside inner loop in `get_line_luminosities_from_pops()` for efficiency
- Improved error handling with better comments distinguishing missing transitions from empty cells
- Renamed `get_rankbatch_parquetfile()` → `get_packets_rankbatch_parquetfile()` and `get_estimators_rankbatch_parquetfile()` for clarity
- Extracted `add_derived_estimator_columns()` as reusable function with proper null handling
- Fixed spectrum unit conversion to support "erg" as input unit in `convert_unit_to_angstroms()`

### Bug Fixes
- Fixed modelmeta initialization in packet processing when reading model data
- Fixed polarization file handling to track time blocks separately instead of modifying array
- Fixed data size reporting for virtual packets to sum all batch sizes instead of assuming uniform
- Fixed `nnelement_*` null handling to fill with zero only for those columns while preserving nulls elsewhere
- Fixed deposition data reading to properly handle timestep column

### Test Additions
- Added `test_directionbins_unequal_bincounts()` for phi/costheta bin count mismatch
- Added `test_directionbins_phibin_upper_edge()` for phi boundary overflow
- Added `test_pos_r_min_straddling_cells()` for coordinate plane straddling
- Added `test_min_abs_coordinate()` for coordinate minimum calculation
- Added `test_vel_on_c_excludes_kmps_columns()` for velocity scaling
- Added `test_add_derived_estimator_columns_*()` tests for estimator column derivation
- Added `test_xunit_conversion_roundtrip()` for spectrum unit conversion
- Added `test_average_direction_bins_unequal_bincounts()` for direction bin averaging

## Notable Implementation Details
- Direction bin packing formula: `dirbin = costhetabin * nphibins + phibin

https://claude.ai/code/session_01Nj64iauPNymsq6G2Ax25bo