### PR TITLE
Enable stricter pyrefly and flake8-type-checking rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Never report that checks passed when you could not run them. If the environment 
 - Target Python >= 3.13 and keep syntax valid on 3.14, including free-threaded builds (`3.14t`), which CI tests. Do not add module-level mutable state or rely on the GIL for thread safety.
 - Annotate every function fully: mypy runs in strict mode and basedpyright/pyright in strict type-checking mode. Untyped defs and untyped calls are errors.
 - Use modern generics: `list[str]`, `X | None`, PEP 695 (`def f[T](...)`, `type Alias = ...`). No `typing.List`, `typing.Optional`, or bare `Any` where a real type fits.
+- A lambda's parameter types have to be inferable from the call site (pyrefly's `implicit-any-lambda`). A `sorted`/`min`/`filter` key that pyrefly cannot infer becomes an annotated `def` instead — lambdas take no annotations. Prefer a comprehension over `filter(lambda ...)` either way.
 - Raise exceptions with a named message variable, not a literal:
   ```python
   msg = f"Unknown path key: {key}"
@@ -68,6 +69,8 @@ Ruff rules are configured by **name**, not by code (`"any-type"`, not `"ANN401"`
 - Use the configured aliases: `artistools as at`, `polars as pl`, `polars.selectors as cs`, `polars.testing as pltest`, `numpy as np`, `numpy.typing as npt`, `matplotlib.pyplot as plt`, `matplotlib.axes as mplax`, `matplotlib.figure as mplfig`, `typing as t`.
 - Inside package modules, import the specific submodule or function (`from artistools.misc import get_nu_grid`) to avoid import cycles. `import artistools as at` is for tests and top-level scripts.
 - Import heavy or optional dependencies (astropy, pyvista, plotly, imageio, pynonthermal, argcomplete) inside the function that needs them. `import-outside-top-level` is disabled deliberately to keep CLI startup fast.
+- flake8-type-checking runs in `strict` mode: an import used *only* in annotations belongs in an `if t.TYPE_CHECKING:` block after the normal imports, for the same startup-cost reason. Adding a runtime use of that name means moving the import back out.
+- Pyrefly's `missing-import` is an error, so a renamed or mistyped module fails CI. A genuinely optional dependency that a plain `uv sync` would not install belongs in `ignore-missing-imports` in `[tool.pyrefly]`.
 - `implicit_reexport` is off: a new public function must be re-exported in the parent `__init__.py` using the `from module import name as name` form, matching the surrounding alphabetical order.
 
 ## Polars

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -76,6 +76,11 @@ def get_units_string(variable: str) -> str:
     return f" [{units}]" if (units := get_variableunits(variable)) else ""
 
 
+def _estimator_colsortkey(col: str) -> str:
+    """Sort timestep, modelgridindex, and titeration first, then the remaining columns alphabetically."""
+    return f"-{col!r}" if col in {"timestep", "modelgridindex", "titeration"} else col
+
+
 def get_estimators_rankbatch_parquetfile(
     folderpath: Path | str,
     batch_mpiranks: Sequence[int],
@@ -134,13 +139,8 @@ def get_estimators_rankbatch_parquetfile(
             cs.by_name("titeration", "timestep", "modelgridindex", require_all=False).cast(pl.Int32)
         )
 
-        pldf_batch = pldf_batch.select(
-            # sort columns with timestep, modelgridindex, and titeration first, then the rest alphabetically
-            sorted(
-                pldf_batch.columns,
-                key=lambda col: f"-{col!r}" if col in {"timestep", "modelgridindex", "titeration"} else str(col),
-            )
-        )
+        sortedcols: list[str] = sorted(pldf_batch.columns, key=_estimator_colsortkey)
+        pldf_batch = pldf_batch.select(sortedcols)
         print(f"took {time.perf_counter() - time_start:.1f} s. Writing parquet file...", end="", flush=True)
         time_start = time.perf_counter()
 

--- a/artistools/inputmodel/downscale3dgrid.py
+++ b/artistools/inputmodel/downscale3dgrid.py
@@ -83,9 +83,9 @@ def make_downscaled_3d_grid(
     with smallabundancefile.open("w", encoding="utf-8") as newabundancefile:
         for z, y, x in itertools.product(range(smallgrid), range(smallgrid), range(smallgrid)):
             line = abund_small[x, y, z, :][1:31]  # index 1:30 are abundances
-            newabundancefile.writelines(f"{i + 1} ")
+            newabundancefile.write(f"{i + 1} ")
             newabundancefile.writelines(f"{item:g} " for item in line)
-            newabundancefile.writelines("\n")
+            newabundancefile.write("\n")
             i += 1
 
     print("writing model file")
@@ -107,9 +107,9 @@ def make_downscaled_3d_grid(
             ]
             line2 = radioabunds_small[x, y, z, :]
             newmodelfile.writelines(f"{item:g} " for item in line1)
-            newmodelfile.writelines("\n")
+            newmodelfile.write("\n")
             newmodelfile.writelines(f"{item:g} " for item in line2)
-            newmodelfile.writelines("\n")
+            newmodelfile.write("\n")
             cellindex += 1
 
     if plot:

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -682,8 +682,8 @@ def map_to_artis(
             )
 
             # mass fractions, avoid looping
-            X_list = list(filter(lambda c: c.startswith("X_"), dfmodel.columns))
-            X_list_dyn_model = list(filter(lambda c: c.startswith("X_"), dyn_model.columns))
+            X_list = [c for c in dfmodel.columns if c.startswith("X_")]
+            X_list_dyn_model = [c for c in dyn_model.columns if c.startswith("X_")]
             els_missing_in_dyn = [value for value in X_list if value not in X_list_dyn_model]
             dyn_model = dyn_model.with_columns(**{col: pl.lit(0.0) for col in els_missing_in_dyn})
             X_list.remove("X_Fegroup")

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -823,6 +823,11 @@ def get_standard_columns(dimensions: int, includenico57: bool = False, pos_unkno
     return cols
 
 
+def _customcolsortkey(col: str) -> tuple[float, int]:
+    """Sort nuclide mass fraction columns by atomic number then mass number, and other columns last."""
+    return get_z_a_nucname(col) if col.startswith("X_") else (math.inf, 0)
+
+
 def save_modeldata(
     dfmodel: pl.LazyFrame | pl.DataFrame,
     outpath: Path | str | None = None,
@@ -912,9 +917,7 @@ def save_modeldata(
 
     dfmodel = dfmodel.with_columns(pl.col("inputcellid").cast(pl.Int32))
     customcols = [col for col in dfmodel.collect_schema().names() if col not in standardcols]
-    customcols.sort(
-        key=lambda col: get_z_a_nucname(col) if col.startswith("X_") else (math.inf, 0)
-    )  # sort columns by atomic number, mass number
+    customcols.sort(key=_customcolsortkey)
 
     modelfilepath = resolve_outputfile(outpath, "model.txt")
 

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -94,7 +94,10 @@ def zopenpl(filename: Path | str, mode: str = "r", encoding: str | None = None) 
         ext, filepath = found
         if ext in POLARS_READABLE_EXTENSIONS:
             return filepath
-        return get_decompress_open(ext)(filepath, mode=mode, encoding=encoding)
+        # get_decompress_open() erases the three backends' differing signatures to Any, so the file
+        # object is Any by design and the annotation says so rather than leaving it implicit
+        fileobj: t.Any = get_decompress_open(ext)(filepath, mode=mode, encoding=encoding)
+        return fileobj
 
     return Path(filename)
 

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -20,7 +20,11 @@ from artistools.misc.modelinfo import get_model_name
 
 def match_closest_time(reftime: float, searchtimes: Iterable[t.Any]) -> float:
     """Return the time in searchtimes that is closest to reftime."""
-    return min((float(x) for x in searchtimes), key=lambda x: abs(x - reftime))
+
+    def offset_from_reftime(time: float) -> float:
+        return abs(time - reftime)
+
+    return min((float(x) for x in searchtimes), key=offset_from_reftime)
 
 
 def get_deposition(modelpath: Path | str = ".") -> pl.LazyFrame:

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -10,13 +10,11 @@ from collections.abc import Callable
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.artist as mplartist
 import matplotlib.axes as mplax
 import matplotlib.colors as mplcolors
 import matplotlib.figure as mplfig
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
-import matplotlib.typing as mplt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -47,6 +45,7 @@ from artistools.misc import get_model_name
 from artistools.misc import get_time_range
 from artistools.misc import get_vpkt_config
 from artistools.misc import get_vspec_dir_labels
+from artistools.misc import match_closest_time
 from artistools.misc import normalize_path_list
 from artistools.misc import parse_cli_args
 from artistools.misc import print_saved
@@ -57,6 +56,10 @@ from artistools.misc import trim_or_pad
 from artistools.plottools import ExponentLabelFormatter
 from artistools.plottools import set_mpl_style
 from artistools.spectra.writespectra import write_flambda_spectra
+
+if t.TYPE_CHECKING:
+    import matplotlib.artist as mplartist
+    import matplotlib.typing as mplt
 
 
 def path_is_artis_model(filepath: str | Path) -> bool:
@@ -205,7 +208,7 @@ def plot_polarisation(modelpath: Path, args: argparse.Namespace) -> None:
     assert args.timemax is not None
 
     timeavg_float = (args.timemin + args.timemax) / 2.0
-    timeavg = f"{min((float(x) for x in timearray), key=lambda x: abs(x - timeavg_float)):.4f}"
+    timeavg = f"{match_closest_time(timeavg_float, timearray):.4f}"
 
     filterfunc = get_filterfunc(args)
     if filterfunc is not None:
@@ -933,6 +936,7 @@ def make_emissionabsorption_plot(
 
     max_f_emission_total = dfspectotal.filter(pl.col("x").is_between(xmin, xmax))["y"].max()
     assert isinstance(max_f_emission_total, (float, np.floating))
+    max_f_emission_total = float(max_f_emission_total)
     max_absorption = 0.0
 
     scalefactor = scale_to_peak / max_f_emission_total if scale_to_peak else 1.0
@@ -1098,12 +1102,12 @@ def make_emissionabsorption_plot(
     # axis.annotate(plotlabel, xy=(0.97, 0.03), xycoords='axes fraction',
     #               horizontalalignment='right', verticalalignment='bottom', fontsize=7)
 
-    ymax = float(max(ymaxrefall, scalefactor * max_f_emission_total * 1.2))
+    ymax = max(ymaxrefall, scalefactor * max_f_emission_total * 1.2)
     if args.ymax is None:
         axis.set_ylim(top=ymax)
 
     if args.ymin is None:
-        axis.set_ylim(bottom=float(-scalefactor * max_absorption * 1.2))
+        axis.set_ylim(bottom=-scalefactor * max_absorption * 1.2)
 
     return plotobjects, plotobjectlabels, dfaxisdata
 

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -1480,10 +1480,9 @@ def get_flux_contributions_from_packets(
         if array_flambda_emission is None:
             array_flambda_emission = np.zeros_like(array_flambda_absorption, dtype=float)
 
-        fluxcontribthisseries = abs(np.trapezoid(array_flambda_emission, x=array_lambda)) + abs(
-            np.trapezoid(array_flambda_absorption, x=array_lambda)
+        fluxcontribthisseries = abs(float(np.trapezoid(array_flambda_emission, x=array_lambda))) + abs(
+            float(np.trapezoid(array_flambda_absorption, x=array_lambda))
         )
-        assert isinstance(fluxcontribthisseries, float)
 
         if fluxcontribthisseries > 0.0:
             contribution_list.append(

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -3,7 +3,6 @@
 import argparse
 import sys
 import typing as t
-from collections.abc import Iterable
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -20,6 +19,9 @@ from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_timedays_arg
 from artistools.misc import add_timestep_arg
+
+if t.TYPE_CHECKING:
+    from collections.abc import Iterable
 
 defaultoutputfile = "plottransitions_cell{cell:03d}_ts{timestep:02d}_{time_days:.0f}d.pdf"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# adding a package here also needs an entry in `ignore-missing-imports` under [tool.pyrefly]
 extras = [
     "astropy>=7.2",
     "george>=0.4.4;python_version<'3.15'", # not compatible with 3.15 yet
@@ -205,13 +206,31 @@ project-excludes = [
     '**/rd_cmfgen.py',
 ]
 python-interpreter-path = ".venv/bin/python3"
+# missing-import is left enabled so a renamed or mistyped first-party module is an error (no other
+# checker catches that: mypy sets ignore_missing_imports and pyright downgrades it to information).
+# The [project.optional-dependencies] packages are absent from a plain `uv sync`, and zstandard is
+# not installed on 3.14+, so those resolve to Any rather than erroring.
+ignore-missing-imports = [
+    "astropy.*",
+    "george",
+    "george.*",
+    "imageio.*",
+    "plotly.*",
+    "pynonthermal",
+    "pypdf",
+    "pyvista",
+    "zstandard",
+]
 
 [tool.pyrefly.errors]
-missing-import = false
+# unbound-name matches basedpyright's reportPossiblyUnboundVariable, which is also off
 unbound-name = false
-unsupported-operation = false
 implicit-any-empty-container = true
-implicit-any-lambda = false
+implicit-any-lambda = true
+no-any-return-implicit = true
+string-as-iterable = true
+unnecessary-type-conversion = true
+unsupported-operation = true
 
 [tool.pyright]
 venvPath = "."
@@ -295,6 +314,7 @@ preview = true
 [tool.ruff.format]
 skip-magic-trailing-comma = true
 preview = true
+docstring-code-format = true
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -370,6 +390,11 @@ unfixable = [
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 require-lazy = "all"
+
+[tool.ruff.lint.flake8-type-checking]
+# imports used only in annotations belong in a `if t.TYPE_CHECKING:` block, which keeps them out
+# of the CLI startup path for the same reason `import-outside-top-level` is allowed
+strict = true
 
 [tool.ruff.lint.isort]
 force-single-line = true


### PR DESCRIPTION
Turns on the pyrefly error categories that were switched off, and fixes what they found. Four of the five checkers were already clean; this closes the gaps where one of them was silently letting things through.

## What is now enforced

**`missing-import`** — so a renamed or mistyped first-party module is an error. No other checker catches this: mypy sets `ignore_missing_imports` and pyright downgrades it to information. The `[project.optional-dependencies]` packages are absent from a plain `uv sync`, and zstandard is not installed on 3.14+, so those are listed in `ignore-missing-imports` and resolve to `Any` instead. There is a note next to the extras list so a package added there does not silently start failing CI.

**`implicit-any-lambda`** — rejects a lambda whose parameter types cannot be inferred from the call site. Lambdas take no annotations, so the three `sorted`/`min` keys it flagged become annotated `def`s, and two `filter(lambda ...)` calls become comprehensions, which reads better anyway.

**`no-any-return-implicit`, `string-as-iterable`, `unnecessary-type-conversion`, `unsupported-operation`.**

**ruff `flake8-type-checking` in strict mode** — an import used only in annotations belongs in an `if t.TYPE_CHECKING:` block, keeping it off the CLI startup path for the same reason `import-outside-top-level` is deliberately allowed.

Plus ruff's `docstring-code-format`.

## The one behavioural fix

`string-as-iterable` found a real bug in `downscale3dgrid.py`. `writelines()` was being handed a plain string rather than an iterable of lines, so it iterated the string and wrote it one character at a time:

```python
newabundancefile.writelines(f"{i + 1} ")
...
newabundancefile.writelines("\n")
```

Those are now `write()`. Same output, but only because the characters happened to concatenate back together — it was working by accident.

The rest of the source changes are type-level only, with no runtime effect. `zopenpl` gains an explicit `t.Any` annotation because `get_decompress_open()` erases its three backends' differing signatures, so the file object genuinely is `Any` and the annotation now says so rather than leaving it implicit.

## Docs

AGENTS.md gains the three rules a contributor would otherwise trip over: the lambda inference constraint, the `TYPE_CHECKING` requirement, and what to do about an optional dependency under `missing-import`.

## Verification

`ruff format --check`, `ruff check --no-fix`, `mypy`, `basedpyright --warnings`, `pyrefly check`, `ty check` and the full pytest suite all pass. basedpyright reports two pre-existing informational notes and no errors or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)