### PR TITLE
Fix bugs in code paths that the test suite does not reach

### DIFF
--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -91,6 +91,7 @@ from artistools.misc import add_timeminmax_args as add_timeminmax_args
 from artistools.misc import add_timestep_arg as add_timestep_arg
 from artistools.misc import add_viewingangle_args as add_viewingangle_args
 from artistools.misc import average_direction_bins as average_direction_bins
+from artistools.misc import check_averaging_angles as check_averaging_angles
 from artistools.misc import firstexisting as firstexisting
 from artistools.misc import firstexisting_or_none as firstexisting_or_none
 from artistools.misc import flatten_list as flatten_list

--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -429,6 +429,15 @@ def get_elsymbolslist() -> list[str]:
     return ["n", *pl.read_csv(get_path("datadir") / "elements.csv", has_header=True, separator=",")["symbol"].to_list()]
 
 
+@lru_cache(maxsize=1)
+def get_elsymbols_longestfirst() -> tuple[str, ...]:
+    """Return the element symbols ordered longest first, for matching a symbol at the start of a string.
+
+    'Fe' must be tried before 'F', otherwise 'FeII' would match the fluorine prefix.
+    """
+    return tuple(sorted(get_elsymbolslist(), key=len, reverse=True))
+
+
 def get_elsymbols_df() -> pl.LazyFrame:
     """Return a polars LazyFrame of atomic number and element symbols."""
     return (
@@ -494,7 +503,7 @@ def get_ion_tuple(ionstr: str) -> tuple[int, int] | int:
     else:
         # no separator, e.g. 'FeII'. Longest symbols first, so that 'Fe' is preferred over 'F', and only accept a
         # match where the remainder is a valid ion stage (otherwise 'Co' would be split as C + 'o')
-        for elsym in sorted(get_elsymbolslist(), key=len, reverse=True):
+        for elsym in get_elsymbols_longestfirst():
             if ionstr.startswith(elsym):
                 remainder = ionstr.removeprefix(elsym)
                 if remainder.isdigit() or decode_roman_numeral(remainder) > 0:
@@ -502,7 +511,7 @@ def get_ion_tuple(ionstr: str) -> tuple[int, int] | int:
                     strion_stage = remainder
                     break
 
-    if elem == "?":
+    if elem in {"?", ""} or strion_stage in {"?", ""}:
         msg = f"Could not parse ionstr {ionstr}"
         raise ValueError(msg)
 

--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -108,11 +108,11 @@ def parse_phixsdata(
                 nptargetlist = np.array([(upperionlevel, 1.0)], dtype=[("level", np.int32), ("fraction", np.float32)])
             else:
                 ntargets = int(fphixs.readline())
-                nptargetlist = np.empty((ntargets, 2), dtype=[("level", np.int32), ("fraction", np.float32)])
-                # targetlist = [(-1, 0.0) for _ in range(ntargets)]
+                # one structured entry per target, matching the shape of the single-target case above
+                nptargetlist = np.empty(ntargets, dtype=[("level", np.int32), ("fraction", np.float32)])
                 for phixstargetindex in range(ntargets):
                     level, fraction = fphixs.readline().split()
-                    nptargetlist[phixstargetindex, :] = (int(level) - firstlevelnumber, float(fraction))
+                    nptargetlist[phixstargetindex] = (int(level) - firstlevelnumber, float(fraction))
 
             if not ionlist or (Z, lowerion_stage) in ionlist:
                 phixslist = [float(fphixs.readline()) * 1e-18 for _ in range(nphixspoints)]
@@ -488,17 +488,21 @@ def get_ion_tuple(ionstr: str) -> tuple[int, int] | int:
     elem = "?"
     strion_stage = "?"
     if " " in ionstr:
-        elem, strion_stage = ionstr.split(" ")
+        elem, strion_stage = ionstr.split(" ", maxsplit=1)
     elif "_" in ionstr:
-        elem, strion_stage = ionstr.split("_")
+        elem, strion_stage = ionstr.split("_", maxsplit=1)
     else:
-        for elsym in get_elsymbolslist():
+        # no separator, e.g. 'FeII'. Longest symbols first, so that 'Fe' is preferred over 'F', and only accept a
+        # match where the remainder is a valid ion stage (otherwise 'Co' would be split as C + 'o')
+        for elsym in sorted(get_elsymbolslist(), key=len, reverse=True):
             if ionstr.startswith(elsym):
-                elem = elsym
-                strion_stage = ionstr.removeprefix(elsym)
-                break
+                remainder = ionstr.removeprefix(elsym)
+                if remainder.isdigit() or decode_roman_numeral(remainder) > 0:
+                    elem = elsym
+                    strion_stage = remainder
+                    break
 
-    if not elem:
+    if elem == "?":
         msg = f"Could not parse ionstr {ionstr}"
         raise ValueError(msg)
 

--- a/artistools/atomic/test_atomic.py
+++ b/artistools/atomic/test_atomic.py
@@ -95,3 +95,31 @@ def test_get_ionrecombratecalibration() -> None:
         "rrc_total": 7.3507e-12,
         "T_e": 1.0e5,
     })
+
+
+def test_parse_phixsdata_multiple_targets(tmp_path: Path) -> None:
+    """A multi-target photoionisation entry must give one structured record per target, like the single-target case."""
+    nphixspoints = 3
+    lines = [
+        f"{nphixspoints}",
+        "0.1",
+        # upper ion level -1 means the targets are listed on the following lines
+        "26 3 -1 2 1 7.9",
+        "2",
+        "1 0.75",
+        "3 0.25",
+        *["1.0"] * nphixspoints,
+    ]
+    phixsfile = tmp_path / "phixsdata_v2.txt"
+    phixsfile.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    from artistools.atomic._atomic_core import parse_phixsdata
+
+    phixsdict = parse_phixsdata(phixsfile)
+
+    nptargetlist, phixstable = phixsdict[26, 2, 0]
+    # one entry per target, not an (ntargets, 2) grid of duplicated tuples
+    assert nptargetlist.shape == (2,)
+    assert nptargetlist["level"].tolist() == [0, 2]
+    assert nptargetlist["fraction"].tolist() == pytest.approx([0.75, 0.25])
+    assert len(phixstable) == nphixspoints

--- a/artistools/ejectaopacity.py
+++ b/artistools/ejectaopacity.py
@@ -205,7 +205,11 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     print()
     print(f"timestep {timestep} T_days = {time_days:.2f}")
 
-    adata = at.atomic.get_levels(args.modelpath, get_transitions=True, derived_transitions_columns=["lambda_angstroms"])
+    # get_binned_opacities_ion() needs the statistical weights as well as the wavelength, and
+    # add_transition_columns() drops every derived column that is not requested here
+    adata = at.atomic.get_levels(
+        args.modelpath, get_transitions=True, derived_transitions_columns=["lambda_angstroms", "lower_g", "upper_g"]
+    )
 
     pl.Config.set_tbl_cols(20)
     pl.Config.set_tbl_rows(5000)

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -201,12 +201,16 @@ def add_derived_estimator_columns(pldflazy: pl.LazyFrame) -> pl.LazyFrame:
         # for older files with no deposition data, take heating part of deposition and heating fraction
         pldflazy = pldflazy.with_columns(total_dep=pl.col("heating_dep") / pl.col("heating_heating_dep/total_dep"))
 
+    # only fill the number density columns: ARTIS omits zero-abundance ions and isotopes from the estimator files,
+    # so a missing number density means zero. The file reader already fills these with zero for cells that skip them
+    # within one file, and this makes the columns that a whole rank omitted agree. Every other column (Te, TR, nne,
+    # ...) must keep its nulls so that missing data isn't silently read as a real zero
+    numberdensitycols = cs.starts_with("nnelement_", "nnion_", "nniso_")
+    if any(col.startswith(("nnelement_", "nnion_", "nniso_")) for col in colnames):
+        pldflazy = pldflazy.with_columns(numberdensitycols.fill_null(0))
+
     if any(col.startswith("nnelement_") for col in colnames):
-        # only fill the nnelement columns: a missing number density means zero, but every other column (Te, TR, nne,
-        # ...) must keep its nulls so that missing data isn't silently read as a real zero
-        pldflazy = pldflazy.with_columns(cs.starts_with("nnelement_").fill_null(0)).with_columns(
-            nntot=pl.sum_horizontal(cs.starts_with("nnelement_"))
-        )
+        pldflazy = pldflazy.with_columns(nntot=pl.sum_horizontal(cs.starts_with("nnelement_")))
 
     return pldflazy
 

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -205,9 +205,8 @@ def add_derived_estimator_columns(pldflazy: pl.LazyFrame) -> pl.LazyFrame:
     # so a missing number density means zero. The file reader already fills these with zero for cells that skip them
     # within one file, and this makes the columns that a whole rank omitted agree. Every other column (Te, TR, nne,
     # ...) must keep its nulls so that missing data isn't silently read as a real zero
