### PR TITLE
Remove scipy as a direct dependency

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -156,7 +156,7 @@ jobs:
               run: uv sync --compile-bytecode
 
             - name: Test with pytest
-              run: uv run --no-sync -- python -m pytest --cov --cov-report=xml
+              run: uv run --no-sync -- python -m pytest --cov=./ --cov-report=xml
 
             - name: Report coverage
               run: uv run -- python -m coverage report

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -156,7 +156,7 @@ jobs:
               run: uv sync --compile-bytecode
 
             - name: Test with pytest
-              run: uv run --no-sync -- python -m pytest --cov= --cov-report=xml
+              run: uv run --no-sync -- python -m pytest --cov --cov-report=xml
 
             - name: Report coverage
               run: uv run -- python -m coverage report

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -156,7 +156,7 @@ jobs:
               run: uv sync --compile-bytecode
 
             - name: Test with pytest
-              run: uv run --no-sync -- python -m pytest --cov=./ --cov-report=xml
+              run: uv run --no-sync -- python -m pytest --cov= --cov-report=xml
 
             - name: Report coverage
               run: uv run -- python -m coverage report

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -95,6 +95,7 @@ from artistools.misc import check_averaging_angles as check_averaging_angles
 from artistools.misc import firstexisting as firstexisting
 from artistools.misc import firstexisting_or_none as firstexisting_or_none
 from artistools.misc import flatten_list as flatten_list
+from artistools.misc import gaussian_filter_wrap as gaussian_filter_wrap
 from artistools.misc import get_cellsofmpirank as get_cellsofmpirank
 from artistools.misc import get_costheta_bins as get_costheta_bins
 from artistools.misc import get_costhetabin_phibin_labels as get_costhetabin_phibin_labels
@@ -137,6 +138,7 @@ from artistools.misc import print_theta_phi_definitions as print_theta_phi_defin
 from artistools.misc import read_rank_outputfiles as read_rank_outputfiles
 from artistools.misc import readnoncommentline as readnoncommentline
 from artistools.misc import resolve_outputfile as resolve_outputfile
+from artistools.misc import savgol_filter as savgol_filter
 from artistools.misc import set_args_from_dict as set_args_from_dict
 from artistools.misc import split_multitable_dataframe as split_multitable_dataframe
 from artistools.misc import stripallsuffixes as stripallsuffixes

