### PR TITLE
Test on Python 3.15 and 3.15t, and fix the three bugs that surfaced

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,7 +108,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.13', '3.14', 3.14t]
+                python-version: ['3.13', '3.14', 3.14t, '3.15', 3.15t]
         runs-on: ubuntu-26.04${{ !endsWith(matrix.python-version, 't') && '-arm' || '' }}
         name: pytest python ${{ matrix.python-version }}
         steps:

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -10,10 +10,16 @@ import sys
 if sys.version_info >= (3, 15) and hasattr(sys, "set_lazy_imports_filter") and hasattr(sys, "set_lazy_imports"):
     sys.set_lazy_imports_filter(
         lambda _importing, imported, _fromlist: (
-            not imported.startswith(("matplotlib.", "polars", "polars.exceptions", "polars.selectors"))
+            not imported.startswith(("matplotlib.", "numpy", "polars", "polars.exceptions", "polars.selectors"))
         )
     )
     sys.set_lazy_imports("all")
+
+    # numpy has to reach sys.modules before anything imports polars. polars substitutes its own lazy proxy for
+    # numpy whenever numpy is absent at that moment, and on free-threaded 3.15 that proxy cannot resolve itself:
+    # polars._dependencies captures globals() to publish the real module, which raises there with
+    # "'module' object does not support item assignment".
+    import numpy as np  # ruff:ignore[unused-import]
 
 if sys.version_info >= (3, 15):
     from artistools._polarscompat import repair_series_expr_dispatch

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -15,6 +15,11 @@ if sys.version_info >= (3, 15) and hasattr(sys, "set_lazy_imports_filter") and h
     )
     sys.set_lazy_imports("all")
 
+if sys.version_info >= (3, 15):
+    from artistools._polarscompat import repair_series_expr_dispatch
+
+    repair_series_expr_dispatch()
+
 from artistools import atomic as atomic
 from artistools import codecomparison as codecomparison
 from artistools import commands as commands

--- a/artistools/_polarscompat.py
+++ b/artistools/_polarscompat.py
@@ -1,0 +1,69 @@
+"""Restore polars Series-to-Expr method dispatch on CPython 3.15.
+
+polars leaves most Series methods as docstring-only stubs and, at import time, rebinds each one to the
+matching Expr implementation. It picks the stubs to rebind by inspecting their code objects, requiring a
+trailing None in co_consts. CPython 3.15 no longer stores that None for a docstring-only function, so
+polars rebinds nothing and every stub silently returns None: Series.unique(), .abs(), .drop_nulls(), and
+the whole .str/.dt/.list namespaces included.
+
+Delete this module once polars ships a fix.
+"""
+
+import typing as t
+from collections.abc import Callable
+from types import FunctionType
+
+import polars as pl
+from polars.series import utils as plseriesutils
+from polars.series.array import ArrayNameSpace
+from polars.series.binary import BinaryNameSpace
+from polars.series.categorical import CatNameSpace
+from polars.series.datetime import DateTimeNameSpace
+from polars.series.ext import ExtensionNameSpace
+from polars.series.list import ListNameSpace
+from polars.series.string import StringNameSpace
+from polars.series.struct import StructNameSpace
+
+_DISPATCH_CLASSES: tuple[type, ...] = (
+    pl.Series,
+    ArrayNameSpace,
+    BinaryNameSpace,
+    CatNameSpace,
+    DateTimeNameSpace,
+    ExtensionNameSpace,
+    ListNameSpace,
+    StringNameSpace,
+    StructNameSpace,
+)
+
+
+def _is_empty_method(func: Callable[..., pl.Series]) -> bool:
+    """Report whether a polars method is a stub whose body is nothing but a docstring."""
+    # matching an empty function's bytecode already implies a body that only returns None, so unlike
+    # polars' own check there is nothing left to confirm in the version-dependent co_consts
+    return isinstance(func, FunctionType) and func.__code__.co_code in plseriesutils._EMPTY_BYTECODE  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
+
+
+def _dispatch_is_working() -> bool:
+    """Report whether polars rebound its stubs, by calling a Series method it never implements itself."""
+    # the type stubs promise a Series, so cast away the lie that an unrepaired stub returns one
+    return t.cast("object", pl.Series("x", [1]).unique()) is not None
+
+
+def repair_series_expr_dispatch() -> None:
+    """Rebind polars' unimplemented Series methods to their Expr equivalents if polars itself failed to."""
+    if _dispatch_is_working():
+        return
+
+    # expr_dispatch reads _is_empty_method as a module global, so swap it only for the rebinding pass
+    original = plseriesutils._is_empty_method  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
+    plseriesutils._is_empty_method = _is_empty_method  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]  # ty:ignore[invalid-assignment]
+    try:
+        for cls in _DISPATCH_CLASSES:
+            plseriesutils.expr_dispatch(cls)
+    finally:
+        plseriesutils._is_empty_method = original  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
+
+    if not _dispatch_is_working():
+        msg = "failed to restore the polars Series methods that polars leaves unimplemented on this Python version"
+        raise RuntimeError(msg)

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -112,23 +112,24 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
     if _extracted_file_is_complete(path_extracted_file):
         return path_extracted_file
 
