### PR TITLE
Use consistent output filename for NLTE population plots vs time/velocity

### DIFF
--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -23,6 +23,9 @@ from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 
 defaultoutputfile = "plotnlte_{elsymbol}_cell{cell:03d}_ts{timestep:02d}_{time_days:.0f}d.pdf"
+# a plot against time covers a range of timesteps, and one against velocity a range of cells, so
+# neither can be named after the single cell and timestep that the default filename describes
+defaultoutputfile_timeorvelocity = "plotnltelevelpops_{elsymbol}.pdf"
 
 
 def annotate_emission_line(ax: mplax.Axes, y: float, upperlevel: int, lowerlevel: int, label: str) -> None:
@@ -479,9 +482,9 @@ def make_plot_populations_with_time_or_velocity(modelpaths: list[Path | str], ar
 
     at.plottools.set_axis_properties(ax, args)
 
-    figname = f"plotnltelevelpopsZ{Z}.pdf"
-    fig.savefig(figname, format="pdf")
-    at.print_saved(figname)
+    outputfilename = str(args.outputfile).format(elsymbol=at.get_elsymbol(Z))
+    fig.savefig(outputfilename, format="pdf")
+    at.print_saved(outputfilename)
     plt.close(fig)
 
 
@@ -826,7 +829,10 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         msg = "Please specify time with -timedays or -timestep"
         raise ValueError(msg)
 
-    args.outputfile = at.resolve_outputfile(args.outputfile, defaultoutputfile)
+    args.outputfile = at.resolve_outputfile(
+        args.outputfile,
+        defaultoutputfile_timeorvelocity if args.x in {"time", "velocity"} else defaultoutputfile,
+    )
 
     ion_stages_permitted = at.parse_range_list(args.ion_stages) if args.ion_stages else None
 

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -788,7 +788,8 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     add_axis_limit_args(parser)
 
-    add_outputfile_arg(parser, default=defaultoutputfile, helptext="path/filename for PDF file")
+    # no default here: which one applies depends on -x, so main chooses it when resolving the path
+    add_outputfile_arg(parser, helptext="path/filename for PDF file")
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -830,8 +830,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         raise ValueError(msg)
 
     args.outputfile = at.resolve_outputfile(
-        args.outputfile,
-        defaultoutputfile_timeorvelocity if args.x in {"time", "velocity"} else defaultoutputfile,
+        args.outputfile, defaultoutputfile_timeorvelocity if args.x in {"time", "velocity"} else defaultoutputfile
     )
 
     ion_stages_permitted = at.parse_range_list(args.ion_stages) if args.ion_stages else None

--- a/artistools/nltepops/test_nltepops.py
+++ b/artistools/nltepops/test_nltepops.py
@@ -96,11 +96,11 @@ def test_nltepops_no_estimator_data(
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 @pytest.mark.benchmark
-def test_nltepops_versus_velocity(mockplot: t.Any) -> None:
+def test_nltepops_versus_velocity(mockplot: t.Any, tmp_path: Path) -> None:
     at.nltepops.plot(
         argsraw=[],
         modelpath=modelpath,
-        outputfile=outputpath,
+        outputfile=tmp_path,
         timestep=40,
         x="velocity",
         ion_stages=[1, 2],
@@ -114,14 +114,16 @@ def test_nltepops_versus_velocity(mockplot: t.Any) -> None:
         assert np.allclose(xarr, [8000.0], rtol=1e-4)
         assert np.allclose(yarr, [expected_yval], rtol=1e-4)
 
+    assert (tmp_path / "plotnltelevelpops_Fe.pdf").is_file()
+
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 @pytest.mark.benchmark
-def test_nltepops_versus_time(mockplot: t.Any) -> None:
+def test_nltepops_versus_time(mockplot: t.Any, tmp_path: Path) -> None:
     at.nltepops.plot(
         argsraw=[],
         modelpath=modelpath,
-        outputfile=outputpath,
+        outputfile=tmp_path,
         cell=0,
         x="time",
         timedays="270-275",
@@ -138,6 +140,8 @@ def test_nltepops_versus_time(mockplot: t.Any) -> None:
         xarr, yarr = get_plot_xy(callargs)
         assert np.allclose(xarr, expected_xarr, rtol=1e-4)
         assert np.allclose(yarr, expected_yarr, rtol=1e-4)
+
+    assert (tmp_path / "plotnltelevelpops_Fe.pdf").is_file()
 
 
 def test_texifyterm_handles_multiplicity_parity_and_jvalue() -> None:

--- a/artistools/nltepops/test_nltepops.py
+++ b/artistools/nltepops/test_nltepops.py
@@ -119,16 +119,11 @@ def test_nltepops_versus_velocity(mockplot: t.Any, tmp_path: Path) -> None:
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 @pytest.mark.benchmark
-def test_nltepops_versus_time(mockplot: t.Any, tmp_path: Path) -> None:
+def test_nltepops_versus_time(mockplot: t.Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # no outputfile, so this covers the default filename that -x time selects
+    monkeypatch.chdir(tmp_path)
     at.nltepops.plot(
-        argsraw=[],
-        modelpath=modelpath,
-        outputfile=tmp_path,
-        cell=0,
-        x="time",
-        timedays="270-275",
-        ion_stages=[1, 2],
-        levels=[0, 1],
+        argsraw=[], modelpath=modelpath, cell=0, x="time", timedays="270-275", ion_stages=[1, 2], levels=[0, 1]
     )
 
     assert len(mockplot.call_args_list) == 10


### PR DESCRIPTION
## Summary
Fixes the output filename handling for NLTE population plots when plotting against time or velocity. Previously, these plots used a hardcoded filename that didn't respect the `--outputfile` argument. Now they use a consistent naming scheme that can be customized via the command-line interface.

## Changes
- Added `defaultoutputfile_timeorvelocity` constant for plots spanning multiple timesteps or cells, since these cannot be named after a single cell/timestep
- Updated `make_plot_populations_with_time_or_velocity()` to use the output filename from `args.outputfile` instead of a hardcoded `plotnltelevelpopsZ{Z}.pdf`
- Modified `main()` to select the appropriate default filename template based on the plot type (time/velocity vs. single cell/timestep)
- Updated tests to verify the correct output filename is generated and to use temporary directories instead of a fixed output path

## Implementation Details
The output filename now respects the `--outputfile` argument for time and velocity plots, with element symbol substitution via `.format(elsymbol=...)`. The default filename template is chosen based on the `args.x` parameter to ensure sensible defaults for each plot type.

https://claude.ai/code/session_01DCNKgRzexhdw3bM4vcUuvd