--- a/artistools/inputmodel/energyinputfiles.py
+++ b/artistools/inputmodel/energyinputfiles.py
@@ -23,30 +23,38 @@ def _cumulative_trapezoid(y: npt.ArrayLike, x: npt.ArrayLike) -> npt.NDArray[np.
     return np.concatenate(([0.0], np.cumsum(np.diff(xarr) * (yarr[:-1] + yarr[1:]) / 2.0)))
 
 
-def _quad_adaptive(func: Callable[[float], float], a: float, b: float, *, rtol: float = 1.5e-8) -> float:
+def _quad_adaptive(
+    func: Callable[[float], float], a: float, b: float, *, rtol: float = 1.5e-8, maxdepth: int = 20
+) -> float:
     """Integrate a smooth function over [a, b] with adaptive Simpson quadrature.
 
     rtol must stay above the rounding noise of the integrand (e.g. cancellation in
-    1/2 - arctan(x)/pi at large x leaves ~1e-9 relative noise), or the recursion never converges.
+    1/2 - arctan(x)/pi at large x leaves ~1e-9 relative noise). Below that noise floor no
+    subdivision can meet the tolerance, so the recursion raises rather than subdividing until
+    maxdepth is exhausted, which would cost up to 2**maxdepth evaluations and silently return
+    an unconverged result.
     """
 
     def simpson(x0: float, x2: float, f0: float, f1: float, f2: float) -> float:
         return (x2 - x0) / 6.0 * (f0 + 4.0 * f1 + f2)
 
-    def recurse(x0: float, x2: float, f0: float, f1: float, f2: float, whole: float, depth: int) -> float:
+    def recurse(x0: float, x2: float, f0: float, f1: float, f2: float, depth: int) -> float:
         x1 = 0.5 * (x0 + x2)
         fleft = func(0.5 * (x0 + x1))
         fright = func(0.5 * (x1 + x2))
+        whole = simpson(x0, x2, f0, f1, f2)
         left = simpson(x0, x1, f0, fleft, f1)
         right = simpson(x1, x2, f1, fright, f2)
-        if depth <= 0 or abs(left + right - whole) <= rtol * (abs(left) + abs(right)):
+        if abs(left + right - whole) <= rtol * (abs(left) + abs(right)):
             # Richardson extrapolation of the two half-interval estimates
             return left + right + (left + right - whole) / 15.0
-        return recurse(x0, x1, f0, fleft, f1, left, depth - 1) + recurse(x1, x2, f1, fright, f2, right, depth - 1)
+        if depth <= 0:
+            msg = f"adaptive quadrature did not reach rtol={rtol:g} on [{x0:g}, {x2:g}] within {maxdepth} levels"
+            raise RuntimeError(msg)
+        return recurse(x0, x1, f0, fleft, f1, depth - 1) + recurse(x1, x2, f1, fright, f2, depth - 1)
 
     x1 = 0.5 * (a + b)
-    fa, f1, fb = func(a), func(x1), func(b)
-    return recurse(a, b, fa, f1, fb, simpson(a, b, fa, f1, fb), 30)
+    return recurse(a, b, func(a), func(x1), func(b), maxdepth)
 
 
 def get_cumulative_heating_fraction() -> tuple[pl.DataFrame, float]:

--- a/artistools/inputmodel/energyinputfiles.py
+++ b/artistools/inputmodel/energyinputfiles.py
@@ -1,5 +1,7 @@
 import argparse
+import itertools
 import typing as t
+from collections.abc import Callable
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -14,6 +16,39 @@ import artistools as at
 from artistools.constants import day_to_s
 
 
+def _cumulative_trapezoid(y: npt.ArrayLike, x: npt.ArrayLike) -> npt.NDArray[np.float64]:
+    """Cumulatively integrate y over x with the trapezoidal rule, starting from zero."""
+    yarr = np.asarray(y, dtype=np.float64)
+    xarr = np.asarray(x, dtype=np.float64)
+    return np.concatenate(([0.0], np.cumsum(np.diff(xarr) * (yarr[:-1] + yarr[1:]) / 2.0)))
+
+
+def _quad_adaptive(func: Callable[[float], float], a: float, b: float, *, rtol: float = 1.5e-8) -> float:
+    """Integrate a smooth function over [a, b] with adaptive Simpson quadrature.
+
+    rtol must stay above the rounding noise of the integrand (e.g. cancellation in
+    1/2 - arctan(x)/pi at large x leaves ~1e-9 relative noise), or the recursion never converges.
+    """
+
+    def simpson(x0: float, x2: float, f0: float, f1: float, f2: float) -> float:
+        return (x2 - x0) / 6.0 * (f0 + 4.0 * f1 + f2)
+
+    def recurse(x0: float, x2: float, f0: float, f1: float, f2: float, whole: float, depth: int) -> float:
+        x1 = 0.5 * (x0 + x2)
+        fleft = func(0.5 * (x0 + x1))
+        fright = func(0.5 * (x1 + x2))
+        left = simpson(x0, x1, f0, fleft, f1)
+        right = simpson(x1, x2, f1, fright, f2)
+        if depth <= 0 or abs(left + right - whole) <= rtol * (abs(left) + abs(right)):
+            # Richardson extrapolation of the two half-interval estimates
+            return left + right + (left + right - whole) / 15.0
+        return recurse(x0, x1, f0, fleft, f1, left, depth - 1) + recurse(x1, x2, f1, fright, f2, right, depth - 1)
+
+    x1 = 0.5 * (a + b)
+    fa, f1, fb = func(a), func(x1), func(b)
+    return recurse(a, b, fa, f1, fb, simpson(a, b, fa, f1, fb), 30)
+
+
 def get_cumulative_heating_fraction() -> tuple[pl.DataFrame, float]:
 
     tmin = 0.0001  # days
@@ -22,16 +57,11 @@ def get_cumulative_heating_fraction() -> tuple[pl.DataFrame, float]:
     times = np.logspace(np.log10(tmin), np.log10(tmax), num=300)  # days
     qdot = 5e9 * (times) ** (-1.3)  # define energy power law (5e9*t^-1.3)
 
-    E_tot = np.trapezoid(y=qdot, x=times)
-    assert isinstance(E_tot, float)
+    cumulative_energy = _cumulative_trapezoid(y=qdot, x=times)
+    E_tot = float(cumulative_energy[-1])
     # print("Etot per gram", E_tot, E_tot*1.989e33*0.01)
 
-    from scipy import integrate
-
-    cumulative_integrated_energy = integrate.cumulative_trapezoid(y=qdot, x=times)
-    cumulative_integrated_energy = np.insert(cumulative_integrated_energy, 0, 0)
-
-    rate = cumulative_integrated_energy / E_tot
+    rate = cumulative_energy / E_tot
 
     times_and_rate = {"times": times, "rate": rate}
     dftimes_and_rate = pl.DataFrame(data=times_and_rate)
@@ -99,16 +129,6 @@ def make_energy_files(rho: npt.NDArray[np.floating], Mtot_grams: float, outputpa
 
 def rprocess_const_and_powerlaw() -> tuple[pl.DataFrame, float]:
     """Following eqn 4 Korobkin 2012."""
-
-    def integrand(
-        t_days: float, t0: float, epsilon0: float, sigma: float, alpha: float, thermalisation_factor: float
-    ) -> float:
-        return float(epsilon0 * ((1 / 2) - (1 / np.pi * np.arctan((t_days - t0) / sigma))) ** alpha) * (
-            thermalisation_factor / 0.5
-        )
-
-    from scipy.integrate import quad
-
     tmin = 0.01 * day_to_s
     tmax = 50 * day_to_s
     t0 = 1.3  # seconds
@@ -117,21 +137,22 @@ def rprocess_const_and_powerlaw() -> tuple[pl.DataFrame, float]:
     alpha = 1.3
     thermalisation_factor = 0.5
 
-    E_tot = quad(integrand, tmin, tmax, args=(t0, epsilon0, sigma, alpha, thermalisation_factor))  # ergs/s/g
-    print("Etot per gram", E_tot[0])
-    E_tot = E_tot[0]
+    def integrand(t_sec: float) -> float:
+        return float(epsilon0 * ((1 / 2) - (1 / np.pi * np.arctan((t_sec - t0) / sigma))) ** alpha) * (
+            thermalisation_factor / 0.5
+        )
 
     times = np.logspace(np.log10(tmin), np.log10(tmax), num=200)
     energy_per_gram_cumulative = [0.0]
-    for time in times[1:]:
-        cumulative_integral = quad(
-            integrand, tmin, time, args=(t0, epsilon0, sigma, alpha, thermalisation_factor)
-        )  # ergs/s/g
-        energy_per_gram_cumulative.append(cumulative_integral[0])
+    for tlow, thigh in itertools.pairwise(times):
+        energy_per_gram_cumulative.append(energy_per_gram_cumulative[-1] + _quad_adaptive(integrand, tlow, thigh))
+
+    E_tot = energy_per_gram_cumulative[-1]  # ergs/g
+    print("Etot per gram", E_tot)
 
     rate = np.array(energy_per_gram_cumulative) / E_tot
 
-    nuclear_heating_power = [integrand(time, t0, epsilon0, sigma, alpha, thermalisation_factor) for time in times]
+    nuclear_heating_power = [integrand(time) for time in times]
 
     times_and_rate = {"times": times / day_to_s, "rate": rate, "nuclear_heating_power": nuclear_heating_power}
     dftimes_and_rate = pl.DataFrame(data=times_and_rate)
@@ -150,16 +171,12 @@ def energy_from_rprocess_calculation(
     times = energy_thermo_data["time/s"][skipfirstnrows:]
     qdot = energy_thermo_data["Qdot"][skipfirstnrows:]
 
-    E_tot = float(np.trapezoid(y=qdot, x=times))  # erg / g
+    cumulative_energy = _cumulative_trapezoid(y=qdot, x=times)
+    E_tot = float(cumulative_energy[-1])  # erg / g
 
     if get_rate:
         print(f"E_tot {E_tot} erg/g")
-        from scipy import integrate
-
-        cumulative_integrated_energy = integrate.cumulative_trapezoid(y=qdot, x=times)
-        cumulative_integrated_energy = np.insert(cumulative_integrated_energy, 0, 0)
-
-        rate = cumulative_integrated_energy / E_tot
+        rate = cumulative_energy / E_tot
 
         dftimes_and_rate = pl.DataFrame({"times": times / day_to_s, "rate": rate})
 

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1810,6 +1810,13 @@ def test_energyfiles_written_then_described(tmp_path: Path, capsys: pytest.Captu
     assert "energydistribution.txt" in capsys.readouterr().out
 
 
+def test_rprocess_const_and_powerlaw() -> None:
+    """The adaptive quadrature must match the scipy.integrate.quad total it replaced for the Korobkin 2012 rate."""
+    times_and_rate, e_tot = at.inputmodel.energyinputfiles.rprocess_const_and_powerlaw()
+    assert np.isclose(e_tot, 1.0364888092e16, rtol=1e-6)
+    assert times_and_rate["rate"].is_sorted(), "the cumulative energy fraction must be non-decreasing"
+
+
 def test_energyfiles_from_trajectory() -> None:
     """Integrating a trajectory's heating rate must give a positive total energy."""
     thermofile = at.inputmodel.rprocess_from_trajectory.get_tar_member_extracted_path(

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1811,10 +1811,18 @@ def test_energyfiles_written_then_described(tmp_path: Path, capsys: pytest.Captu
 
 
 def test_rprocess_const_and_powerlaw() -> None:
-    """The adaptive quadrature must match the scipy.integrate.quad total it replaced for the Korobkin 2012 rate."""
+    """The adaptive quadrature must match the scipy.integrate.quad values it replaced for the Korobkin 2012 rate."""
     times_and_rate, e_tot = at.inputmodel.energyinputfiles.rprocess_const_and_powerlaw()
     assert np.isclose(e_tot, 1.0364888092e16, rtol=1e-6)
-    assert times_and_rate["rate"].is_sorted(), "the cumulative energy fraction must be non-decreasing"
+
+    # interior points of the cumulative curve, not just the total: accumulating per-interval could
+    # get the endpoint right while distorting the shape in between
+    rate = times_and_rate["rate"].to_numpy()
+    assert np.isclose(times_and_rate["times"][100], 0.7224019284438787, rtol=1e-9)
+    assert np.isclose(rate[50], 0.5138699342846266, rtol=1e-6)
+    assert np.isclose(rate[100], 0.7840751031432063, rtol=1e-6)
+    assert np.isclose(rate[150], 0.9262544511559376, rtol=1e-6)
+    assert rate[-1] == pytest.approx(1.0)
 
 
 def test_energyfiles_from_trajectory() -> None:

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -205,8 +205,6 @@ def generate_band_lightcurve_data(
     **kwargs: t.Any,
 ) -> dict[str, t.Any]:
     """Integrate spectra to get band magnitude vs time. Method adapted from https://github.com/cinserra/S3/blob/master/src/s3/SMS.py."""
-    from scipy.interpolate import interp1d
-
     args = args_from_kwargs(
         args,
         kwargs,
@@ -298,14 +296,17 @@ def generate_band_lightcurve_data(
                     average_over_theta=args.average_over_theta_angle,
                 )
 
-                # interpolate the coarser-sampled series onto the finer wavelength grid before multiplying
+                # interpolate the coarser-sampled series onto the finer wavelength grid before multiplying,
+                # with zero contribution outside the sampled range
                 if len(wavelength_from_spectrum) > len(wavefilter):
-                    interpolate_fn = interp1d(x=wavefilter, y=transmission, bounds_error=False, fill_value=0.0)
-                    integrand = flux * interpolate_fn(wavelength_from_spectrum)
+                    integrand = flux * np.interp(
+                        wavelength_from_spectrum, wavefilter, transmission, left=0.0, right=0.0
+                    )
                     integration_grid = wavelength_from_spectrum
                 else:
-                    interpolate_fn = interp1d(wavelength_from_spectrum, flux, bounds_error=False, fill_value=0.0)
-                    integrand = interpolate_fn(wavefilter) * transmission
+                    integrand = (
+                        np.interp(wavefilter, wavelength_from_spectrum, flux, left=0.0, right=0.0) * transmission
+                    )
                     integration_grid = wavefilter
 
                 weighted_flux_obs = float(abs(np.trapezoid(integrand, integration_grid)))
@@ -379,10 +380,15 @@ def get_filter_data(
         wavefilter.append(float(row.split()[0]))
         transmission.append(float(row.split()[1]))
 
-    wavefilter_min = min(wavefilter)
-    wavefilter_max = max(wavefilter)
+    # some filter files (e.g. data/filters/NOT) are not in ascending wavelength order, but callers
+    # interpolate and integrate over the wavelength grid, so sort here
+    arr_wavefilter = np.array(wavefilter)
+    arr_transmission = np.array(transmission)
+    sortidx = np.argsort(arr_wavefilter)
+    arr_wavefilter = arr_wavefilter[sortidx]
+    arr_transmission = arr_transmission[sortidx]
 
-    return zeropointenergyflux, np.array(wavefilter), np.array(transmission), wavefilter_min, wavefilter_max
+    return zeropointenergyflux, arr_wavefilter, arr_transmission, float(arr_wavefilter[0]), float(arr_wavefilter[-1])
 
 
 def get_spectrum_in_filter_range(

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -380,13 +380,11 @@ def get_filter_data(
         wavefilter.append(float(row.split()[0]))
         transmission.append(float(row.split()[1]))
 
-    # some filter files (e.g. data/filters/NOT) are not in ascending wavelength order, but callers
-    # interpolate and integrate over the wavelength grid, so sort here
-    arr_wavefilter = np.array(wavefilter)
-    arr_transmission = np.array(transmission)
-    sortidx = np.argsort(arr_wavefilter)
-    arr_wavefilter = arr_wavefilter[sortidx]
-    arr_transmission = arr_transmission[sortidx]
+    # the files under data/filters/NOT are not in ascending wavelength order, and callers both
+    # interpolate on this grid and integrate over it with np.trapezoid, so sort it here
+    sortidx = np.argsort(wavefilter)
+    arr_wavefilter = np.array(wavefilter)[sortidx]
+    arr_transmission = np.array(transmission)[sortidx]
 
     return zeropointenergyflux, arr_wavefilter, arr_transmission, float(arr_wavefilter[0]), float(arr_wavefilter[-1])
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -66,6 +66,31 @@ def test_band_lightcurve_plot() -> None:
     at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["B"], outputfile=outputpath)
 
 
+def test_filter_data_is_sorted_by_wavelength() -> None:
+    """Filter curves must come back in ascending wavelength order with transmissions still paired.
+
+    The files under data/filters/NOT are stored out of order. Callers interpolate on this grid and
+    integrate over it with np.trapezoid, which silently cancels flux across negative-width segments,
+    so the sort must happen here rather than at each use.
+    """
+    filterdir = Path(at.get_path("artistools_dir"), "data/filters/")
+
+    rawlines = (filterdir / "NOT" / "B.txt").read_text(encoding="utf-8").splitlines()[4:]
+    rawpairs = {float(row.split()[0]): float(row.split()[1]) for row in rawlines if row.split()}
+    assert sorted(rawpairs) != list(rawpairs), "this fixture is only meaningful while the file is unsorted"
+
+    _, wavefilter, transmission, wavefilter_min, wavefilter_max = at.lightcurve.get_filter_data(filterdir, "NOT/B")
+
+    assert np.all(np.diff(wavefilter) > 0), "wavelengths must be strictly ascending after sorting"
+    assert wavefilter_min == wavefilter[0]
+    assert wavefilter_max == wavefilter[-1]
+
+    # the sort must move transmissions with their wavelengths, not just reorder one of the two
+    assert len(wavefilter) == len(rawpairs)
+    for wavelength, transmit in zip(wavefilter, transmission, strict=True):
+        assert transmit == rawpairs[wavelength]
+
+
 def test_band_magnitude_calculations() -> None:
     band_magnitude_data = at.lightcurve.generate_band_lightcurve_data(
         modelpath,

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -258,6 +258,10 @@ def lightcurve_polyfit(
     try:
         import george
 
+        # scipy is not a direct dependency of artistools, but george depends on it. Import it here
+        # so a george install without scipy also falls back to the polynomial fit.
+        import scipy.optimize as op
+
     except ModuleNotFoundError:
         print(
             "Could not find 'george' module, falling back to polynomial fit. WARNING: polynomial fit method is sensitive to the degrees of freedom used in the polynomial fit. "
@@ -271,9 +275,6 @@ def lightcurve_polyfit(
         fxfit = np.poly1d(zfit)
         pred = fxfit(xfit)
     else:
-        # scipy is not a direct dependency of artistools, but george depends on it, so it is
-        # always importable when this branch is reached
-        import scipy.optimize as op
         from george import kernels
 
         kernel = np.var(magnitude) * kernels.Matern32Kernel(kernel_scale)

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -271,6 +271,8 @@ def lightcurve_polyfit(
         fxfit = np.poly1d(zfit)
         pred = fxfit(xfit)
     else:
+        # scipy is not a direct dependency of artistools, but george depends on it, so it is
+        # always importable when this branch is reached
         import scipy.optimize as op
         from george import kernels
 

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -48,7 +48,9 @@ from artistools.misc.fileio import write_parquet_atomic as write_parquet_atomic
 from artistools.misc.fileio import zopen as zopen
 from artistools.misc.fileio import zopenpl as zopenpl
 from artistools.misc.general import df_filter_minmax_bounded as df_filter_minmax_bounded
+from artistools.misc.general import gaussian_filter_wrap as gaussian_filter_wrap
 from artistools.misc.general import parallel_map as parallel_map
+from artistools.misc.general import savgol_filter as savgol_filter
 from artistools.misc.general import vec_len as vec_len
 from artistools.misc.modelinfo import get_cellsofmpirank as get_cellsofmpirank
 from artistools.misc.modelinfo import get_dfrankassignments as get_dfrankassignments

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -382,12 +382,12 @@ def get_filterfunc(args: argparse.Namespace) -> Callable[[t.Any], t.Any] | None:
         filterfunc = movavgfilterfunc
 
     if dictargs.get("filtersavgol", False):
-        import scipy.signal
+        from artistools.misc.general import savgol_filter
 
         window_length, polyorder = (int(x) for x in args.filtersavgol)
 
         def savgolfilterfunc(ylist: t.Any) -> t.Any:
-            return scipy.signal.savgol_filter(ylist, window_length=window_length, polyorder=polyorder, mode="interp")
+            return savgol_filter(ylist, window_length=window_length, polyorder=polyorder)
 
         assert filterfunc is None
         filterfunc = savgolfilterfunc

--- a/artistools/misc/general.py
+++ b/artistools/misc/general.py
@@ -50,11 +50,16 @@ def _savgol_coeffs(window_length: int, polyorder: int) -> npt.NDArray[np.float64
 
 
 def savgol_filter(ylist: npt.ArrayLike, window_length: int, polyorder: int) -> npt.NDArray[np.float64]:
-    """Apply Savitzky-Golay smoothing, fitting polynomials to the edge windows.
+    """Apply Savitzky-Golay smoothing to a 1D array, fitting polynomials to the edge windows.
 
-    Matches scipy.signal.savgol_filter with mode="interp".
+    Matches scipy.signal.savgol_filter with mode="interp" for an odd window_length. Unlike scipy,
+    only odd windows and 1D input are accepted: an even window is centred half a sample off, which
+    phase-shifts the output, and every caller here smooths a single series.
     """
     y = np.asarray(ylist, dtype=np.float64)
+    if y.ndim != 1:
+        msg = f"savgol_filter needs a 1D array, got {y.ndim} dimensions"
+        raise ValueError(msg)
     if window_length % 2 == 0 or window_length < 3:
         msg = f"window_length {window_length} must be an odd number of at least 3"
         raise ValueError(msg)
@@ -79,9 +84,17 @@ def savgol_filter(ylist: npt.ArrayLike, window_length: int, polyorder: int) -> n
 def gaussian_filter_wrap(data: npt.NDArray[np.floating], sigma: float) -> npt.NDArray[np.float64]:
     """Smooth a 2D array with a Gaussian kernel, wrapping at the array boundaries.
 
-    Matches scipy.ndimage.gaussian_filter with mode="wrap" and the default truncation
-    of four standard deviations.
+    Matches scipy.ndimage.gaussian_filter with mode="wrap" and the default truncation of four
+    standard deviations, but only for a 2D array and a scalar sigma greater than zero.
     """
+    out = np.asarray(data, dtype=np.float64)
+    if out.ndim != 2:
+        msg = f"gaussian_filter_wrap needs a 2D array, got {out.ndim} dimensions"
+        raise ValueError(msg)
+    if sigma <= 0.0:
+        msg = f"sigma {sigma} must be greater than zero"
+        raise ValueError(msg)
+
     radius = int(4.0 * sigma + 0.5)
     xkernel = np.arange(-radius, radius + 1, dtype=np.float64)
     kernel = np.exp(-0.5 * (xkernel / sigma) ** 2)
@@ -90,7 +103,6 @@ def gaussian_filter_wrap(data: npt.NDArray[np.floating], sigma: float) -> npt.ND
     def convolve_valid(arr: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
         return np.asarray(np.convolve(arr, kernel, mode="valid"), dtype=np.float64)
 
-    out = np.asarray(data, dtype=np.float64)
     for axis in (0, 1):
         padwidth = [(0, 0), (0, 0)]
         padwidth[axis] = (radius, radius)

--- a/artistools/misc/general.py
+++ b/artistools/misc/general.py
@@ -63,8 +63,8 @@ def savgol_filter(ylist: npt.ArrayLike, window_length: int, polyorder: int) -> n
     if window_length % 2 == 0 or window_length < 3:
         msg = f"window_length {window_length} must be an odd number of at least 3"
         raise ValueError(msg)
-    if polyorder >= window_length:
-        msg = f"polyorder {polyorder} must be less than window_length {window_length}"
+    if not 0 <= polyorder < window_length:
+        msg = f"polyorder {polyorder} must be at least zero and less than window_length {window_length}"
         raise ValueError(msg)
     if y.size < window_length:
         msg = f"window_length {window_length} exceeds the data length {y.size}"

--- a/artistools/misc/general.py
+++ b/artistools/misc/general.py
@@ -1,6 +1,7 @@
 """Small generic utilities."""
 
 import contextlib
+import functools
 import sys
 import typing as t
 from collections.abc import Callable
@@ -37,6 +38,64 @@ def df_filter_minmax_bounded(
 
 def vec_len(vec: Sequence[float] | npt.NDArray[np.floating]) -> float:
     return float(np.sqrt(np.dot(vec, vec)))
+
+
+@functools.lru_cache
+def _savgol_coeffs(window_length: int, polyorder: int) -> npt.NDArray[np.float64]:
+    """Return the Savitzky-Golay smoothing coefficients for a centred window."""
+    halflen = window_length // 2
+    xwindow = np.arange(-halflen, halflen + 1, dtype=np.float64)
+    # the first pseudoinverse row evaluates the least-squares fitted polynomial at the window centre
+    return np.asarray(np.linalg.pinv(np.vander(xwindow, polyorder + 1, increasing=True))[0], dtype=np.float64)
+
+
+def savgol_filter(ylist: npt.ArrayLike, window_length: int, polyorder: int) -> npt.NDArray[np.float64]:
+    """Apply Savitzky-Golay smoothing, fitting polynomials to the edge windows.
+
+    Matches scipy.signal.savgol_filter with mode="interp".
+    """
+    y = np.asarray(ylist, dtype=np.float64)
+    if window_length % 2 == 0 or window_length < 3:
+        msg = f"window_length {window_length} must be an odd number of at least 3"
+        raise ValueError(msg)
+    if polyorder >= window_length:
+        msg = f"polyorder {polyorder} must be less than window_length {window_length}"
+        raise ValueError(msg)
+    if y.size < window_length:
+        msg = f"window_length {window_length} exceeds the data length {y.size}"
+        raise ValueError(msg)
+
+    halflen = window_length // 2
+    filtered = np.correlate(y, _savgol_coeffs(window_length, polyorder), mode="same")
+
+    # the outermost points have incomplete windows, so evaluate polynomial fits to the first and last full windows
+    xedge = np.arange(window_length, dtype=np.float64)
+    filtered[:halflen] = np.polynomial.Polynomial.fit(xedge, y[:window_length], polyorder)(xedge[:halflen])
+    filtered[-halflen:] = np.polynomial.Polynomial.fit(xedge, y[-window_length:], polyorder)(xedge[-halflen:])
+
+    return filtered
+
+
+def gaussian_filter_wrap(data: npt.NDArray[np.floating], sigma: float) -> npt.NDArray[np.float64]:
+    """Smooth a 2D array with a Gaussian kernel, wrapping at the array boundaries.
+
+    Matches scipy.ndimage.gaussian_filter with mode="wrap" and the default truncation
+    of four standard deviations.
+    """
+    radius = int(4.0 * sigma + 0.5)
+    xkernel = np.arange(-radius, radius + 1, dtype=np.float64)
+    kernel = np.exp(-0.5 * (xkernel / sigma) ** 2)
+    kernel /= kernel.sum()
+
+    def convolve_valid(arr: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        return np.asarray(np.convolve(arr, kernel, mode="valid"), dtype=np.float64)
+
+    out = np.asarray(data, dtype=np.float64)
+    for axis in (0, 1):
+        padwidth = [(0, 0), (0, 0)]
+        padwidth[axis] = (radius, radius)
+        out = np.apply_along_axis(convolve_valid, axis, np.pad(out, padwidth, mode="wrap"))
+    return out
 
 
 def parallel_map[IterableType, ResultType](

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -382,10 +382,14 @@ def test_get_filterfunc() -> None:
     # invalid parameters are rejected
     with pytest.raises(ValueError, match="must be an odd number"):
         at.savgol_filter(yvalues, window_length=4, polyorder=3)
-    with pytest.raises(ValueError, match="must be less than window_length"):
+    with pytest.raises(ValueError, match="must be at least zero and less than window_length"):
         at.savgol_filter(yvalues, window_length=5, polyorder=7)
+    with pytest.raises(ValueError, match="must be at least zero and less than window_length"):
+        at.savgol_filter(yvalues, window_length=5, polyorder=-1)
     with pytest.raises(ValueError, match="exceeds the data length"):
         at.savgol_filter(yvalues[:3], window_length=5, polyorder=3)
+    with pytest.raises(ValueError, match="needs a 1D array"):
+        at.savgol_filter(np.tile(yvalues, (2, 1)), window_length=5, polyorder=3)
 
 
 def test_gaussian_filter_wrap() -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -392,14 +392,45 @@ def test_gaussian_filter_wrap() -> None:
     """The smoothing must match scipy.ndimage.gaussian_filter(data, sigma=1.2, mode="wrap"), which it replaced."""
     data = np.outer(np.sin(np.linspace(0.0, np.pi, 4)), np.cos(np.linspace(0.0, 2 * np.pi, 6, endpoint=False)))
     expected = np.array([
-        [0.16333386804037386, 0.08166693402018696, -0.08166693402018693],
-        [0.22987577583564325, 0.11493788791782167, -0.11493788791782165],
-        [0.22987577583564328, 0.11493788791782168, -0.11493788791782164],
-        [0.16333386804037386, 0.08166693402018697, -0.08166693402018695],
+        [
+            0.16333386804037386,
+            0.08166693402018696,
+            -0.08166693402018693,
+            -0.16333386804037395,
+            -0.08166693402018704,
+            0.08166693402018683,
+        ],
+        [
+            0.22987577583564325,
+            0.11493788791782167,
+            -0.11493788791782165,
+            -0.22987577583564336,
+            -0.11493788791782181,
+            0.11493788791782150,
+        ],
+        [
+            0.22987577583564328,
+            0.11493788791782168,
+            -0.11493788791782164,
+            -0.22987577583564340,
+            -0.11493788791782182,
+            0.11493788791782152,
+        ],
+        [
+            0.16333386804037386,
+            0.08166693402018697,
+            -0.08166693402018695,
+            -0.16333386804037395,
+            -0.08166693402018706,
+            0.08166693402018685,
+        ],
     ])
-    # the input's symmetry means columns 3-5 mirror columns 0-2 with alternating sign
-    expected = np.hstack((expected, -expected))
     assert np.allclose(at.gaussian_filter_wrap(data, sigma=1.2), expected, rtol=1e-10, atol=1e-12)
+
+    with pytest.raises(ValueError, match="must be greater than zero"):
+        at.gaussian_filter_wrap(data, sigma=0.0)
+    with pytest.raises(ValueError, match="needs a 2D array"):
+        at.gaussian_filter_wrap(data[0], sigma=1.2)
 
 
 # --- timesteps.py ------------------------------------------------------------------------------

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -10,6 +10,7 @@ import io
 import lzma
 from pathlib import Path
 
+import numpy as np
 import polars as pl
 import polars.testing as pltest
 import pytest
@@ -356,6 +357,49 @@ def test_get_filterfunc() -> None:
     filterfunc = at.get_filterfunc(argparse.Namespace(filtermovingavg=3))
     assert filterfunc is not None
     assert filterfunc([1.0, 2.0, 3.0, 4.0, 5.0]) == pytest.approx([4 / 3, 2.0, 3.0, 4.0, 14 / 3])
+
+    # the Savitzky-Golay filter matches scipy.signal.savgol_filter(y, window_length=5, polyorder=3, mode="interp"),
+    # which it replaced
+    filterfunc = at.get_filterfunc(argparse.Namespace(filtersavgol=["5", "3"]))
+    assert filterfunc is not None
+    yvalues = np.sin(np.linspace(0.0, 3.0, num=12)) + np.linspace(0.0, 0.5, num=12) ** 2
+    expected = [
+        -4.0498103264955503e-05,
+        2.7158701565113680e-01,
+        5.2682820534895669e-01,
+        7.4815740267140873e-01,
+        9.1968938266004074e-01,
+        1.0298135494226284e00,
+        1.0717640450420927e00,
+        1.0441198836391163e00,
+        9.5090999103591567e-01,
+        8.0131538546057457e-01,
+        6.0937710159007052e-01,
+        3.9107049789170700e-01,
+    ]
+    assert np.allclose(filterfunc(yvalues), expected, rtol=1e-10, atol=1e-12)
+
+    # invalid parameters are rejected
+    with pytest.raises(ValueError, match="must be an odd number"):
+        at.savgol_filter(yvalues, window_length=4, polyorder=3)
+    with pytest.raises(ValueError, match="must be less than window_length"):
+        at.savgol_filter(yvalues, window_length=5, polyorder=7)
+    with pytest.raises(ValueError, match="exceeds the data length"):
+        at.savgol_filter(yvalues[:3], window_length=5, polyorder=3)
+
+
+def test_gaussian_filter_wrap() -> None:
+    """The smoothing must match scipy.ndimage.gaussian_filter(data, sigma=1.2, mode="wrap"), which it replaced."""
+    data = np.outer(np.sin(np.linspace(0.0, np.pi, 4)), np.cos(np.linspace(0.0, 2 * np.pi, 6, endpoint=False)))
+    expected = np.array([
+        [0.16333386804037386, 0.08166693402018696, -0.08166693402018693],
+        [0.22987577583564325, 0.11493788791782167, -0.11493788791782165],
+        [0.22987577583564328, 0.11493788791782168, -0.11493788791782164],
+        [0.16333386804037386, 0.08166693402018697, -0.08166693402018695],
+    ])
+    # the input's symmetry means columns 3-5 mirror columns 0-2 with alternating sign
+    expected = np.hstack((expected, -expected))
+    assert np.allclose(at.gaussian_filter_wrap(data, sigma=1.2), expected, rtol=1e-10, atol=1e-12)
 
 
 # --- timesteps.py ------------------------------------------------------------------------------

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -15,6 +15,7 @@ from artistools.misc import add_figscale_args
 from artistools.misc import add_maxpacketfiles_arg
 from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
+from artistools.misc import gaussian_filter_wrap
 from artistools.misc import print_theta_phi_definitions
 
 
@@ -202,10 +203,8 @@ def plot_spherical(
         data = alldirbins.get_column(plotvar).to_numpy().reshape((ncosthetabins, nphibins))
 
         if gaussian_sigma is not None and gaussian_sigma > 0:
-            import scipy.ndimage
-
             sigma_bins = gaussian_sigma / 360 * nphibins
-            data = scipy.ndimage.gaussian_filter(data, sigma=sigma_bins, mode="wrap")
+            data = gaussian_filter_wrap(data, sigma_bins)
 
         colormesh = ax.pcolormesh(meshgrid_phi, meshgrid_theta, data, rasterized=True, cmap=cmap)
 

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -319,6 +319,13 @@ def test_plotspherical() -> None:
     at.plotspherical.main(argsraw=[], modelpath=modelpath, outputfile=funcoutpath)
 
 
+def test_plotspherical_gaussian_filter() -> None:
+    """-gaussian_sigma must reach the smoothing helper, which lives in artistools.misc."""
+    funcoutpath = outputpath / funcname()
+    funcoutpath.mkdir(exist_ok=True, parents=True)
+    at.plotspherical.main(argsraw=[], modelpath=modelpath, gaussian_sigma=20, outputfile=funcoutpath)
+
+
 def test_plotspherical_gif() -> None:
     at.plotspherical.main(argsraw=[], modelpath=modelpath, makegif=True, timemax=270, outputfile=outputpath)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "pyarrow>=24.0.0",
     "pyyaml>=6.0.2",
     "rich>=15.0.0",
-    "scipy>=1.18.0",
     "tqdm>=4.67.3",
     "zstandard>=0.25.0;python_version<'3.14'",
 ]
@@ -59,12 +58,12 @@ dependencies = [
 [project.optional-dependencies]
 extras = [
     "astropy>=7.2",
-    "george>=0.4.4",
+    "george>=0.4.4;python_version<'3.15'", # not compatible with 3.15 yet
     "imageio>=2.37.3",
     "plotly>=6.7.0",
     "pypdf>=6.14.2",
     "pynonthermal>=2026.4.27",
-    "pyvista>=0.47.1;python_version<'3.15'", # not compatible with cpython 3.15 yet
+    "pyvista>=0.47.1;python_version<'3.15'", # not compatible with 3.15 yet
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,6 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pyyaml" },
     { name = "rich" },
-    { name = "scipy" },
     { name = "tqdm" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
@@ -44,7 +43,7 @@ dependencies = [
 [package.optional-dependencies]
 extras = [
     { name = "astropy" },
-    { name = "george" },
+    { name = "george", marker = "python_full_version < '3.15'" },
     { name = "imageio" },
     { name = "plotly" },
     { name = "pynonthermal" },
@@ -81,7 +80,7 @@ requires-dist = [
     { name = "argcomplete", specifier = ">=3.6.3" },
     { name = "astropy", marker = "extra == 'extras'", specifier = ">=7.2" },
     { name = "extinction", specifier = ">=0.4.7" },
-    { name = "george", marker = "extra == 'extras'", specifier = ">=0.4.4" },
+    { name = "george", marker = "python_full_version < '3.15' and extra == 'extras'", specifier = ">=0.4.4" },
     { name = "imageio", marker = "extra == 'extras'", specifier = ">=2.37.3" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.4.6" },
@@ -94,7 +93,6 @@ requires-dist = [
     { name = "pyvista", marker = "python_full_version < '3.15' and extra == 'extras'", specifier = ">=0.47.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=15.0.0" },
-    { name = "scipy", specifier = ">=1.18.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
     { name = "zstandard", marker = "python_full_version < '3.14'", specifier = ">=0.25.0" },
 ]


### PR DESCRIPTION
## What changed

Removes `scipy` from `[project.dependencies]`, replacing the five runtime call sites with pure-numpy implementations. Each replacement was verified numerically against scipy before removal (agreement at machine precision for the filters/interpolation, ~1e-11 relative for the quadrature).

- **`at.gaussian_filter_wrap`** (new, `misc/general.py`): separable Gaussian smoothing with wrap-around boundaries, matching `scipy.ndimage.gaussian_filter(mode="wrap")` with the default 4σ truncation. Used by `plotspherical`.
- **`at.savgol_filter`** (new, `misc/general.py`): Savitzky-Golay smoothing matching `scipy.signal.savgol_filter(mode="interp")` — least-squares window coefficients from a Vandermonde pseudoinverse (`lru_cache`d per `(window_length, polyorder)`), with polynomial fits to the first/last full window at the edges. Used by `-filtersavgol`.
- **Band lightcurves** (`lightcurve.py`): `interp1d(bounds_error=False, fill_value=0.0)` → `np.interp(..., left=0.0, right=0.0)`.
- **`energyinputfiles.py`**: `scipy.integrate.cumulative_trapezoid` → a one-line cumsum helper; `scipy.integrate.quad` → `_quad_adaptive` (adaptive Simpson). `E_tot` is now taken from the last element of the cumulative integral rather than integrated a second time, so the normalized rate ends at exactly 1.

## Why a scipy import remains in `viewingangleanalysis.py`

The `scipy.optimize` L-BFGS-B call in the gaussian-process branch of `lightcurve_polyfit` only executes when the optional `george` package imports successfully, and `george` declares scipy as a dependency — so scipy is always available on that path without being a direct dependency. `scipy-stubs` stays in the dev group so the type checkers can check that file.

## Behavior notes for reviewers

- **NOT filter magnitudes change (bug fix).** The files under `data/filters/NOT/` are not in ascending wavelength order. `interp1d` sorted internally, but the unsorted grid was still passed to `np.trapezoid` as the integration grid, so band magnitudes for those filters were silently wrong. `get_filter_data` now sorts the filter curve at load time, which fixes the integration; all other filter files were already sorted and are unaffected (the existing strict band-magnitude reference tests pass unchanged).
- **Quadrature tolerance.** `_quad_adaptive` uses `rtol=1.5e-8` (scipy's `quad` default epsrel). It cannot be much tighter: the Korobkin integrand computes `1/2 − arctan(x)/π`, whose catastrophic cancellation at large `x` leaves ~1e-9 relative noise in function values, below which the adaptive recursion never converges.
- `rprocess_const_and_powerlaw` now accumulates the cumulative integral segment-by-segment instead of re-integrating from `tmin` for each of the 200 output times (O(n) instead of O(n²) quadrature work).

## Tests

New regression tests pin the replacements to scipy-computed reference values: savgol output and parameter validation (`test_misc.py`), the wrap-mode Gaussian filter (`test_misc.py`), and the Korobkin `E_tot = 1.0364888092e16` erg/g (`test_inputmodel.py`). The interp change is covered end-to-end by the existing `test_band_magnitude_calculations` reference values.

All of ruff format/check, mypy, basedpyright, pyrefly, ty, refurb, and the misc/lightcurve/inputmodel/plotspherical test suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)