-    numberdensitycols = cs.starts_with("nnelement_", "nnion_", "nniso_")
-    if any(col.startswith(("nnelement_", "nnion_", "nniso_")) for col in colnames):
-        pldflazy = pldflazy.with_columns(numberdensitycols.fill_null(0))
+    # a selector that matches nothing makes this a no-op, so no guard is needed here
+    pldflazy = pldflazy.with_columns(cs.starts_with("nnelement_", "nnion_", "nniso_").fill_null(0))
 
     if any(col.startswith("nnelement_") for col in colnames):
         pldflazy = pldflazy.with_columns(nntot=pl.sum_horizontal(cs.starts_with("nnelement_")))

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -428,6 +428,11 @@ def default_plotitem_has_data(plotitems: t.Any, estimatorcolumns: Collection[str
         return True
 
     if isinstance(plotitems, (list, tuple)):
+        # initabundances/initmasses series read the input model file, not the estimators, so the element names in
+        # those items say nothing about which estimator columns exist
+        if len(plotitems) == 2 and isinstance(plotitems[0], str) and plotitems[0] in {"initabundances", "initmasses"}:
+            return True
+
         return all(default_plotitem_has_data(item, estimatorcolumns) for item in plotitems)
 
     return True

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -417,8 +417,13 @@ def default_plotitem_has_data(plotitems: t.Any, estimatorcolumns: Collection[str
     applied to that default list: an explicitly requested plot item is never dropped, so a typo there still raises.
     """
     if isinstance(plotitems, str):
+        # an estimator variable always wins over the element reading of its name, because several estimator names
+        # are also element symbols (Te is tellurium, W is tungsten)
+        if plotitems in estimatorcolumns:
+            return True
+
         atomic_number = get_iontuple(plotitems)[0]
-        if atomic_number >= 1:
+        if 1 <= atomic_number < len(at.get_elsymbolslist()):
             return f"nnelement_{at.get_elsymbol(atomic_number)}" in estimatorcolumns
         return True
 
@@ -1208,9 +1213,14 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     estimatorcolumns = estimators.collect_schema().names()
 
     if usingdefaultplotlist:
-        keptplotlist = [x for x in plotlist if default_plotitem_has_data(x, estimatorcolumns)]
-        if skipped := [x for x in plotlist if x not in keptplotlist]:
-            print(f"Skipping default plots for elements that are not in this model: {skipped}")
+        keptplotlist: list[t.Any] = []
+        skippedplotlist: list[t.Any] = []
+        for plotitems in plotlist:
+            target = keptplotlist if default_plotitem_has_data(plotitems, estimatorcolumns) else skippedplotlist
+            target.append(plotitems)
+
+        if skippedplotlist:
+            print(f"Skipping default plots for elements that are not in this model: {skippedplotlist}")
         if not keptplotlist:
             msg = "No default plots apply to this model. Choose what to plot with -plot (e.g. -plot Te TR)"
             raise ValueError(msg)

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -288,7 +288,7 @@ def plot_levelpop(
 
     modeldata = (
         at.inputmodel
-        .get_modeldata(modelpath, derived_cols=["mass_g", "volume"])[0]
+        .get_modeldata(modelpath, derived_cols=["mass_g", "volume", "vel_r_min_kmps", "vel_r_max_kmps"])[0]
         .collect()
         .to_pandas(use_pyarrow_extension_array=True)
     )
@@ -408,6 +408,24 @@ def could_be_ion(plotvar: t.Any) -> bool:
 
     # a string that is an integer is an atomic number
     return plotvar.isdigit() or "=" in plotvar or get_iontuple(plotvar)[0] >= 1
+
+
+def default_plotitem_has_data(plotitems: t.Any, estimatorcolumns: Collection[str]) -> bool:
+    """Return False if a plot item names an element that is missing from this model's estimators.
+
+    The built-in plot list names particular elements (e.g. Sr), which most models do not contain. This is only
+    applied to that default list: an explicitly requested plot item is never dropped, so a typo there still raises.
+    """
+    if isinstance(plotitems, str):
+        atomic_number = get_iontuple(plotitems)[0]
+        if atomic_number >= 1:
+            return f"nnelement_{at.get_elsymbol(atomic_number)}" in estimatorcolumns
+        return True
+
+    if isinstance(plotitems, (list, tuple)):
+        return all(default_plotitem_has_data(item, estimatorcolumns) for item in plotitems)
+
+    return True
 
 
 def normalise_plotitems(plotitems: t.Any, estimatorcolumns: Collection[str]) -> list[t.Any]:
@@ -1151,6 +1169,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     estimators = estimators.with_columns(deltavol_deltat=pl.col("volume") * pl.col("twidth_days"))
 
+    usingdefaultplotlist = not args.plotlist
     plotlist: list[t.Any] = args.plotlist or [
         # [["initabundances", ["Fe", "Ni_stable", "Ni_56"]]],
         # ['heating_dep', 'heating_coll', 'heating_bf', 'heating_ff',
@@ -1187,6 +1206,15 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     ]
 
     estimatorcolumns = estimators.collect_schema().names()
+
+    if usingdefaultplotlist:
+        keptplotlist = [x for x in plotlist if default_plotitem_has_data(x, estimatorcolumns)]
+        if skipped := [x for x in plotlist if x not in keptplotlist]:
+            print(f"Skipping default plots for elements that are not in this model: {skipped}")
+        if not keptplotlist:
+            msg = "No default plots apply to this model. Choose what to plot with -plot (e.g. -plot Te TR)"
+            raise ValueError(msg)
+        plotlist = keptplotlist
 
     plotlist = [normalise_plotitems(plotitems, estimatorcolumns) for plotitems in plotlist]
 

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -481,8 +481,8 @@ def test_estimator_default_plotlist_skips_absent_elements(mockplot: t.Any) -> No
     # testmodel has no Sr, so the default averageionisation/populations plots must be skipped rather than raising
     at.estimators.plot(argsraw=[], modelpath=modelpath, timedays=300, outputfile=funcoutpath)
 
-    # the two element-independent default subplots (rho and TR) are still drawn
-    assert len(mockplot.call_args_list) == 2
+    # the element-independent default subplots (rho and TR) are still drawn
+    assert len(mockplot.call_args_list) >= 2
     for call in mockplot.call_args_list:
         yvalues = np.array(call[0][2], dtype=float)
         assert np.all(np.isfinite(yvalues))

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -411,3 +411,99 @@ def test_add_derived_estimator_columns_total_dep() -> None:
 
     assert dfout["total_dep"].to_list() == [7.0]
     assert "nntot" not in dfout.columns
+
+
+def test_add_derived_estimator_columns_fills_ion_and_isotope_nulls() -> None:
+    """A number density column that a whole MPI rank omitted arrives as null, and must be read as zero.
+
+    Within a single estimator file the reader already fills these with zero, so leaving the cross-rank nulls
+    alone would give the same missing ion two different values depending on which rank wrote the cell.
+    """
+    pldf = pl.LazyFrame({
+        "timestep": [0, 1],
+        "modelgridindex": [0, 1],
+        "nnelement_Fe": [2.0, None],
+        "nnion_Fe_II": [None, 1.5],
+        "nniso_Ni56": [None, 3.0],
+        "Te": [5000.0, None],
+    })
+
+    dfout = at.estimators.add_derived_estimator_columns(pldf).collect()
+
+    assert dfout["nnion_Fe_II"].to_list() == [0.0, 1.5]
+    assert dfout["nniso_Ni56"].to_list() == [0.0, 3.0]
+    assert dfout["nnelement_Fe"].to_list() == [2.0, 0.0]
+
+    # temperatures are not number densities, so a null must stay null
+    assert dfout["Te"].to_list() == [5000.0, None]
+
+
+def test_estimparse_rejects_missing_nne(tmp_path: Path) -> None:
+    """A '*nne' estimator must not be divided by another cell's electron density.
+
+    The nne column is only as long as the current row once this cell has set it, so a cell header without nne has
+    to be an error rather than silently reusing the previous cell's value.
+    """
+    (tmp_path / "estimators_0000.out").write_text(
+        "timestep 0 modelgridindex 0 TR 2000 Te 2000 W 1 TJ 2000 nne 1.0e5\n"
+        "Alpha_R*nne    Z=26  2: 2.0e5\n"
+        "timestep 0 modelgridindex 1 TR 2000 Te 2000 W 1 TJ 2000\n"
+        "Alpha_R*nne    Z=26  2: 4.0e5\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Exception, match="nne is not set for this cell"):
+        at.rustext.estimparse(tmp_path, 0, 0)
+
+
+def test_estimparse_divides_by_own_cell_nne(tmp_path: Path) -> None:
+    """Each cell's '*nne' estimator is divided by that same cell's electron density."""
+    (tmp_path / "estimators_0000.out").write_text(
+        "timestep 0 modelgridindex 0 TR 2000 Te 2000 W 1 TJ 2000 nne 1.0e5\n"
+        "Alpha_R*nne    Z=26  2: 2.0e5\n"
+        "timestep 0 modelgridindex 1 TR 2000 Te 2000 W 1 TJ 2000 nne 4.0e5\n"
+        "Alpha_R*nne    Z=26  2: 8.0e5\n",
+        encoding="utf-8",
+    )
+
+    dfest = at.rustext.estimparse(tmp_path, 0, 0).sort("modelgridindex")
+
+    assert dfest["nne"].to_list() == pytest.approx([1.0e5, 4.0e5])
+    assert dfest["Alpha_R_Fe_II"].to_list() == pytest.approx([2.0, 2.0])
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_estimator_default_plotlist_skips_absent_elements(mockplot: t.Any) -> None:
+    """The built-in plot list names particular elements, which most models do not contain."""
+    funcoutpath = outputpath / "test_estimator_default_plotlist"
+    funcoutpath.mkdir(exist_ok=True, parents=True)
+
+    # testmodel has no Sr, so the default averageionisation/populations plots must be skipped rather than raising
+    at.estimators.plot(argsraw=[], modelpath=modelpath, timedays=300, outputfile=funcoutpath)
+
+    # the two element-independent default subplots (rho and TR) are still drawn
+    assert len(mockplot.call_args_list) == 2
+    for call in mockplot.call_args_list:
+        yvalues = np.array(call[0][2], dtype=float)
+        assert np.all(np.isfinite(yvalues))
+        assert np.all(yvalues > 0.0)
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_estimator_levelpopulation_dn_on_dvel(mockplot: t.Any) -> None:
+    """Plotting dN/dv needs the inner shell velocity, which is a derived model column."""
+    funcoutpath = outputpath / "test_estimator_levelpopulation_dn_on_dvel"
+    funcoutpath.mkdir(exist_ok=True, parents=True)
+
+    at.estimators.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        timedays=300,
+        outputfile=funcoutpath,
+        plotlist=[[["levelpopulation_dn_on_dvel", ["Fe II 5"]]]],
+    )
+
+    assert mockplot.call_args_list, "nothing was plotted"
+    yvalues = np.array(mockplot.call_args_list[0][0][2], dtype=float)
+    assert np.all(np.isfinite(yvalues))
+    assert np.all(yvalues >= 0.0)

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -179,7 +179,7 @@ def process_trajectory(
     traj_masses_g: dict[int, float],
     arr_t_day: npt.NDArray[np.floating],
     nuclide_contrib: bool,
-    traj_parquet: bool,
+    traj_parquet_dir: Path | None,
     traj_ID: int,
 ) -> dict[str, npt.NDArray[np.floating]]:
     """Process a single trajectory to extract decay powers."""
@@ -314,7 +314,7 @@ def process_trajectory(
     #     # import shutil
 
     # dump to parquet
-    if traj_parquet:
+    if traj_parquet_dir is not None:
         traj_df = pl.DataFrame(decay_powers)
 
         # perform time interpolation to prevent effects from low trajectory time grid resolution
@@ -334,7 +334,7 @@ def process_trajectory(
         traj_df = pl.concat([main, last_row])
         traj_df = traj_df.fill_null(0.0).fill_nan(0.0)
 
-        traj_df.write_parquet(f"parquet/decay_powers_{traj_ID}.parquet")
+        traj_df.write_parquet(traj_parquet_dir / f"decay_powers_{traj_ID}.parquet")
     return decay_powers
 
 
@@ -358,13 +358,11 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     # get beta decay data
     nuc_data = get_nuc_data(nuc_dataset)
+    parquet_dir: Path | None = None
     if args.parquet or args.trajparquet:
-        traj_parquet_dir = args.outputpath / "parquet"
-        if not Path(traj_parquet_dir).exists():
-            Path(traj_parquet_dir).mkdir(parents=True)
-            print(f"Created directory '{traj_parquet_dir}'.")
-        else:
-            print(f"'{traj_parquet_dir}' already exists.")
+        parquet_dir = Path(args.outputpath) / "parquet"
+        parquet_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Writing parquet files to '{parquet_dir}'.")
     assert nuc_data.height == nuc_data.unique(("Z", "A")).height
 
     # set timesteps logarithmically
@@ -403,7 +401,13 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     alltraj_decay_powers: list[dict[str, npt.NDArray[np.floating]]] = at.parallel_map(
         partial(
-            process_trajectory, nuc_data, args.trajectoryroot, traj_masses_g, arr_t_day, args.nuclides, args.trajparquet
+            process_trajectory,
+            nuc_data,
+            args.trajectoryroot,
+            traj_masses_g,
+            arr_t_day,
+            args.nuclides,
+            parquet_dir if args.trajparquet else None,
         ),
         traj_ids,
         chunksize=2,
@@ -460,8 +464,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         )
 
         if args.parquet:
+            assert parquet_dir is not None
             traj_set_df = pl.DataFrame(decay_powers)
-            traj_set_df.write_parquet(f"parquet/decay_powers_{labelfull}.parquet")
+            traj_set_df.write_parquet(parquet_dir / f"decay_powers_{labelfull}.parquet")
 
         fig, axes = plt.subplots(
             nrows=2, ncols=1, figsize=(6, 10), tight_layout={"pad": 0.4, "w_pad": 0.0, "h_pad": 0.0}

--- a/artistools/gsinetwork/test_gsinetwork.py
+++ b/artistools/gsinetwork/test_gsinetwork.py
@@ -50,20 +50,28 @@ def test_decayproducts(mockplot: t.Any) -> None:
         assert math.isclose(y_arr[0], expected_y_arr[0], rel_tol=1e-3)
 
 
-def test_decayproducts_parquet_output(tmp_path: Path) -> None:
+def test_decayproducts_parquet_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Parquet files must be written under the requested output path, not a relative 'parquet' folder."""
     trajpath = at.get_path("testdata") / "kilonova" / "trajectories"
+    outputpath_requested = tmp_path / "requested"
+    outputpath_requested.mkdir()
+
+    # run from an empty directory so that a relative "parquet/..." write is visible and cannot hit a leftover folder
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
     at.gsinetwork.decayproducts.main(
         argsraw=[],
         trajectoryroot=trajpath,
         tmin=0.1,
         tmax=0.1,
         nsteps=1,
-        outputpath=tmp_path,
+        outputpath=outputpath_requested,
         parquet=True,
         trajparquet=True,
     )
 
-    parquetfiles = sorted(p.name for p in (tmp_path / "parquet").glob("*.parquet"))
+    parquetfiles = sorted(p.name for p in (outputpath_requested / "parquet").glob("*.parquet"))
     assert parquetfiles, "no parquet files written under the output path"
-    assert not Path("parquet").exists(), "parquet files must not be written relative to the working directory"
+    assert not (cwd / "parquet").exists(), "parquet files must not be written relative to the working directory"

--- a/artistools/gsinetwork/test_gsinetwork.py
+++ b/artistools/gsinetwork/test_gsinetwork.py
@@ -1,5 +1,6 @@
 import math
 import typing as t
+from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
@@ -47,3 +48,22 @@ def test_decayproducts(mockplot: t.Any) -> None:
         y_arr = x[0][2]
         assert len(y_arr) == 1
         assert math.isclose(y_arr[0], expected_y_arr[0], rel_tol=1e-3)
+
+
+def test_decayproducts_parquet_output(tmp_path: Path) -> None:
+    """Parquet files must be written under the requested output path, not a relative 'parquet' folder."""
+    trajpath = at.get_path("testdata") / "kilonova" / "trajectories"
+    at.gsinetwork.decayproducts.main(
+        argsraw=[],
+        trajectoryroot=trajpath,
+        tmin=0.1,
+        tmax=0.1,
+        nsteps=1,
+        outputpath=tmp_path,
+        parquet=True,
+        trajparquet=True,
+    )
+
+    parquetfiles = sorted(p.name for p in (tmp_path / "parquet").glob("*.parquet"))
+    assert parquetfiles, "no parquet files written under the output path"
+    assert not Path("parquet").exists(), "parquet files must not be written relative to the working directory"

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -1335,7 +1335,7 @@ def scale_model_to_time(
     """Homologously expand model to targetmodeltime_days by reducing densities and adjusting cell positions."""
     if t_model_days is None:
         assert modelmeta is not None
-        t_model_days = modelmeta["t_model_days"]
+        t_model_days = modelmeta["t_model_init_days"]
 
     assert t_model_days is not None
 
@@ -1357,7 +1357,7 @@ def scale_model_to_time(
     if modelmeta is None:
         modelmeta = {}
 
-    modelmeta["t_model_days"] = targetmodeltime_days
+    modelmeta["t_model_init_days"] = targetmodeltime_days
     modelmeta.setdefault("headercommentlines", []).append(
         f"scaled from {t_model_days} to {targetmodeltime_days} (no abund change from decays)"
     )

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -113,7 +113,8 @@ def slice_abundance_file(
             linesplit = line.split()
 
             if len(currentblock) + len(linesplit) >= 30:
-                blocklens.add(len(currentblock))
+                if currentblock:  # record only completed blocks, not the empty state before the first one
+                    blocklens.add(len(currentblock))
                 if keepcurrentblock:
                     fabundancesout.write("  ".join(currentblock) + "\n")
                 currentblock = []

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -80,10 +80,10 @@ def slice_3dmodel(
                 print("Wrong line size")
                 sys.exit()
 
-            xmatch = cell["pos_x_min"] == "0.0000000" or (chosenaxis == "x" and float(cell["pos_x_min"]) >= 0.0)
-            ymatch = cell["pos_y_min"] == "0.0000000" or (chosenaxis == "y" and float(cell["pos_y_min"]) >= 0.0)
-            zmatch = cell["pos_z_min"] == "0.0000000" or (chosenaxis == "z" and float(cell["pos_z_min"]) >= 0.0)
-            if xmatch and ymatch and zmatch:
+            # a cell is on the chosen positive axis when its two other coordinates are zero. Compare the parsed
+            # numbers, not their text: model.txt is written in several formats (e.g. "0.0000000" or "0.0000e0")
+            positions = {ax: float(cell[f"pos_{ax}_min"]) for ax in ("x", "y", "z")}
+            if all(pos == 0.0 or (chosenaxis == ax and pos >= 0.0) for ax, pos in positions.items()):
                 outcellid += 1
                 dict3dcellidto1dcellid[int(cell["cellid"])] = outcellid
                 append_cell_to_output(cell, outcellid, t_model, listout, xlist, ylists)
@@ -126,8 +126,9 @@ def slice_abundance_file(
             else:
                 currentblock.extend(linesplit)
 
-    if keepcurrentblock:
-        print("WARNING: unfinished block")
+        # the loop only writes a block when the next one starts, so the last block still has to be flushed
+        if keepcurrentblock:
+            fabundancesout.write("  ".join(currentblock) + "\n")
 
 
 def append_cell_to_output(
@@ -161,7 +162,7 @@ def make_plot(xlist: list[float], ylists: list[list[float]], pdfoutputfile: str)
     ylabels = [r"$\rho$", "fNi56", "fCo"]
     for ylist, ylabel in zip(ylists, ylabels, strict=False):
         axis.plot(xlist, ylist, linewidth=1.5, label=ylabel)
-    axis.set_yscale("log", nonposy="clip")
+    axis.set_yscale("log", nonpositive="clip")
     axis.legend(loc="best", handlelength=2, frameon=False, numpoints=1, prop={"size": 10})
     fig.savefig(pdfoutputfile, format="pdf")
     at.print_saved(pdfoutputfile)

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -108,10 +108,12 @@ def slice_abundance_file(
     ):
         currentblock: list[str] = []
         keepcurrentblock = False
+        blocklens: set[int] = set()
         for line in fabundancesin:
             linesplit = line.split()
 
             if len(currentblock) + len(linesplit) >= 30:
+                blocklens.add(len(currentblock))
                 if keepcurrentblock:
                     fabundancesout.write("  ".join(currentblock) + "\n")
                 currentblock = []
@@ -127,8 +129,14 @@ def slice_abundance_file(
                 currentblock.extend(linesplit)
 
         # the loop only writes a block when the next one starts, so the last block still has to be flushed
-        if keepcurrentblock:
-            fabundancesout.write("  ".join(currentblock) + "\n")
+        if currentblock:
+            if blocklens and len(currentblock) < max(blocklens):
+                print(
+                    f"WARNING: the last block has {len(currentblock)} values, but earlier blocks have"
+                    f" {max(blocklens)}. The input file looks truncated"
+                )
+            if keepcurrentblock:
+                fabundancesout.write("  ".join(currentblock) + "\n")
 
 
 def append_cell_to_output(

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1647,3 +1647,42 @@ def test_vel_on_c_excludes_kmps_columns() -> None:
     assert dfmodel["vel_r_max_on_c"].to_numpy() == pytest.approx(
         dfmodel["vel_r_max_kmps"].to_numpy() * 1e5 / at.constants.C_cm_per_s
     )
+
+
+def test_scale_model_to_time_uses_modelmeta() -> None:
+    """The model time key must be the same one that get_modeldata and save_modeldata use."""
+    dfmodel, modelmeta = at.inputmodel.get_modeldata(modelpath, derived_cols=["pos_min"])
+    t_model_init_days = modelmeta["t_model_init_days"]
+    targettime = t_model_init_days * 2.0
+
+    pddfmodel = dfmodel.collect().to_pandas(use_pyarrow_extension_array=False)
+    rho_before = pddfmodel["logrho"].to_numpy().copy()
+
+    dfscaled, modelmeta_out = at.inputmodel.scale_model_to_time(
+        dfmodel=pddfmodel, targetmodeltime_days=targettime, modelmeta=dict(modelmeta)
+    )
+
+    assert modelmeta_out["t_model_init_days"] == targettime
+    # homologous expansion by a factor of two drops the density by a factor of eight
+    assert dfscaled["logrho"].to_numpy() == pytest.approx(rho_before + math.log10(2.0**-3))
+
+
+def test_slice_abundance_file_writes_last_block(tmp_path: Path) -> None:
+    """The abundance blocks are written when the next one starts, so the final block needs an explicit flush."""
+    from artistools.inputmodel.make1dslicefrom3d import slice_abundance_file
+
+    inputfolder = tmp_path / "in"
+    outputfolder = tmp_path / "out"
+    inputfolder.mkdir()
+    outputfolder.mkdir()
+
+    # abundances.txt as written by save_initelemabundances: one line per cell with inputcellid and 30 mass fractions
+    lines = [" ".join([str(cellid), *[f"{cellid * 0.001:.5f}"] * 30]) for cellid in (1, 2, 3)]
+    (inputfolder / "abundances.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    slice_abundance_file(inputfolder, outputfolder, {1: 1, 3: 2})
+
+    outlines = (outputfolder / "abundances.txt").read_text(encoding="utf-8").splitlines()
+    # both selected cells must appear, including cell 3 which is the final block in the input
+    assert [int(line.split()[0]) for line in outlines] == [1, 2]
+    assert all(len(line.split()) == 31 for line in outlines)

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1686,3 +1686,41 @@ def test_slice_abundance_file_writes_last_block(tmp_path: Path) -> None:
     # both selected cells must appear, including cell 3 which is the final block in the input
     assert [int(line.split()[0]) for line in outlines] == [1, 2]
     assert all(len(line.split()) == 31 for line in outlines)
+
+
+def test_slice_3dmodel_matches_axis_numerically(tmp_path: Path) -> None:
+    """Cell positions must be compared as numbers: model.txt is written in several float formats."""
+    from artistools.inputmodel.make1dslicefrom3d import slice_3dmodel
+
+    inputfolder = tmp_path / "in"
+    outputfolder = tmp_path / "out"
+    inputfolder.mkdir()
+    outputfolder.mkdir()
+
+    xmax = 1.0e15
+    # a 2x2x2 grid written with scientific notation, as save_modeldata() does (float_scientific=True)
+    lines = ["8", "1.0", f"{xmax:.4e}"]
+    cellid = 0
+    for zpos in (-xmax, 0.0):
+        for ypos in (-xmax, 0.0):
+            for xpos in (-xmax, 0.0):
+                cellid += 1
+                lines.extend((f"{cellid} {xpos:.4e} {ypos:.4e} {zpos:.4e} 1.0e-10", "0.1 0.2 0.3 0.0 0.0"))
+    (inputfolder / "model.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    dict3dcellidto1dcellid, xlist, _ylists = slice_3dmodel(inputfolder, outputfolder, "x")
+
+    # only the cell at (0, 0, 0) is on the positive x axis with y == z == 0
+    assert dict3dcellidto1dcellid == {8: 1}
+    assert xlist == pytest.approx([0.0])
+    assert (outputfolder / "model.txt").read_text(encoding="utf-8").splitlines()[0].strip() == "1"
+
+
+def test_make1dslice_plot(tmp_path: Path) -> None:
+    """The log y-axis uses matplotlib's 'nonpositive' argument; 'nonposy' was removed in matplotlib 3.3."""
+    from artistools.inputmodel.make1dslicefrom3d import make_plot
+
+    pdfpath = tmp_path / "slice.pdf"
+    make_plot([1000.0, 2000.0], [[1e-10, 1e-12], [0.1, 0.05], [0.0, 0.01]], str(pdfpath))
+
+    assert pdfpath.is_file()

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -3,6 +3,7 @@ import math
 import typing as t
 from collections.abc import Collection
 from collections.abc import Iterable
+from collections.abc import Mapping
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -308,12 +309,14 @@ def generate_band_lightcurve_data(
                     integration_grid = wavefilter
 
                 weighted_flux_obs = float(abs(np.trapezoid(integrand, integration_grid)))
-                phot_filtobs_mag: float | int = (
-                    0.0 if weighted_flux_obs == 0.0 else -2.5 * math.log10(weighted_flux_obs / zeropointenergyflux)
-                )
+                if weighted_flux_obs <= 0.0:
+                    # no flux in the band, so there is no magnitude to report. Appending zero here would look like
+                    # an extremely bright source
+                    print(f"  no {filter_name} band flux at {time:.2f} d. Skipping this time.")
+                    continue
 
-                if phot_filtobs_mag != 0.0:
-                    phot_filtobs_mag -= 25  # Absolute magnitude
+                # 25 converts the apparent magnitude at 10 pc to an absolute magnitude
+                phot_filtobs_mag = -2.5 * math.log10(weighted_flux_obs / zeropointenergyflux) - 25
                 filters_dict[filter_name].append((time, phot_filtobs_mag))
 
     return filters_dict
@@ -435,24 +438,17 @@ def get_band_lightcurve(
 
 
 def get_colour_delta_mag(
-    band_lightcurve_data: dict[str, Iterable[t.Any]], filter_names: Sequence[str]
+    band_lightcurve_data: Mapping[str, Iterable[tuple[float, float]]], filter_names: Sequence[str]
 ) -> tuple[list[float], list[float]]:
-    time_dict_1 = {}
-    time_dict_2 = {}
+    """Return the times and magnitude differences of two bands, using only the times sampled by both bands."""
+    # make magnitude dictionaries where time is the key
+    time_dict_1 = {float(time): mag for time, mag in band_lightcurve_data[filter_names[0]]}
+    time_dict_2 = {float(time): mag for time, mag in band_lightcurve_data[filter_names[1]]}
 
-    plot_times = []
-    colour_delta_mag = []
-
-    for filter_1, filter_2 in zip(
-        band_lightcurve_data[filter_names[0]], band_lightcurve_data[filter_names[1]], strict=True
-    ):
-        # Make magnitude dictionaries where time is the key
-        time_dict_1[float(filter_1[0])] = filter_1[1]
-        time_dict_2[float(filter_2[0])] = filter_2[1]
-
-    for time in time_dict_1 | time_dict_2:
-        plot_times.append(time)
-        colour_delta_mag.append(time_dict_1[time] - time_dict_2[time])
+    # a band with no flux at some time contributes no point there, so the two bands can be sampled at different
+    # times. Only times present in both bands have a colour
+    plot_times = sorted(time_dict_1.keys() & time_dict_2.keys())
+    colour_delta_mag = [time_dict_1[time] - time_dict_2[time] for time in plot_times]
 
     return plot_times, colour_delta_mag
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -160,3 +160,16 @@ def test_colour_evolution_plot() -> None:
 
 def test_colour_evolution_subplots() -> None:
     at.lightcurve.plot(argsraw=[], modelpath=modelpath, colour_evolution=["U-B", "B-V"], outputfile=outputpath)
+
+
+def test_get_colour_delta_mag_unequal_sampling() -> None:
+    """A band with no flux at some time has no point there, so the two bands can be sampled differently."""
+    band_lightcurve_data: dict[str, list[tuple[float, float]]] = {
+        "B": [(10.0, -18.0), (20.0, -17.0), (30.0, -16.0)],
+        "V": [(10.0, -18.5), (30.0, -16.5), (40.0, -15.0)],
+    }
+
+    times, colours = at.lightcurve.get_colour_delta_mag(band_lightcurve_data, ["B", "V"])
+
+    assert times == [10.0, 30.0]
+    assert colours == pytest.approx([0.5, 0.5])

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -65,9 +65,7 @@ define_colours_list2 = [
 
 def parse_directionbin_args(modelpath: Path | str, args: argparse.Namespace) -> tuple[Sequence[int], dict[int, str]]:
     modelpath = Path(modelpath)
-    if args.average_over_phi_angle and args.average_over_theta_angle:
-        msg = "Cannot use --average_over_phi_angle together with --average_over_theta_angle"
-        raise ValueError(msg)
+    at.check_averaging_angles(args.average_over_phi_angle, args.average_over_theta_angle)
 
     viewing_angle_data_exists = args.frompackets or bool(list(modelpath.glob("*_res.out*")))
     if isinstance(args.plotviewingangle, int):

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -65,6 +65,10 @@ define_colours_list2 = [
 
 def parse_directionbin_args(modelpath: Path | str, args: argparse.Namespace) -> tuple[Sequence[int], dict[int, str]]:
     modelpath = Path(modelpath)
+    if args.average_over_phi_angle and args.average_over_theta_angle:
+        msg = "Cannot use --average_over_phi_angle together with --average_over_theta_angle"
+        raise ValueError(msg)
+
     viewing_angle_data_exists = args.frompackets or bool(list(modelpath.glob("*_res.out*")))
     if isinstance(args.plotviewingangle, int):
         args.plotviewingangle = [args.plotviewingangle]

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -42,10 +42,11 @@ def parse_emfeaturesearch(strfeature: str) -> tuple[int, ...]:
         msg = f"Could not parse emission feature {strfeature!r}. Expected e.g. '(26, 2, 7155, 7150, 7160)'"
         raise argparse.ArgumentTypeError(msg) from exc
 
+    # bool is a subclass of int, so isinstance() would accept '(26, True, 7155)'
     if (
         not isinstance(feature, (tuple, list))
         or not (3 <= len(feature) <= 7)
-        or not all(isinstance(x, int) for x in feature)
+        or not all(type(x) is int for x in feature)
     ):
         msg = (
             f"Emission feature {strfeature!r} must be 3 to 7 integers:"
@@ -855,18 +856,23 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         msg = f"At least two emission features are needed for a flux ratio, but got {len(args.emfeaturesearch)}"
         raise ValueError(msg)
 
-    # the time bins default to the timesteps of the first model
-    if args.timebins_tstart is None:
-        args.timebins_tstart = at.get_timestep_times(args.modelpath[0], loc="start")
-    if args.timebins_tend is None:
-        args.timebins_tend = at.get_timestep_times(args.modelpath[0], loc="end")
+    if (args.timebins_tstart is None) != (args.timebins_tend is None):
+        msg = "timebins_tstart and timebins_tend must be given together"
+        raise ValueError(msg)
 
-    if len(args.timebins_tstart) != len(args.timebins_tend):
+    if args.timebins_tstart is not None and len(args.timebins_tstart) != len(args.timebins_tend):
         msg = (
             f"timebins_tstart has {len(args.timebins_tstart)} values but timebins_tend has"
             f" {len(args.timebins_tend)}. They must match"
         )
         raise ValueError(msg)
+
+    if args.plotemittingregions and args.timebins_tstart is None:
+        # this plot needs concrete time bins, so fall back to the first model's timesteps. The flux ratio plot
+        # leaves them as None, which makes each model use its own timesteps
+        # copy the lists, because get_timestep_times() is lru_cached
+        args.timebins_tstart = list(at.get_timestep_times(args.modelpath[0], loc="start"))
+        args.timebins_tend = list(at.get_timestep_times(args.modelpath[0], loc="end"))
 
     assert isinstance(args.label, list)
     for i in range(len(args.label)):

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -28,6 +28,33 @@ from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_series_style_args
 
+# the Fe II 7155 Å / 12570 Å pair used for the Flörs et al. (2020) ratio comparison
+DEFAULT_EMFEATURESEARCH: tuple[tuple[int, ...], ...] = ((26, 2, 7155, 7150, 7160), (26, 2, 12570, 12470, 12670))
+
+
+def parse_emfeaturesearch(strfeature: str) -> tuple[int, ...]:
+    """Parse an emission feature given on the command line, e.g. '(26, 2, 7155, 7150, 7160)'."""
+    import ast
+
+    try:
+        feature = ast.literal_eval(strfeature)
+    except (ValueError, SyntaxError) as exc:
+        msg = f"Could not parse emission feature {strfeature!r}. Expected e.g. '(26, 2, 7155, 7150, 7160)'"
+        raise argparse.ArgumentTypeError(msg) from exc
+
+    if (
+        not isinstance(feature, (tuple, list))
+        or not (3 <= len(feature) <= 7)
+        or not all(isinstance(x, int) for x in feature)
+    ):
+        msg = (
+            f"Emission feature {strfeature!r} must be 3 to 7 integers:"
+            " (atomic_number, ion_stage, feature_wavelength[, lambdamin, lambdamax, lowerlevelindex, upperlevelindex])"
+        )
+        raise argparse.ArgumentTypeError(msg)
+
+    return tuple(feature)
+
 
 class FeatureTuple(t.NamedTuple):
     colname: str
@@ -109,7 +136,12 @@ def get_line_luminosities_from_pops(
     # arr_timedelta = np.array(arr_tend) - np.array(arr_tstart)
     arr_tmid = (np.array(arr_tstart) + np.array(arr_tend)) / 2.0
 
-    modeldata = at.inputmodel.get_modeldata(modelpath)[0].collect().to_pandas(use_pyarrow_extension_array=True)
+    modeldata = (
+        at.inputmodel
+        .get_modeldata(modelpath, derived_cols=["vel_r_min_kmps", "vel_r_max_kmps"])[0]
+        .collect()
+        .to_pandas(use_pyarrow_extension_array=True)
+    )
 
     ionlist = [(feature.atomic_number, feature.ion_stage) for feature in emfeatures]
     adata = at.atomic.get_levels_pandas(modelpath, ionlist=tuple(ionlist), get_transitions=True)
@@ -748,11 +780,13 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument(
         "-emfeaturesearch",
-        default=[],
+        default=list(DEFAULT_EMFEATURESEARCH),
         nargs="*",
+        type=parse_emfeaturesearch,
         help=(
             "Emission features as (atomic_number, ion_stage, feature_wavelength, lower_wavelength, upper_wavelength)"
-            " tuples, e.g. (26, 2, 7155, 7150, 7160) for the Fe II 7155 Å feature"
+            " tuples, e.g. '(26, 2, 7155, 7150, 7160)' for the Fe II 7155 Å feature. At least two are needed for the"
+            " flux ratio plot"
         ),
     )
 
@@ -782,10 +816,20 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "-timebins_tstart", default=[], nargs="*", action="append", help="Time bin start values in days"
+        "-timebins_tstart",
+        default=None,
+        nargs="*",
+        type=float,
+        help="Time bin start values in days. Defaults to the model timestep starts",
     )
 
-    parser.add_argument("-timebins_tend", default=[], nargs="*", action="append", help="Time bin end values in days")
+    parser.add_argument(
+        "-timebins_tend",
+        default=None,
+        nargs="*",
+        type=float,
+        help="Time bin end values in days. Defaults to the model timestep ends",
+    )
 
     add_figscale_args(parser, figscaledefault=1.8)
 
@@ -805,6 +849,24 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     args.label, args.modeltag, args.color = at.trim_or_pad(len(args.modelpath), args.label, args.modeltag, args.color)
 
     args.emtypecolumn = "emissiontype" if args.use_lastemissiontype else "trueemissiontype"
+
+    args.emfeaturesearch = [parse_emfeaturesearch(f) if isinstance(f, str) else tuple(f) for f in args.emfeaturesearch]
+    if len(args.emfeaturesearch) < 2:
+        msg = f"At least two emission features are needed for a flux ratio, but got {len(args.emfeaturesearch)}"
+        raise ValueError(msg)
+
+    # the time bins default to the timesteps of the first model
+    if args.timebins_tstart is None:
+        args.timebins_tstart = at.get_timestep_times(args.modelpath[0], loc="start")
+    if args.timebins_tend is None:
+        args.timebins_tend = at.get_timestep_times(args.modelpath[0], loc="end")
+
+    if len(args.timebins_tstart) != len(args.timebins_tend):
+        msg = (
+            f"timebins_tstart has {len(args.timebins_tstart)} values but timebins_tend has"
+            f" {len(args.timebins_tend)}. They must match"
+        )
+        raise ValueError(msg)
 
     assert isinstance(args.label, list)
     for i in range(len(args.label)):

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -32,7 +32,7 @@ from artistools.misc import add_series_style_args
 DEFAULT_EMFEATURESEARCH: tuple[tuple[int, ...], ...] = ((26, 2, 7155, 7150, 7160), (26, 2, 12570, 12470, 12670))
 
 
-def parse_emfeaturesearch(strfeature: str) -> tuple[int, ...]:
+def parse_emfeaturesearch(strfeature: str) -> tuple[int | float, ...]:
     """Parse an emission feature given on the command line, e.g. '(26, 2, 7155, 7150, 7160)'."""
     import ast
 
@@ -42,15 +42,18 @@ def parse_emfeaturesearch(strfeature: str) -> tuple[int, ...]:
         msg = f"Could not parse emission feature {strfeature!r}. Expected e.g. '(26, 2, 7155, 7150, 7160)'"
         raise argparse.ArgumentTypeError(msg) from exc
 
-    # bool is a subclass of int, so isinstance() would accept '(26, True, 7155)'
+    # the atomic number, ion stage, and level indices must be integers, but the wavelengths (entries 2 to 4) may be
+    # fractional. Exact type checks, because bool is a subclass of int and would otherwise be accepted
     if (
         not isinstance(feature, (tuple, list))
         or not (3 <= len(feature) <= 7)
-        or not all(type(x) is int for x in feature)
+        or not all(type(x) in {int, float} for x in feature)
+        or not all(type(x) is int for x in (*feature[:2], *feature[5:]))
     ):
         msg = (
-            f"Emission feature {strfeature!r} must be 3 to 7 integers:"
-            " (atomic_number, ion_stage, feature_wavelength[, lambdamin, lambdamax, lowerlevelindex, upperlevelindex])"
+            f"Emission feature {strfeature!r} must be 3 to 7 numbers:"
+            " (atomic_number, ion_stage, feature_wavelength[, lambdamin, lambdamax, lowerlevelindex,"
+            " upperlevelindex]), with integer atomic number, ion stage, and level indices"
         )
         raise argparse.ArgumentTypeError(msg)
 

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -23,6 +23,7 @@ from artistools.misc.cliutils import resolve_outputfile as resolve_outputfile
 from artistools.misc.cliutils import set_args_from_dict as set_args_from_dict
 from artistools.misc.cliutils import trim_or_pad as trim_or_pad
 from artistools.misc.dirbins import average_direction_bins as average_direction_bins
+from artistools.misc.dirbins import check_averaging_angles as check_averaging_angles
 from artistools.misc.dirbins import get_costheta_bins as get_costheta_bins
 from artistools.misc.dirbins import get_costhetabin_phibin_labels as get_costhetabin_phibin_labels
 from artistools.misc.dirbins import get_dirbin_labels as get_dirbin_labels

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -40,16 +40,20 @@ def add_viewingangle_args(parser: argparse.ArgumentParser, allow_select_all: boo
         help="Use degrees instead of radians for direction angles. Only works with -plotviewingangle",
     )
 
-    parser.add_argument(
+    # averaging over one angle leaves one bin per index of the other, so the two cannot be combined. argparse
+    # enforces this once here for every command that takes these flags
+    averagegroup = parser.add_mutually_exclusive_group()
+
+    averagegroup.add_argument(
         "--average_over_phi_angle",
         action="store_true",
         help="Average over phi (azimuthal) viewing angles to make direction bins into polar angle bins",
     )
 
     # deprecated alias for --average_over_phi_angle kept for backwards compatibility
-    parser.add_argument("--average_every_tenth_viewing_angle", action="store_true", help=argparse.SUPPRESS)
+    averagegroup.add_argument("--average_every_tenth_viewing_angle", action="store_true", help=argparse.SUPPRESS)
 
-    parser.add_argument(
+    averagegroup.add_argument(
         "--average_over_theta_angle",
         action="store_true",
         help="Average over theta (polar) viewing angles to make direction bins into azimuthal angle bins",

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -95,9 +95,20 @@ def get_viewingdirection_costhetabincount() -> int:
     return 10
 
 
+def check_averaging_angles(average_over_phi: bool, average_over_theta: bool) -> None:
+    """Reject averaging over both angles at once, which leaves too few direction bins to average again.
+
+    The command-line flags are already mutually exclusive (see add_viewingangle_args), so this covers the callers
+    that pass the values directly or build an argparse.Namespace from keyword arguments.
+    """
+    if average_over_phi and average_over_theta:
+        msg = "Cannot average over both the phi and theta viewing angles"
+        raise ValueError(msg)
+
+
 def get_dirbins(average_over_phi: bool = False, average_over_theta: bool = False) -> list[int]:
     """Return the viewing direction bin indices, reduced to the first bin of each averaging group when averaging over phi or theta angle."""
-    assert not (average_over_phi and average_over_theta)
+    check_averaging_angles(average_over_phi, average_over_theta)
     if average_over_phi:
         return list(range(0, get_viewingdirectionbincount(), get_viewingdirection_phibincount()))
     if average_over_theta:

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -39,6 +39,14 @@ def average_direction_bins(
         raise ValueError(msg)
     start_bin_range = get_dirbins(average_over_phi=overangle == "phi", average_over_theta=overangle == "theta")
 
+    if missingbins := sorted(set(range(dirbincount)) - set(dirbindataframes)):
+        # averaging twice (e.g. over theta and then over phi) leaves too few bins to average again
+        msg = (
+            f"Cannot average over {overangle}: expected all {dirbincount} direction bins, but"
+            f" {len(missingbins)} are missing (first missing bin is {missingbins[0]})"
+        )
+        raise ValueError(msg)
+
     # we will make a copy to ensure that we don't cause side effects from altering the original DataFrames
     # that might be returned again later by an lru_cached function
     dirbindataframesout: dict[int, pl.LazyFrame] = {}

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -205,7 +205,7 @@ def get_file_metadata(filepath: Path | str) -> dict[str, t.Any]:
 
 
 def merge_pdf_files(pdf_files: list[str]) -> None:
-    """Merge a list of PDF files into a single PDF file."""
+    """Merge a list of PDF files into a single PDF file, deleting the inputs once the merged file is written."""
     from pypdf import PdfWriter
 
     merger = PdfWriter()
@@ -213,13 +213,16 @@ def merge_pdf_files(pdf_files: list[str]) -> None:
     for pdfpath in pdf_files:
         with Path(pdfpath).open("rb") as pdffile:
             merger.append(pdffile)
-        Path(pdfpath).unlink()
 
-    resultfilename = f"{pdf_files[0].replace('.pdf', '')}-{pdf_files[-1].replace('.pdf', '')}"
-    with Path(f"{resultfilename}.pdf").open("wb") as resultfile:
+    resultfilename = f"{Path(pdf_files[0]).with_suffix('')}-{Path(pdf_files[-1]).with_suffix('').name}.pdf"
+    with Path(resultfilename).open("wb") as resultfile:
         merger.write(resultfile)
 
-    print_saved(f"{resultfilename}.pdf")
+    # only remove the inputs once the merged file exists, so a failed write cannot destroy them
+    for pdfpath in pdf_files:
+        Path(pdfpath).unlink()
+
+    print_saved(resultfilename)
 
 
 def write_parquet_atomic(

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -460,3 +460,24 @@ def test_get_time_range_timesteps_without_clamping(tmp_path: Path) -> None:
         assert (timestepmin, timestepmax) == (1, 3)
         assert tlow == pytest.approx(at.get_timestep_times(tmp_path, loc="start")[1])
         assert thigh == pytest.approx(at.get_timestep_times(tmp_path, loc="end")[3])
+
+
+def test_check_averaging_angles() -> None:
+    """Averaging over phi and theta at once must be rejected wherever the values arrive."""
+    for phi, theta in ((False, False), (True, False), (False, True)):
+        at.check_averaging_angles(phi, theta)
+
+    with pytest.raises(ValueError, match="both the phi and theta"):
+        at.check_averaging_angles(average_over_phi=True, average_over_theta=True)
+
+
+def test_viewingangle_averaging_flags_are_mutually_exclusive() -> None:
+    """The two averaging flags are rejected by argparse itself, for every command that defines them."""
+    parser = argparse.ArgumentParser()
+    at.add_viewingangle_args(parser)
+
+    assert parser.parse_args(["--average_over_phi_angle"]).average_over_phi_angle
+    assert parser.parse_args(["--average_over_theta_angle"]).average_over_theta_angle
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--average_over_phi_angle", "--average_over_theta_angle"])

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -429,3 +429,34 @@ def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatc
     for start_bin in (0, 4, 8):
         expected = sum(start_bin + n for n in range(nphibins)) / nphibins
         assert averaged_phi[start_bin].collect()["value"].to_list() == pytest.approx([expected, expected])
+
+
+def test_average_direction_bins_rejects_missing_bins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Averaging a second time must raise instead of a bare KeyError for the bins that no longer exist."""
+    nphibins = 4
+    ncosthetabins = 3
+
+    monkeypatch.setattr(dirbins, "get_viewingdirection_phibincount", lambda: nphibins)
+    monkeypatch.setattr(dirbins, "get_viewingdirection_costhetabincount", lambda: ncosthetabins)
+
+    dirbindataframes = {
+        dirbin: pl.DataFrame({"timestep": [0, 1], "value": [float(dirbin), float(dirbin)]})
+        for dirbin in range(nphibins * ncosthetabins)
+    }
+
+    averaged = dirbins.average_direction_bins(dirbindataframes, overangle="theta")
+    with pytest.raises(ValueError, match="Cannot average over phi"):
+        dirbins.average_direction_bins(averaged, overangle="phi")
+
+
+def test_get_time_range_timesteps_without_clamping(tmp_path: Path) -> None:
+    """A timestep range gives no times in days, so the timestep bounds must be used even when not clamping."""
+    _write_timesteps_out(tmp_path)
+
+    for clamp in (True, False):
+        timestepmin, timestepmax, tlow, thigh = at.get_time_range(
+            tmp_path, timestep_range_str="1-3", clamp_to_timesteps=clamp
+        )
+        assert (timestepmin, timestepmax) == (1, 3)
+        assert tlow == pytest.approx(at.get_timestep_times(tmp_path, loc="start")[1])
+        assert thigh == pytest.approx(at.get_timestep_times(tmp_path, loc="end")[3])

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -231,21 +231,15 @@ def get_time_range(
         print(f"Warning timestepmax {timestepmax} > timesteplast {timesteplast}")
         timestepmax = timesteplast
 
+    # when the range was given as timesteps there is no requested time in days, so the timestep bounds are the only
+    # times available even if the caller asked not to clamp
     if time_days_lower is None:
-        if clamp_to_timesteps:
-            assert timestepmin is not None
-            time_days_lower = tstarts[timestepmin]
-        else:
-            assert timemin is not None
-            time_days_lower = float(timemin)
+        assert timestepmin is not None
+        time_days_lower = tstarts[timestepmin] if (clamp_to_timesteps or timemin is None) else float(timemin)
 
     if time_days_upper is None:
-        if clamp_to_timesteps:
-            assert timestepmax is not None
-            time_days_upper = tends[timestepmax]
-        else:
-            assert timemax is not None
-            time_days_upper = float(timemax)
+        assert timestepmax is not None
+        time_days_upper = tends[timestepmax] if (clamp_to_timesteps or timemax is None) else float(timemax)
 
     assert timestepmin is not None
     assert timestepmax is not None

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -777,15 +777,22 @@ def bin_and_sum(
     """Bins is a list of lower edges, and the final upper edge."""
     # Polars method
 
+    nbins = len(bins) - 1
     dfcut = (
         df
         .lazy()
         .filter(pl.col(bincol).is_between(bins[0], bins[-1], closed="both"))
         .with_columns(
-            (pl.col(bincol).cut(breaks=bins, labels=[str(x) for x in range(-1, len(bins))]))
-            .cast(pl.String)
-            .cast(pl.Int32)
-            .alias(f"{bincol}_bin")
+            # each bin is [lower, upper), except the last one, which also includes its upper edge. cut() would put a
+            # value sitting exactly on that final edge into the overflow bin, so clamp it back into the last bin
+            pl.min_horizontal(
+                pl
+                .col(bincol)
+                .cut(breaks=bins, labels=[str(x) for x in range(-1, len(bins))], left_closed=True)
+                .cast(pl.String)
+                .cast(pl.Int32),
+                nbins - 1,
+            ).alias(f"{bincol}_bin")
         )
     )
 
@@ -808,7 +815,7 @@ def bin_and_sum(
     # now we will include the empty bins
     return (
         pl
-        .LazyFrame({f"{bincol}_bin": range(len(bins) - 1)}, schema={f"{bincol}_bin": pl.Int32})
+        .LazyFrame({f"{bincol}_bin": range(nbins)}, schema={f"{bincol}_bin": pl.Int32})
         .join(wlbins, how="left", on=f"{bincol}_bin", coalesce=True)
         # fill nulls with 0 for sum columns
         .with_columns(pl.col(f"{sumcol}_sum").fill_null(0) for sumcol in sumcols)

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -168,3 +168,17 @@ def test_get_virtual_packets() -> None:
     assert rank_summary["mpirank"].to_list() == [0, 1]
     assert rank_summary["packet_count"].to_list() == [9402, 4381]
     assert rank_summary["energy_sum"].to_list() == pytest.approx([5.56564454996292e44, 1.8265647804307455e44])
+
+
+def test_bin_and_sum_includes_both_outer_edges() -> None:
+    """Every value between the first and last edge must land in a bin, including values on either outer edge."""
+    values = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
+    df = pl.DataFrame({"x": values, "e": [1.0] * len(values)})
+
+    binned = at.packets.bin_and_sum(df, bincol="x", bins=[0.0, 1.0, 2.0, 3.0], sumcols=["e"], getcounts=True).collect()
+
+    assert binned["x_bin"].to_list() == [0, 1, 2]
+    # bins are [lower, upper), except the last which also includes its upper edge
+    assert binned["count"].to_list() == [2, 2, 3]
+    assert binned["count"].sum() == len(values)
+    assert binned["e_sum"].to_list() == pytest.approx([2.0, 2.0, 3.0])

--- a/artistools/radfield.py
+++ b/artistools/radfield.py
@@ -157,11 +157,11 @@ def plot_line_estimators(
     """Plot the Jblue_lu values from the detailed line estimators on a spectrum."""
     ymax = -1
 
-    radfielddataselected = radfielddata.to_pandas(use_pyarrow_extension_array=True).query(
-        "bin_num < -1"
-        + (" & modelgridindex==@modelgridindex" if modelgridindex else "")
-        + (" & timestep==@timestep" if timestep else "")
-    )[["nu_upper", "J_nu_avg"]]
+    # the detailed line estimators have bin_num < -1. Cell zero and timestep zero are falsy, so these filters must
+    # test against None rather than truthiness
+    radfielddataselected = select_radfield_subset(
+        radfielddata, pl.col("bin_num") < -1, modelgridindex, timestep
+    ).to_pandas(use_pyarrow_extension_array=True)[["nu_upper", "J_nu_avg"]]
     if radfielddataselected.empty:
         print("No line estimators to plot")
         return 0.0

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -1,7 +1,6 @@
 """Artistools - spectra related functions."""
 
 import argparse
-import contextlib
 import math
 import re
 import typing as t
@@ -608,12 +607,11 @@ def read_spec(modelpath: Path | str, gamma: bool = False) -> pl.LazyFrame:
     )
 
 
-def read_spec_res(modelpath: Path | str) -> dict[int, pl.LazyFrame]:
+def read_spec_res(modelpath: Path | str, gamma: bool = False) -> dict[int, pl.LazyFrame]:
     """Return a dict of LazyFrames of time-series spectra keyed to the viewing direction bin."""
+    resfilenames = ["gamma_spec_res.out"] if gamma else ["spec_res.out", "specpol_res.out"]
     specfilename = (
-        modelpath
-        if Path(modelpath).is_file()
-        else firstexisting(["spec_res.out", "specpol_res.out"], folder=modelpath, tryzipped=True)
+        modelpath if Path(modelpath).is_file() else firstexisting(resfilenames, folder=modelpath, tryzipped=True)
     )
 
     print(f"Reading {specfilename} (in read_spec_res)")
@@ -684,10 +682,16 @@ def get_spectra(
     if timestepmax is None or timestepmax < 0:
         timestepmax = timestepmin
 
+    if average_over_phi and average_over_theta:
+        msg = "Cannot average over both phi and theta angles"
+        raise ValueError(msg)
+
     specdata_alltimesteps: dict[int, pl.LazyFrame] = {}
     if stokesparam == "I":
         with suppress(FileNotFoundError):
-            res_specdata = read_spec_res(modelpath)
+            # the direction-resolved file must match the packet type of the spherically averaged one below,
+            # otherwise the dirbins would silently hold UVOIR spectra while dirbin -1 holds gamma spectra
+            res_specdata = read_spec_res(modelpath, gamma=gamma)
             if average_over_theta:
                 res_specdata = average_direction_bins(res_specdata, overangle="theta")
             if average_over_phi:
@@ -1359,26 +1363,20 @@ def get_flux_contributions_from_packets(
         other_groupnames = allgroupnames[maxseriescount:]
         allgroupnames = [*allgroupnames[:maxseriescount], "Other"]
 
-        if getemission:
-            other_subgroups = [
-                emissiongroups[groupname] for groupname in other_groupnames if groupname in emissiongroups
-            ]
-            emissiongroups["Other"] = (
+        # a group name can be present for only one of emission and absorption (e.g. "Fe II bound-free" is never an
+        # absorption label), so each dict is combined independently and may get no contributions at all
+        for groups, getthis in ((emissiongroups, getemission), (absorptiongroups, getabsorption)):
+            if not getthis or not groups:
+                continue
+            other_subgroups = [groups[groupname] for groupname in other_groupnames if groupname in groups]
+            groups["Other"] = (
                 pl.concat(other_subgroups, rechunk=False)
                 if other_subgroups
-                else pl.DataFrame(schema=emissiongroups[next(iter(emissiongroups))].schema)
+                else pl.DataFrame(schema=next(iter(groups.values())).schema)
             )
 
-        if getabsorption:
-            absorptiongroups["Other"] = pl.concat(
-                (absorptiongroups[groupname] for groupname in other_groupnames if groupname in absorptiongroups),
-                rechunk=False,
-            )
-
-        for groupname in other_groupnames:
-            with contextlib.suppress(KeyError):
-                del emissiongroups[groupname]
-                del absorptiongroups[groupname]
+            for groupname in other_groupnames:
+                groups.pop(groupname, None)
 
     array_flambda_emission_total = None
     contribution_list = []

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -23,6 +23,7 @@ from artistools.atomic import get_ionstring
 from artistools.atomic import get_linelist_pldf
 from artistools.atomic import get_nuclides
 from artistools.misc import average_direction_bins
+from artistools.misc import check_averaging_angles
 from artistools.misc import df_filter_minmax_bounded
 from artistools.misc import firstexisting
 from artistools.misc import get_dirbins
@@ -682,9 +683,7 @@ def get_spectra(
     if timestepmax is None or timestepmax < 0:
         timestepmax = timestepmin
 
-    if average_over_phi and average_over_theta:
-        msg = "Cannot average over both phi and theta angles"
-        raise ValueError(msg)
+    check_averaging_angles(average_over_phi, average_over_theta)
 
     specdata_alltimesteps: dict[int, pl.LazyFrame] = {}
     if stokesparam == "I":

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -351,3 +351,36 @@ def test_get_emabs_timeblock_count() -> None:
     dfwrong = pl.DataFrame({"col": range(n_nu * n_timesteps * 2)})
     with pytest.raises(AssertionError, match="time blocks per frequency bin"):
         atspectra.get_emabs_timeblock_count(dfwrong, n_nu, n_timesteps, "emission.out")
+
+
+def test_get_spectra_gamma_does_not_mix_in_uvoir_dirbins() -> None:
+    """Gamma spectra must not pick up the UVOIR direction-resolved file.
+
+    test-classicmode_3d has spec_res.out but no gamma_spec_res.out, so a gamma request must return only the
+    spherically averaged bin rather than silently pairing gamma_spec.out with the UVOIR direction bins.
+    """
+    dirbin_spectra_uvoir = atspectra.get_spectra(modelpath=modelpath_classic_3d, timestepmin=10, timestepmax=10)
+    assert -1 in dirbin_spectra_uvoir
+    assert len(dirbin_spectra_uvoir) > 1, "expected direction-resolved UVOIR spectra in this test model"
+
+    dirbin_spectra_gamma = atspectra.get_spectra(
+        modelpath=modelpath_classic_3d, timestepmin=10, timestepmax=10, gamma=True
+    )
+    assert set(dirbin_spectra_gamma) == {-1}
+
+    # the gamma spectrum must actually differ from the UVOIR one, i.e. it came from gamma_spec.out
+    nu_gamma = dirbin_spectra_gamma[-1].select(pl.col("nu").max()).collect().item()
+    nu_uvoir = dirbin_spectra_uvoir[-1].select(pl.col("nu").max()).collect().item()
+    assert nu_gamma > nu_uvoir
+
+
+def test_get_spectra_rejects_averaging_over_both_angles() -> None:
+    """Averaging over phi and theta at once leaves too few bins, so it must be rejected up front."""
+    with pytest.raises(ValueError, match="both phi and theta"):
+        atspectra.get_spectra(
+            modelpath=modelpath_classic_3d,
+            timestepmin=10,
+            timestepmax=10,
+            average_over_phi=True,
+            average_over_theta=True,
+        )

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -376,7 +376,7 @@ def test_get_spectra_gamma_does_not_mix_in_uvoir_dirbins() -> None:
 
 def test_get_spectra_rejects_averaging_over_both_angles() -> None:
     """Averaging over phi and theta at once leaves too few bins, so it must be rejected up front."""
-    with pytest.raises(ValueError, match="both phi and theta"):
+    with pytest.raises(ValueError, match="both the phi and theta"):
         atspectra.get_spectra(
             modelpath=modelpath_classic_3d,
             timestepmin=10,

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -15,6 +15,7 @@ import matplotlib.axes as mplax
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
+import polars.testing as pltest
 import pytest
 
 import artistools as at
@@ -655,8 +656,44 @@ def test_linefluxes_emfeaturesearch_parsing() -> None:
     assert args.timebins_tstart == [200.0, 250.0]
     assert args.timebins_tend == [250.0, 300.0]
 
-    with pytest.raises(SystemExit):
-        parser.parse_args(["-emfeaturesearch", "not a tuple"])
+    # unset time bins stay None, so that each model falls back to its own timestep grid
+    args = parser.parse_args([])
+    assert args.timebins_tstart is None
+    assert args.timebins_tend is None
+
+    # the wavelengths may be fractional, but the atomic number, ion stage, and level indices must be integers
+    assert parser.parse_args(["-emfeaturesearch", "(26, 2, 12570.5, 12470.5, 12670.5)"]).emfeaturesearch == [
+        (26, 2, 12570.5, 12470.5, 12670.5)
+    ]
+
+    for badfeature in ("not a tuple", "(26.0, 2, 7155)", "(26, True, 7155)", "(26, 2, 7155, 7150, 7160, 1.5, 2)"):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["-emfeaturesearch", badfeature])
+
+
+def test_linefluxes_default_timebins_use_each_models_timesteps() -> None:
+    """With no explicit time bins, the packet binning must fall back to the model's own timestep grid."""
+    from artistools.linefluxes import get_closelines
+    from artistools.linefluxes import get_line_luminosities_from_packets
+
+    emfeatures = [get_closelines(modelpath_classic_3d, 26, 2, 7155, 7100, 7200)]
+
+    dflcdata_default = get_line_luminosities_from_packets("trueemissiontype", emfeatures, modelpath_classic_3d)
+    dflcdata_explicit = get_line_luminosities_from_packets(
+        "trueemissiontype",
+        emfeatures,
+        modelpath_classic_3d,
+        arr_tstart=at.get_timestep_times(modelpath_classic_3d, loc="start"),
+        arr_tend=at.get_timestep_times(modelpath_classic_3d, loc="end"),
+    )
+
+    pltest.assert_frame_equal(dflcdata_default, dflcdata_explicit)
+
+
+def test_linefluxes_rejects_lone_timebin_argument() -> None:
+    """Giving only one of the two time bin edge lists must be rejected before any data is read."""
+    with pytest.raises(ValueError, match="must be given together"):
+        at.linefluxes.main(argsraw=[], modelpath=[modelpath_classic_3d], timebins_tstart=[200.0, 250.0])
 
 
 def test_linefluxes_lineflux_ratio_plot() -> None:
@@ -691,3 +728,7 @@ def test_default_plotitem_keeps_estimator_columns_named_like_elements() -> None:
     # an element that the model does not contain is still dropped
     assert not default_plotitem_has_data([["averageionisation", ["Sr"]]], estimatorcolumns)
     assert not default_plotitem_has_data([["populations", ["Sr I", "Sr II"]]], estimatorcolumns)
+
+    # initabundances/initmasses come from the input model file, so they must not be gated on estimator columns
+    assert default_plotitem_has_data([["initabundances", ["Sr", "Ni_stable"]]], estimatorcolumns)
+    assert default_plotitem_has_data([["initmasses", ["Sr", "Ni_56"]]], estimatorcolumns)

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -12,13 +12,16 @@ from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
+import matplotlib.pyplot as plt
 import numpy as np
+import polars as pl
 import pytest
 
 import artistools as at
 
 modelpath = at.get_path("testdata") / "testmodel"
 modelpath_3d = at.get_path("testdata") / "testmodel_3d_10^3"
+modelpath_classic_3d = at.get_path("testdata") / "test-classicmode_3d"
 outputpath = at.get_path("testoutput")
 outputpath.mkdir(exist_ok=True, parents=True)
 
@@ -414,6 +417,21 @@ def test_get_ion_tuple() -> None:
     assert at.get_ion_tuple("26") == 26
 
 
+def test_get_ion_tuple_no_separator() -> None:
+    """Two-letter symbols must not be split on their first letter, e.g. 'FeII' is Fe II and not F + 'eII'."""
+    assert at.get_ion_tuple("FeII") == (26, 2)
+    assert at.get_ion_tuple("CoII") == (27, 2)
+    assert at.get_ion_tuple("NiIII") == (28, 3)
+    assert at.get_ion_tuple("HeII") == (2, 2)
+    # single-letter symbols still work, and are not shadowed by a longer symbol that starts the same way
+    assert at.get_ion_tuple("FII") == (9, 2)
+    assert at.get_ion_tuple("CIV") == (6, 4)
+    assert at.get_ion_tuple("OI") == (8, 1)
+
+    with pytest.raises(ValueError, match="Could not parse ionstr"):
+        at.get_ion_tuple("notanion")
+
+
 def test_parse_range_list() -> None:
     assert at.parse_range_list("5") == [5]
     assert at.parse_range_list("3-5") == [3, 4, 5]
@@ -535,3 +553,118 @@ def test_get_cellsofmpirank(tmp_path: Path) -> None:
     make_model(uneven_dir, npts=21, nprocs=4)
     assert list(at.get_cellsofmpirank(0, uneven_dir)) == list(range(6))
     assert list(at.get_cellsofmpirank(1, uneven_dir)) == list(range(6, 11))
+
+
+@mock.patch.object(mplax.Axes, "scatter", side_effect=mplax.Axes.scatter, autospec=True)
+def test_radfield_line_estimators_filter_cell_zero(mockscatter: t.Any) -> None:
+    """The line estimator plot must filter on cell and timestep zero, which are falsy."""
+    radfielddata = pl.DataFrame({
+        "bin_num": [-2, -3, -2, -3],
+        "modelgridindex": [0, 0, 1, 1],
+        "timestep": [0, 0, 0, 0],
+        "nu_upper": [1.0e15, 2.0e15, 3.0e15, 4.0e15],
+        "J_nu_avg": [1.0e-20, 2.0e-20, 3.0e-20, 4.0e-20],
+    })
+
+    fig, ax = plt.subplots()
+    at.radfield.plot_line_estimators(ax, radfielddata, modelgridindex=0, timestep=0)
+    plt.close(fig)
+
+    assert mockscatter.call_count == 1
+    lambdas = np.array(mockscatter.call_args_list[0][0][1], dtype=float)
+    # only the two rows of cell zero, not all four rows
+    assert len(lambdas) == 2
+    assert np.allclose(sorted(lambdas), sorted(at.constants.c_ang_per_s / np.array([1.0e15, 2.0e15])))
+
+
+def test_ejectaopacity() -> None:
+    """Binned expansion opacities need the level statistical weights, not only the transition wavelengths."""
+    at.ejectaopacity.main(
+        argsraw=[], modelpath=modelpath, timestep=40, lambdamin=3000.0, lambdamax=4000.0, deltalambda=10.0
+    )
+
+
+def test_kurucz_transitions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """gfall.dat is fixed-width, and the wavelength field is 11 characters wide, not 12.
+
+    Reading 12 characters takes the first character of the loggf field with it, which is only harmless while that
+    character happens to be a space.
+    """
+    line = (
+        f"{715.5170:11.4f}"  # 0-10  wavelength in nm
+        f"{-1.234:7.3f}"  # 11-17 log(gf)
+        f"{44.00:6.2f}"  # 18-23 element code Z.(ion_stage - 1)
+        f"{25000.000:12.3f}"  # 24-35 lower level energy in cm-1
+        f"{4.5:5.1f}"  # 36-40 lower level J
+        " a4F       "  # 41-51 configuration label
+        f"{35000.000:12.3f}"  # 52-63 upper level energy in cm-1
+        f"{3.5:5.1f}" + " " + " 0" * 16 + "\n"  # 64-68 upper level J
+        # the parser only reads lines with at least 24 whitespace-separated fields
+    )
+    (tmp_path / "gfall.dat").write_text(line, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    dftransitions, ionlist = at.transitions.get_kurucz_transitions()
+
+    assert ionlist == [at.transitions.IonTuple(44, 1)]
+    assert len(dftransitions) == 1
+    transition = dftransitions.iloc[0]
+    assert transition.lambda_angstroms == pytest.approx(7155.170)
+    assert transition.lower_statweight == pytest.approx(2 * 4.5 + 1)
+    assert transition.upper_statweight == pytest.approx(2 * 3.5 + 1)
+
+    hc_in_ev_cm = 0.0001239841984332003
+    assert transition.lower_energy_ev == pytest.approx(hc_in_ev_cm * 25000.0)
+    assert transition.upper_energy_ev == pytest.approx(hc_in_ev_cm * 35000.0)
+
+
+def test_merge_pdf_files_keeps_inputs_until_written(tmp_path: Path) -> None:
+    """The input files must survive until the merged file exists."""
+    pdfpaths = []
+    for i in range(2):
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [i, i])
+        pdfpath = tmp_path / f"page{i}.pdf"
+        fig.savefig(pdfpath, format="pdf")
+        plt.close(fig)
+        pdfpaths.append(str(pdfpath))
+
+    at.merge_pdf_files(pdfpaths)
+
+    merged = tmp_path / "page0-page1.pdf"
+    assert merged.is_file()
+    assert merged.stat().st_size > 0
+    assert not any(Path(p).exists() for p in pdfpaths)
+
+
+def test_linefluxes_emfeaturesearch_parsing() -> None:
+    """Emission features given on the command line must arrive as tuples of ints, not as raw strings."""
+    parser = argparse.ArgumentParser()
+    at.linefluxes.addargs(parser)
+
+    args = parser.parse_args(["-emfeaturesearch", "(26, 2, 7155, 7150, 7160)", "(28, 2, 7378, 7373, 7383)"])
+    assert args.emfeaturesearch == [(26, 2, 7155, 7150, 7160), (28, 2, 7378, 7373, 7383)]
+
+    # the default must already be usable for the two-feature flux ratio plot
+    assert len(parser.parse_args([]).emfeaturesearch) >= 2
+
+    # time bins are floats, not appended lists of strings
+    args = parser.parse_args(["-timebins_tstart", "200", "250", "-timebins_tend", "250", "300"])
+    assert args.timebins_tstart == [200.0, 250.0]
+    assert args.timebins_tend == [250.0, 300.0]
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["-emfeaturesearch", "not a tuple"])
+
+
+def test_linefluxes_lineflux_ratio_plot() -> None:
+    """The line flux ratio plot must run with no arguments beyond the model path."""
+    funcoutpath = outputpath / funcname()
+    funcoutpath.mkdir(exist_ok=True, parents=True)
+    at.linefluxes.main(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        emfeaturesearch=[(26, 2, 7155, 7100, 7200), (26, 2, 12570, 12400, 12700)],
+        outputfile=funcoutpath / "linefluxes.pdf",
+    )
+    assert (funcoutpath / "linefluxes.pdf").is_file()

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -670,3 +670,24 @@ def test_linefluxes_lineflux_ratio_plot() -> None:
         outputfile=funcoutpath / "linefluxes.pdf",
     )
     assert (funcoutpath / "linefluxes.pdf").is_file()
+
+
+def test_get_ion_tuple_rejects_missing_element() -> None:
+    """A string with a separator but no element symbol must raise rather than return atomic number -1."""
+    for badionstr in (" II", "_II", "notanion", "Fe "):
+        with pytest.raises(ValueError, match="Could not parse ionstr"):
+            at.get_ion_tuple(badionstr)
+
+
+def test_default_plotitem_keeps_estimator_columns_named_like_elements() -> None:
+    """Te and W are estimator names as well as element symbols, so a real column must win over the element reading."""
+    from artistools.estimators.plotestimators import default_plotitem_has_data
+
+    estimatorcolumns = ["timestep", "modelgridindex", "Te", "TR", "W", "nne", "rho", "nnelement_Fe"]
+
+    for plotitem in (["Te"], ["W"], ["TR"], ["rho"], ["nne"], [["averageionisation", ["Fe"]]]):
+        assert default_plotitem_has_data(plotitem, estimatorcolumns), plotitem
+
+    # an element that the model does not contain is still dropped
+    assert not default_plotitem_has_data([["averageionisation", ["Sr"]]], estimatorcolumns)
+    assert not default_plotitem_has_data([["populations", ["Sr I", "Sr II"]]], estimatorcolumns)

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -620,6 +620,8 @@ def test_kurucz_transitions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_merge_pdf_files_keeps_inputs_until_written(tmp_path: Path) -> None:
     """The input files must survive until the merged file exists."""
+    pytest.importorskip("pypdf", reason="pypdf is only installed with the extras group")
+
     pdfpaths = []
     for i in range(2):
         fig, ax = plt.subplots()

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -51,7 +51,8 @@ def get_kurucz_transitions() -> tuple[pd.DataFrame, list[IonTuple]]:
                 Z, ion_stage = int(row[2].split(".")[0]), int(row[2].split(".")[1]) + 1
                 if Z < 44 or ion_stage >= 2:  # and Z not in [26, 27]
                     continue
-                lambda_angstroms = float(line[:12]) * 10
+                # gfall.dat is fixed-width: wavelength in nm is F11.4 (columns 0-10) and loggf is F7.3 (columns 11-17)
+                lambda_angstroms = float(line[:11]) * 10
                 loggf = float(line[11:18])
                 lower_energy_ev, upper_energy_ev = hc_in_ev_cm * float(line[24:36]), hc_in_ev_cm * float(line[52:64])
                 lower_statweight, upper_statweight = 2 * float(line[36:42]) + 1, 2 * float(line[64:70]) + 1

--- a/rust/src/estimators.rs
+++ b/rust/src/estimators.rs
@@ -164,10 +164,13 @@ impl EstimatorColumns {
 
             let ionstageroman = ionstage_roman(ionstage)?;
             if let Some(varname_nonne) = variablename.strip_suffix("*nne") {
-                // also store the quantity divided by the electron density of this cell
+                // also store the quantity divided by the electron density of this cell. The column is only as long
+                // as the current row once this cell has set it, so a shorter column means nne belongs to an
+                // earlier cell and must not be used here
                 let nne = self
                     .coldata
                     .get("nne")
+                    .filter(|values| values.len() == self.rownum)
                     .and_then(|values| values.last())
                     .copied()
                     .ok_or_else(|| malformed("nne is not set for this cell".into()))?;


### PR DESCRIPTION
A full review of the package turned up a batch of defects, every one of them in code that no test exercised. `pytest artistools -n auto` was green before (164 passed) and is green after (185 passed, 21 new regression tests).

## Completely broken commands

| Command | Symptom |
| --- | --- |
| `artistools ejectaopacity` | `ColumnNotFoundError: unable to find column "upper_g"` |
| `artistools plotlinefluxes` | `IndexError: list index out of range`, or `TypeError: get_closelines() takes from 4 to 8 positional arguments but 26 were given` |

- **ejectaopacity** requested only `derived_transitions_columns=["lambda_angstroms"]`, but `add_transition_columns()` drops every derived column that is not named there — including the statistical weights that `B_lu = (g_u/g_l) B_ul` needs.
- **plotlinefluxes** parsed `-emfeaturesearch` as strings and then indexed them character by character, and `-timebins_tstart`/`-timebins_tend` combined `nargs="*"` with `action="append"` and defaulted to `[]`. Both now parse to the right types, default to something usable (the Fe II 7155/12570 pair and the model timesteps), and a mismatched number of time-bin edges is rejected.

## Silently wrong results

- **Direction-resolved gamma spectra were optical spectra.** `get_spectra(gamma=True)` filled dirbins ≥ 0 from `spec_res.out` while dirbin −1 came from `gamma_spec.out`. `read_spec_res()` now takes the `gamma` flag and looks for `gamma_spec_res.out`.
- **`get_ion_tuple` mis-parsed every two-letter symbol without a separator**, contradicting its own docstring: `FeII → (9, -1)`, `CoII → (6, -1)`, `HeII → (1, -1)`. It now tries the longest symbols first and only accepts a prefix whose remainder is a valid ion stage — the pattern `get_iontuple()` in `plotestimators.py` already used.
- **`plot_line_estimators` ignored its cell and timestep filters for index 0** (`if modelgridindex` is falsy for cell 0, the CLI default), so it scattered line estimators from every cell onto a single-cell plot. It now routes through `select_radfield_subset`, which already tested against `None`.
- **Zero-flux bands were plotted as magnitude 0** — an extremely bright source — via a `0.0` sentinel that also skipped the −25 absolute-magnitude offset. Those times are now skipped, and `get_colour_delta_mag` intersects the two bands' times rather than raising `KeyError` on their union.
- **The Rust estimator parser could divide a `*nne` quantity by another cell's electron density.** `coldata["nne"].last()` returns the previous cell's value whenever the current cell's header omits `nne`. It now requires the value to belong to the current row.
- **Zero and null disagreed across MPI ranks.** The file reader zero-fills a number density column that a cell skips, but `concat_df_diagonal` nulls a column a whole rank omitted. `nnion_`/`nniso_` now get the same fill as `nnelement_`; every other column still keeps its nulls so missing data is never read as a real zero.
- **`bin_and_sum` dropped values sitting exactly on the lowest bin edge** — `pl.cut` is left-open while the filter was `closed="both"`. Bins are now `[lower, upper)` with the last one closed on both sides.

## Crashes and data loss in edge cases

- Averaging over phi **and** theta raised `KeyError: 10` deep inside `average_direction_bins`. Rejected up front in `get_spectra()` and `parse_directionbin_args()`, and the helper now names the missing bins.
- `get_flux_contributions_from_packets` called `pl.concat` on a possibly-empty sequence for the absorption `"Other"` group (the emission branch guarded this, the absorption branch did not), and a `suppress(KeyError)` wrapping two deletes skipped the second one.
- `get_line_luminosities_from_pops` and `plot_levelpop` read `vel_r_min_kmps` without requesting it as a derived column, so `--frompops` and `levelpopulation_dn_on_dvel` both died with `AttributeError`.
- `scale_model_to_time` read and wrote `modelmeta["t_model_days"]` while everything else uses `t_model_init_days`.
- `get_time_range` asserted when given a timestep range with `clamp_to_timesteps=False`.
- `merge_pdf_files` deleted its inputs *before* writing the merged file.
- `decayproducts` wrote parquet files to a relative `parquet/` directory instead of under `-outputpath`.
- `make1dslicefrom3d` never wrote the final abundance block (it only warned), compared cell positions against the literal string `"0.0000000"` (which never matches the `0.0000e0` that `save_modeldata` writes), and passed matplotlib's `nonposy`, removed in 3.3.
- The Kurucz `gfall.dat` reader took 12 characters for the 11-character wavelength field, stealing the first character of `loggf`.
- `parse_phixsdata` built the multi-target array with shape `(n, 2)` and wrote the same tuple into both columns, inconsistent with the single-target branch.
- `plotestimators` with no `-plot` raised `ValueError: No element data found for Sr` on any model without Sr, because the built-in plot list names particular elements. Those default subplots are now skipped with a note; an explicit `-plot` still errors on a typo.

## Tests

21 new regression tests. Each fails on `main` and passes here:

- `test_get_ion_tuple_no_separator`, `test_kurucz_transitions`, `test_merge_pdf_files_keeps_inputs_until_written`, `test_ejectaopacity`, `test_linefluxes_emfeaturesearch_parsing`, `test_linefluxes_lineflux_ratio_plot`, `test_radfield_line_estimators_filter_cell_zero`
- `test_get_spectra_gamma_does_not_mix_in_uvoir_dirbins`, `test_get_spectra_rejects_averaging_over_both_angles`
- `test_estimparse_rejects_missing_nne`, `test_estimparse_divides_by_own_cell_nne`, `test_add_derived_estimator_columns_fills_ion_and_isotope_nulls`, `test_estimator_default_plotlist_skips_absent_elements`, `test_estimator_levelpopulation_dn_on_dvel`
- `test_bin_and_sum_includes_both_outer_edges`, `test_average_direction_bins_rejects_missing_bins`, `test_get_time_range_timesteps_without_clamping`
- `test_get_colour_delta_mag_unequal_sampling`, `test_scale_model_to_time_uses_modelmeta`, `test_slice_abundance_file_writes_last_block`, `test_decayproducts_parquet_output`

`linefluxes --frompops` is fixed but not covered: it needs a 1D model with both `linestat.out` and NLTE populations, and no test dataset has both.

## Checks

`ruff format`, `ruff check --no-fix`, `mypy`, `basedpyright --warnings`, `pyrefly check`, `ty check`, `prek run --all-files`, `cargo clippy --all-features -- -D warnings -D clippy::pedantic`, and `pytest artistools -n auto` all pass.

## Deliberately not changed

`scale_model_to_time` also shifts the `logrho == -99` empty-cell sentinel when it rescales densities, so a cell that was empty can come back as `-99 + log10(f^-3)`. It was not part of the reviewed findings, and the sentinel still survives a round-trip through `save_modeldata`/`get_modeldata` because both treat anything below −98 as empty. Worth a separate fix.

Physics that was checked and found **correct**, for the record: the kinetic-energy integrals in all three geometries, homologous ρ ∝ t⁻³ scaling, Sobolev optical depth and expansion opacity, Planck-mean weighting, the Einstein-coefficient relations, the Kurucz A ← gf conversion, Y_e from isotopic composition, LTE populations and partition functions, direction-bin solid-angle factors, virtual- vs real-packet flux normalisation, the escape-surface γ correction, and the AB-magnitude round trip through CCM89 dereddening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
