### PR TITLE
Skip the coverage upload when the push has no associated PR

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -182,9 +182,16 @@ jobs:
               uses: actions/download-artifact@v8
               with:
                   name: coverage-report-python
+            - name: Check for a pull request associated with this commit
+              id: haspr
+              if: github.ref != 'refs/heads/main'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: echo "found=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq 'length > 0')" >> "$GITHUB_OUTPUT"
+
             - uses: actions/upload-code-coverage@v1
+              if: github.ref == 'refs/heads/main' || steps.haspr.outputs.found == 'true'
               with:
                   file: coverage.xml
                   language: Python
                   label: code-coverage-agent
-                  fail-on-error: false


### PR DESCRIPTION
Applies the improvement from [artis-mcrt/artisatomic#82](https://github.com/artis-mcrt/artisatomic/pull/82) here.

The `upload-coverage-python` job triggers on `push` and `actions/upload-code-coverage` resolves the PR number at run time, so a branch pushed before its PR is opened fails with "HTTP 400: Only default branch is allowed if no pull_request_number is provided".

artistools currently masks this with `fail-on-error: false`, which also hides permission, malformed-report, and service errors on the runs where the upload should work. Replace it with a check of the `commits/{sha}/pulls` API, and skip the upload step only when the push has no associated PR and isn't on `main` — so genuine upload failures stay red.

Coverage still uploads normally whenever the PR exists or the ref is the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)