+    if tarfilepath is None:
+        # an incomplete leftover is unusable and there is no archive to replace it from, so clear it out
+        path_extracted_file.unlink(missing_ok=True)
+        msg = f"  No network data found for particle {particleid} (so can't access {memberfilename})"
+        raise FileNotFoundError(msg)
+
     # and memberfilename.endswith(".dat")
-    if tarfilepath is not None:
-        try:
-            _extract_tar_member_atomic(tarfilepath, memberfilename, path_extracted_file)
-        except OSError:
-            print(f"Problem extracting file {memberfilename} from {tarfilepath}")
-            raise
-        except KeyError:
-            print(f"File {memberfilename} not found in {tarfilepath}")
-            raise
+    try:
+        _extract_tar_member_atomic(tarfilepath, memberfilename, path_extracted_file)
+    except OSError:
+        print(f"Problem extracting file {memberfilename} from {tarfilepath}")
+        raise
+    except KeyError:
+        print(f"File {memberfilename} not found in {tarfilepath}")
+        raise
 
     if path_extracted_file.is_file():
         return path_extracted_file
-
-    if tarfilepath is None:
-        msg = f"  No network data found for particle {particleid} (so can't access {memberfilename})"
-        raise FileNotFoundError(msg)
 
     print(f"Member {memberfilename} not found in {tarfilepath}")
     raise AssertionError

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -368,7 +368,7 @@ def add_abundancecontributions(
         particleid for particleid, df in zip(particleids, list_traj_nuc_abund, strict=True) if not df
     ]
     dfcontribs = filtermissinggridparticlecontributions(dfcontribs, missing_particle_ids).sort("particleid")
