### PR TITLE
Rank emission/absorption contributions within the plotted wavelength window

### DIFF
--- a/artistools/spectra/__init__.py
+++ b/artistools/spectra/__init__.py
@@ -7,6 +7,7 @@ from artistools.spectra import writespectra as writespectra
 from artistools.spectra.plotspectra import main as plot
 from artistools.spectra.spectra import convert_angstroms_to_unit as convert_angstroms_to_unit
 from artistools.spectra.spectra import convert_unit_to_angstroms as convert_unit_to_angstroms
+from artistools.spectra.spectra import convert_xlimits_to_lambda_range as convert_xlimits_to_lambda_range
 from artistools.spectra.spectra import convert_xunit_aliases_to_canonical as convert_xunit_aliases_to_canonical
 from artistools.spectra.spectra import get_dfspectrum_x_y_with_units as get_dfspectrum_x_y_with_units
 from artistools.spectra.spectra import get_flux_contributions as get_flux_contributions

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -329,10 +329,7 @@ def plot_reference_spectrum(
 
     print(" metadata: " + ", ".join([f"{k}='{v}'" if hasattr(v, "lower") else f"{k}={v}" for k, v in metadata.items()]))
 
-    lambda_min, lambda_max = sorted([
-        atspectra.convert_unit_to_angstroms(xmin, xunit),
-        atspectra.convert_unit_to_angstroms(xmax, xunit),
-    ])
+    lambda_min, lambda_max = atspectra.convert_xlimits_to_lambda_range(xmin, xmax, xunit)
 
     specdata = specdata.filter(pl.col("lambda_angstroms").is_between(lambda_min, lambda_max))
 
@@ -883,6 +880,7 @@ def make_emissionabsorption_plot(
         )
     else:
         assert not args.vpkt_match_emission_exclusion_to_opac
+        lambda_min, lambda_max = atspectra.convert_xlimits_to_lambda_range(xmin, xmax, args.xunit)
         contribution_list, array_flambda_emission_total, arraylambda_angstroms = atspectra.get_flux_contributions(
             modelpath,
             filterfunc,
@@ -894,6 +892,8 @@ def make_emissionabsorption_plot(
             directionbin=dirbin,
             average_over_phi=args.average_over_phi_angle,
             average_over_theta=args.average_over_theta_angle,
+            lambda_min=lambda_min,
+            lambda_max=lambda_max,
         )
 
     atspectra.print_integrated_flux(array_flambda_emission_total, arraylambda_angstroms)

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -273,10 +273,10 @@ def get_lambda_bin_edges(
         deltax = convert_angstroms_to_unit(deltalambda, xunit)
         xmin = xmin_plot - deltax * 0.5
         xmax = xmax_plot + deltax * 0.5
-        lambda_min, lambda_max = sorted(convert_unit_to_angstroms(np.array((xmin, xmax)), xunit))
+        lambda_min, lambda_max = convert_xlimits_to_lambda_range(xmin, xmax, xunit)
         lambda_bin_edges = np.arange(lambda_min, lambda_max + deltalambda, deltalambda)
     else:
-        lambda_min_plot, lambda_max_plot = sorted(convert_unit_to_angstroms(np.array((xmin_plot, xmax_plot)), xunit))
+        lambda_min_plot, lambda_max_plot = convert_xlimits_to_lambda_range(xmin_plot, xmax_plot, xunit)
         lambda_bin_edges_fullrange = get_exspec_lambda_bin_edges(modelpath=modelpath, gamma=gamma)
         lambda_bin_edges = (
             df_filter_minmax_bounded(
@@ -394,6 +394,15 @@ def convert_unit_to_angstroms(
         case _:
             msg = f"Unknown xunit {old_units}"
             raise ValueError(msg)
+
+
+def convert_xlimits_to_lambda_range(xmin: float, xmax: float, xunit: str) -> tuple[float, float]:
+    """Convert plot x-axis limits to an ascending wavelength range in angstroms.
+
+    Frequency and energy units invert the ordering, so the converted limits are sorted.
+    """
+    lambda_min, lambda_max = sorted((convert_unit_to_angstroms(xmin, xunit), convert_unit_to_angstroms(xmax, xunit)))
+    return lambda_min, lambda_max
 
 
 def weighted_average_spectra(
@@ -977,12 +986,21 @@ def get_flux_contributions(
     directionbin: int | None = None,
     average_over_phi: bool = False,
     average_over_theta: bool = False,
+    lambda_min: float = 0.0,
+    lambda_max: float = math.inf,
 ) -> tuple[list[FluxContributionTuple], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Return the per-ion emission and absorption contributions from emission.out, and the flux and wavelength arrays."""
+    """Return the per-ion emission and absorption contributions from emission.out, and the flux and wavelength arrays.
+
+    The returned spectra are restricted to lambda_min to lambda_max [Å], so that the flux contributions used for
+    ranking count only the plotted window, matching get_flux_contributions_from_packets.
+    """
     arr_tmid = get_timestep_times(modelpath, loc="mid")
     arr_tdelta = get_timestep_times(modelpath, loc="delta")
-    arraynu = get_nu_grid(modelpath)
-    arraylambda = const.c_ang_per_s / arraynu
+    arraynu_full = get_nu_grid(modelpath)
+    arraylambda_full = const.c_ang_per_s / arraynu_full
+    nu_select = (arraylambda_full >= lambda_min) & (arraylambda_full <= lambda_max)
+    arraynu = arraynu_full[nu_select]
+    arraylambda = arraylambda_full[nu_select]
     if not Path(modelpath, "compositiondata.txt").is_file():
         print("WARNING: compositiondata.txt not found. Using output*.txt instead")
         from artistools.atomic import get_composition_data_from_outputfile
@@ -1027,7 +1045,7 @@ def get_flux_contributions(
 
             emissiondata[dbin] = read_emission_absorption_file(emissionfilename).collect()
             emission_timeblocks[dbin] = get_emabs_timeblock_count(
-                emissiondata[dbin], len(arraynu), len(arr_tmid), str(emissionfilename)
+                emissiondata[dbin], len(arraynu_full), len(arr_tmid), str(emissionfilename)
             )
 
             if emission_timeblocks[dbin] > len(arr_tmid) and not polarisation_notified:
@@ -1056,7 +1074,7 @@ def get_flux_contributions(
 
             absorptiondata[dbin] = read_emission_absorption_file(absorptionfilename).collect()
             absorption_timeblocks[dbin] = get_emabs_timeblock_count(
-                absorptiondata[dbin], len(arraynu), len(arr_tmid), str(absorptionfilename)
+                absorptiondata[dbin], len(arraynu_full), len(arr_tmid), str(absorptionfilename)
             )
 
             if absorption_timeblocks[dbin] > len(arr_tmid) and not polarisation_notified:
@@ -1104,7 +1122,7 @@ def get_flux_contributions(
                         )
                         for timestep in range(timestepmin, timestepmax + 1)
                         for dbin in dbinlist
-                    ])
+                    ])[nu_select]
                 else:
                     array_fnu_emission = np.zeros_like(arraylambda, dtype=float)
 
@@ -1116,7 +1134,7 @@ def get_flux_contributions(
                         )
                         for timestep in range(timestepmin, timestepmax + 1)
                         for dbin in dbinlist
-                    ])
+                    ])[nu_select]
                 else:
                     array_fnu_absorption = np.zeros_like(arraylambda, dtype=float)
 

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -240,6 +240,41 @@ def test_spectra_get_flux_contributions(benchmark: BenchmarkFixture) -> None:
     assert max(diff) / integrated_flux_specout < 1e-9
 
 
+def test_spectra_get_flux_contributions_wavelength_window() -> None:
+    """A wavelength window restricts the spectra and the flux contributions used for ranking."""
+    timestepmin = 40
+    timestepmax = 80
+    lambda_min = 3500.0
+    lambda_max = 7000.0
+
+    contributions_full, flambda_total_full, arraylambda_full = at.spectra.get_flux_contributions(
+        modelpath, timestepmin=timestepmin, timestepmax=timestepmax, use_lastemissiontype=False
+    )
+
+    contributions_window, flambda_total_window, arraylambda_window = at.spectra.get_flux_contributions(
+        modelpath,
+        timestepmin=timestepmin,
+        timestepmax=timestepmax,
+        use_lastemissiontype=False,
+        lambda_min=lambda_min,
+        lambda_max=lambda_max,
+    )
+
+    nu_select = (arraylambda_full >= lambda_min) & (arraylambda_full <= lambda_max)
+    assert np.array_equal(arraylambda_window, arraylambda_full[nu_select])
+    assert np.allclose(flambda_total_window, flambda_total_full[nu_select], rtol=1e-12)
+
+    contrib_full_bylabel = {c.linelabel: c for c in contributions_full}
+    assert any(c.fluxcontrib < 0.999 * contrib_full_bylabel[c.linelabel].fluxcontrib for c in contributions_window), (
+        "expected some flux contribution outside the window to be excluded from the ranking integral"
+    )
+    for contrib in contributions_window:
+        full = contrib_full_bylabel[contrib.linelabel]
+        assert contrib.fluxcontrib <= full.fluxcontrib * (1 + 1e-12)
+        assert np.allclose(contrib.array_flambda_emission, full.array_flambda_emission[nu_select], rtol=1e-12)
+        assert np.allclose(contrib.array_flambda_absorption, full.array_flambda_absorption[nu_select], rtol=1e-12)
+
+
 def test_spectra_get_flux_contributions_from_packets(benchmark: BenchmarkFixture) -> None:
     lambdamin = 200.0
     lambdamax = 20000.0


### PR DESCRIPTION
## What changed

`at spec --showemission --showabsorption` (non-`--frompackets` mode) now restricts the emission/absorption data to the plotted wavelength window before ranking ion contributions, matching what `--frompackets` mode already did.

- `get_flux_contributions` gains `lambda_min`/`lambda_max` parameters (Å, default unbounded) and masks the frequency grid before the filter function and per-series flux integrals, so the returned spectra, ranking integrals, and totals cover only the window — the same semantics as `get_flux_contributions_from_packets`.
- The caller in `make_emissionabsorption_plot` converts the axis x-limits to an angstrom window and passes it through.
- The repeated "x-limits → sorted angstrom range" idiom (unit conversion + sort, since frequency/energy units invert the ordering) is extracted into `convert_xlimits_to_lambda_range` and used at all call sites.
- New regression test `test_spectra_get_flux_contributions_wavelength_window`.

## Why

The two modes ranked contributions differently: frompackets filtered packets to the plotted frequency window before summing `e_rf` per group, while the emission.out/absorption.out path integrated each series over the whole frequency grid (e.g. 60–298,515 Å on a kilonova model), over-ranking ions with strong flux outside the plotted range.

Verified on a 3D kilonova model (`-t 2.2-2.8 --showemission --showabsorption`): both modes now print the identical `-fixedionlist` ranking, where previously the full-range integration ranked Th III above Nd II and pulled Gd I into the top series.

## Notes for reviewers

- In non-packets mode, the printed integrated flux and the written data columns now cover the plotted window rather than the full grid — this matches frompackets-mode behaviour and is intentional.
- The window becomes part of the `lru_cache` key of `get_flux_contributions`, so calls at different x-limits re-read the emission files; the per-figure call pattern is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)