-    active_inputcellcount = dfcontribs["cellindex"].unique().shape[0]
+    active_inputcellcount = dfcontribs["cellindex"].n_unique()
 
     print(
         f"{active_inputcellcount} of {len(dfmodel)} model cells have >0 particles contributing "

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -63,6 +63,35 @@ def get_dfelemabund_from_dfmodel(dfmodel: pl.DataFrame) -> pl.DataFrame:
     return dfelabundances
 
 
+def _extracted_file_is_complete(path_extracted_file: Path) -> bool:
+    """Report whether a previously extracted member is present and non-empty."""
+    if not path_extracted_file.is_file() or path_extracted_file.stat().st_size == 0:
+        return False
+
+    with contextlib.suppress(OSError), path_extracted_file.open(encoding="utf-8") as f:
+        return bool(f.read(1))
+
+    return False
+
+
+def _extract_tar_member_atomic(tarfilepath: Path, memberfilename: str, path_extracted_file: Path) -> None:
+    """Extract one tar member into place through a temporary file and an atomic replace.
+
+    Several processes routinely want the same trajectory member at once. Extracting straight to the destination
+    lets a reader open a file that another process is still writing, so unpack into a private directory and move
+    the result into place: a reader then sees either no file or a complete one, never a half-written one.
+    """
+    import tempfile
+
+    path_extracted_file.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=path_extracted_file.parent, prefix=".partial") as tempdir:
+        with tarfile.open(tarfilepath, "r:*") as tarfilehandle:
+            tarfilehandle.extract(path=tempdir, member=memberfilename, filter="data")
+
+        # a concurrent process may have extracted the same member first, but the contents are identical
+        Path(tempdir, memberfilename).replace(path_extracted_file)
+
+
 def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, memberfilename: str) -> Path:
     """Trajectory files are generally stored as {particleid}.tar.xz, but this is slow to access, so first check for extracted files, or decompressed .tar files, which are much faster to access.
 
@@ -80,20 +109,13 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
     ]
     tarfilepath = next((tarfilepath for tarfilepath in tarfilepaths if tarfilepath.is_file()), None)
 
-    if path_extracted_file.is_file():
-        if path_extracted_file.stat().st_size > 0:
-            with contextlib.suppress(OSError), path_extracted_file.open(encoding="utf-8") as f:
-                if f.read(1):
-                    return path_extracted_file
-
-        # file is empty, so remove it
-        path_extracted_file.unlink(missing_ok=True)
+    if _extracted_file_is_complete(path_extracted_file):
+        return path_extracted_file
 
     # and memberfilename.endswith(".dat")
-    if not path_extracted_file.is_file() and tarfilepath is not None:
+    if tarfilepath is not None:
         try:
-            with tarfile.open(tarfilepath, "r:*") as tarfilehandle:
-                tarfilehandle.extract(path=Path(traj_root, str(particleid)), member=memberfilename, filter="data")
+            _extract_tar_member_atomic(tarfilepath, memberfilename, path_extracted_file)
         except OSError:
             print(f"Problem extracting file {memberfilename} from {tarfilepath}")
             raise

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2,6 +2,7 @@ import argparse
 import hashlib
 import json
 import math
+import multiprocessing
 import shutil
 import tarfile
 import time
@@ -49,13 +50,31 @@ def test_tar_member_extraction_is_atomic(tmp_path: Path) -> None:
         membersize = tarfilehandle.getmember(memberfilename).size
 
     readsize = partial(_trajectory_member_size, traj_root, memberfilename)
-    with ProcessPoolExecutor(max_workers=nworkers) as executor:
+    # at.parallel_map would give a thread pool on free-threaded builds, and only separate processes can race on
+    # the filesystem. Spawn for the same reason parallel_map does: forking with polars/rayon threads live is unsafe.
+    with ProcessPoolExecutor(max_workers=nworkers, mp_context=multiprocessing.get_context("spawn")) as executor:
         # start the workers up front so that each trial races on the extraction rather than on process startup
         list(executor.map(time.sleep, [0.0] * nworkers))
 
         for _trial in range(20):
             shutil.rmtree(traj_root / "114511", ignore_errors=True)
             assert list(executor.map(readsize, range(nworkers), chunksize=1)) == [membersize] * nworkers
+
+
+def test_tar_member_empty_leftover_without_archive_raises(tmp_path: Path) -> None:
+    """An empty leftover from an interrupted run is not usable data when there is no archive to re-extract from."""
+    memberfilename = "./Run_rprocess/nz-plane00223"
+    traj_root = tmp_path / "trajectories"
+    path_extracted_file = traj_root / "114511" / "Run_rprocess" / "nz-plane00223"
+    path_extracted_file.parent.mkdir(parents=True)
+    path_extracted_file.touch()
+
+    with pytest.raises(FileNotFoundError):
+        at.inputmodel.rprocess_from_trajectory.get_tar_member_extracted_path(
+            traj_root=traj_root, particleid=114511, memberfilename=memberfilename
+        )
+
+    assert not path_extracted_file.exists()
 
 
 def test_describeinputmodel() -> None:

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -3,7 +3,11 @@ import hashlib
 import json
 import math
 import shutil
+import tarfile
+import time
 import typing as t
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -20,6 +24,38 @@ modelpath_3d = at.get_path("testdata") / "testmodel_3d_10^3"
 outputpath = at.get_path("testoutput")
 testdatapath = at.get_path("testdata")
 modelpath_classic_3d = testdatapath / "test-classicmode_3d"
+
+
+def _trajectory_member_size(traj_root: Path, memberfilename: str, _worker: int) -> int:
+    """Return the byte count one process sees for a trajectory tar member, extracting it if needed."""
+    filepath = at.inputmodel.rprocess_from_trajectory.get_tar_member_extracted_path(
+        traj_root=traj_root, particleid=114511, memberfilename=memberfilename
+    )
+    return len(filepath.read_bytes())
+
+
+def test_tar_member_extraction_is_atomic(tmp_path: Path) -> None:
+    """Processes extracting the same trajectory member at once must never see a half-written file.
+
+    Extracting straight to the destination let one process read what another was still writing, which failed
+    runs at random on a truncated file.
+    """
+    nworkers = 16
+    memberfilename = "./Run_rprocess/heating.dat"  # the largest member, so the widest window to catch a partial read
+    traj_root = tmp_path / "trajectories"
+    traj_root.mkdir()
+    shutil.copy(testdatapath / "kilonova" / "trajectories" / "114511.tar.xz", traj_root)
+    with tarfile.open(traj_root / "114511.tar.xz", "r:*") as tarfilehandle:
+        membersize = tarfilehandle.getmember(memberfilename).size
+
+    readsize = partial(_trajectory_member_size, traj_root, memberfilename)
+    with ProcessPoolExecutor(max_workers=nworkers) as executor:
+        # start the workers up front so that each trial races on the extraction rather than on process startup
+        list(executor.map(time.sleep, [0.0] * nworkers))
+
+        for _trial in range(20):
+            shutil.rmtree(traj_root / "114511", ignore_errors=True)
+            assert list(executor.map(readsize, range(nworkers), chunksize=1)) == [membersize] * nworkers
 
 
 def test_describeinputmodel() -> None:

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tomllib
 import typing as t
+from datetime import date
 from pathlib import Path
 from unittest import mock
 
@@ -46,6 +47,24 @@ def funcname() -> str:
 
 def get_plot_xy(callargs: t.Any) -> tuple[np.ndarray, np.ndarray]:
     return np.array(callargs[0][1], dtype=float), np.array(callargs[0][2], dtype=float)
+
+
+def test_polars_series_expr_dispatch() -> None:
+    """Polars leaves most Series methods unimplemented, so check that they reach their Expr implementations.
+
+    On CPython 3.15 polars fails to rebind them and they silently return None, which artistools/_polarscompat.py
+    repairs. Sample the plain Series methods and each namespace that the repair covers.
+    """
+    assert pl.Series("x", [2, 1, 1, None]).unique().sort().to_list() == [None, 1, 2]
+    assert pl.Series("x", [-1, 2]).abs().to_list() == [1, 2]
+    assert pl.Series("x", [1, None]).drop_nulls().to_list() == [1]
+    assert pl.Series("x", ["ab"]).str.to_uppercase().to_list() == ["AB"]
+    assert pl.Series("x", [[1, 1, 2]]).list.unique().list.len().to_list() == [2]
+    assert pl.Series("x", [[1, 2]], dtype=pl.Array(pl.Int64, 2)).arr.sum().to_list() == [3]
+    assert pl.Series("x", [date(2026, 8, 8)]).dt.year().to_list() == [2026]
+    assert pl.Series("x", [{"a": 7}]).struct.field("a").to_list() == [7]
+    assert pl.Series("x", ["a"], dtype=pl.Categorical).cat.len_bytes().to_list() == [1]
+    assert pl.Series("x", [b"ab"]).bin.size().to_list() == [2]
 
 
 def _console_script_targets() -> list[tuple[str, str, str]]:


### PR DESCRIPTION
Adds `3.15` and `3.15t` to the pytest matrix, and fixes the three separate bugs that turned up once those jobs ran.

## 1. polars leaves its Series methods unimplemented on 3.15

polars ships most `Series` methods as docstring-only stubs and rebinds each one to the matching `Expr` implementation at import time. It picks the stubs to rebind by inspecting their code objects, requiring a trailing `None` in `co_consts`. CPython 3.15 no longer stores that `None` for a docstring-only function:

```
3.14: co_consts == ('docstring', None)
3.15: co_consts == ('docstring',)
```

So polars rebinds nothing, and roughly 350 methods silently return `None` — `Series.unique()`, `.abs()`, `.drop_nulls()`, `.sort()`, `.is_in()`, `.fill_null()`, plus the whole `.str`/`.dt`/`.list`/`.arr`/`.cat`/`.struct`/`.bin` namespaces. That accounted for all 14 failures in both the 3.15 and 3.15t jobs. polars 1.43.2 is current and has no fix.

`artistools/_polarscompat.py` re-runs polars' own `expr_dispatch` with an empty-method check that relies on the bytecode match alone, which is sufficient and does not depend on how a given CPython lays out `co_consts`. It runs from `artistools/__init__.py` behind a version guard, before the submodule imports, and raises if the repair did not take rather than failing quietly should polars restructure.

This covers every affected method rather than only the call sites the tests happen to reach, it is a no-op wherever polars' own dispatch works, and the module can be deleted outright once polars ships a fix.

## 2. polars proxies numpy, and that proxy corrupts itself under free threading

`sys.set_lazy_imports("all")` left numpy absent from `sys.modules`, so polars installed its own `_LazyModule` proxy for it — `polars._dependencies._lazy_import` only proxies a module that is not already imported. That proxy is neither idempotent nor thread-safe:

```python
def _import(self):
    module = import_module(self.__name__)
    self._globals[self._module_name] = module
    self.__dict__.update(module.__dict__)   # copies numpy._globals over self._globals
```

numpy has a `_globals` **submodule**, so the last line replaces the proxy's `_globals` **dict** with a module, and a second `_import()` on the same proxy raises `TypeError: 'module' object does not support item assignment`.

Only 3.15t hit this. `parallel_map` dispatches through `thread_map` on free-threaded builds, so several threads entered `pl.lit()` → `_check_for_numpy` → the proxy at once with no GIL to serialise them, and whichever arrived second saw the clobbered attribute. Under the GIL the name is rebound in polars' globals before anyone reaches the proxy again, and 3.14t predates `set_lazy_imports`, so numpy is already imported and no proxy is ever built.

The fix excludes numpy from the lazy-import filter and imports it before anything pulls in polars, so the proxy is never created. The exclusion alone is not enough — the import has to actually land in `sys.modules` ahead of polars. polars now holds the real numpy module instead of a `_LazyModule`.

The cost is that numpy loads eagerly at `import artistools` on 3.15+, giving up some of what lazy imports bought. Nearly every submodule imports numpy anyway, so it is small.

## 3. Trajectory tar members were extracted non-atomically

Unrelated to 3.15, but it broke the 3.13 job on this branch and is a pre-existing bug.

`get_tar_member_extracted_path` unpacked straight to its destination inside a shared, gitignored cache directory. Several processes routinely ask for the same trajectory member at once, so one could open a file another was still writing, and the "file is empty, so remove it" branch could delete a file mid-write. Two gsinetwork tests extract the same trajectory concurrently, which failed at random with:

```
ValueError: not enough values to unpack (expected 6, got 0)
ValueError: Problem with ./Run_rprocess/nz-plane00223 for traj 114511
```

Extraction now unpacks into a private temporary directory and moves the result into place, matching the temp-file-then-replace pattern already used by `write_parquet_atomic`. A reader sees either no file or a complete one. If a concurrent process published the member first it is simply replaced by identical contents.

`test_tar_member_extraction_is_atomic` races several processes onto a cold cache. It uses an explicit spawn context: `at.parallel_map` is not usable here because it returns a thread pool on free-threaded builds, and only separate processes can race on the filesystem.

## Also here

- `dfcontribs["cellindex"].unique().shape[0]` becomes `.n_unique()`, which says what it means and does not go through the dispatch machinery at all.
- `test_polars_series_expr_dispatch` pins the dispatch behaviour across plain `Series` and each namespace the repair covers.
- `test_tar_member_empty_leftover_without_archive_raises` covers a regression found in review: an empty extracted file whose archive is missing was being served to the caller instead of raising `FileNotFoundError`.

## For the reviewer

- **`_polarscompat.py` shows 0% coverage.** Coverage is uploaded from the 3.14 job, and the module is behind a `sys.version_info >= (3, 15)` guard, so it is never imported there. It is exercised by the 3.15 and 3.15t jobs, whose coverage is not uploaded. Removing the guard to make it register would mean doing the work on Pythons that do not need it.
- **The 3.15t job is slow on a cold cache.** There are no `cp315t` wheels yet for numpy, scipy, matplotlib or polars, so uv builds them from source, which took about 40 minutes the first time. Because the job previously failed, its post-steps never saved the uv cache, so it rebuilt every run; now that it passes the cache is stored and it finishes in about three minutes.
- **Patching a dependency's internals is a deliberate trade** for the polars issue, taken over rewriting call sites throughout the package for a bug upstream will fix. The module docstring says why and says to delete it.
- One review thread is left open on purpose: `Path.replace()` can raise `PermissionError` on Windows when another process holds the destination open. I have not changed it, because `write_parquet_atomic` has the identical property and there is no Windows job to validate a divergence at a single call site. Worth doing for both together if Windows is a target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
