### PR TITLE
Replace astropy cosmology with a local luminosity_distance function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Ruff rules are configured by **name**, not by code (`"any-type"`, not `"ANN401"`
 - One import per line (`force-single-line`); no `from x import a, b`.
 - Use the configured aliases: `artistools as at`, `polars as pl`, `polars.selectors as cs`, `polars.testing as pltest`, `numpy as np`, `numpy.typing as npt`, `matplotlib.pyplot as plt`, `matplotlib.axes as mplax`, `matplotlib.figure as mplfig`, `typing as t`.
 - Inside package modules, import the specific submodule or function (`from artistools.misc import get_nu_grid`) to avoid import cycles. `import artistools as at` is for tests and top-level scripts.
-- Import heavy or optional dependencies (astropy, pyvista, plotly, imageio, pynonthermal, argcomplete) inside the function that needs them. `import-outside-top-level` is disabled deliberately to keep CLI startup fast.
+- Import heavy or optional dependencies (pyvista, plotly, imageio, pynonthermal, argcomplete) inside the function that needs them. `import-outside-top-level` is disabled deliberately to keep CLI startup fast.
 - flake8-type-checking runs in `strict` mode: an import used *only* in annotations belongs in an `if t.TYPE_CHECKING:` block after the normal imports, for the same startup-cost reason. Adding a runtime use of that name means moving the import back out.
 - Pyrefly's `missing-import` is an error, so a renamed or mistyped module fails CI. A genuinely optional dependency that a plain `uv sync` would not install belongs in `ignore-missing-imports` in `[tool.pyrefly]`.
 - `implicit_reexport` is off: a new public function must be re-exported in the parent `__init__.py` using the `from module import name as name` form, matching the surrounding alphabetical order.

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -9,6 +9,7 @@ from artistools.lightcurve.lightcurve import get_colour_delta_mag as get_colour_
 from artistools.lightcurve.lightcurve import get_filter_data as get_filter_data
 from artistools.lightcurve.lightcurve import get_from_packets as get_from_packets
 from artistools.lightcurve.lightcurve import get_phillips_relation_data as get_phillips_relation_data
+from artistools.lightcurve.lightcurve import luminosity_distance as luminosity_distance
 from artistools.lightcurve.lightcurve import read_bol_reflightcurve_data as read_bol_reflightcurve_data
 from artistools.lightcurve.lightcurve import read_hesma_lightcurve as read_hesma_lightcurve
 from artistools.lightcurve.lightcurve import read_hesma_lightcurve_file as read_hesma_lightcurve_file

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -483,12 +483,11 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     an entire function of u, so that the quadrature stays accurate to a few ulp out to arbitrarily high z
     rather than needing hundreds of nodes beyond z ~ 10.
 
-    That accuracy holds for any matter density from Om0 ~ 0.01 up to Om0 = 1. Outside that range the
-    integrand develops an endpoint the fixed node count cannot follow, and only in the two limits that have
-    a closed form does this function stay exact. As Om0 -> 0 the u integrand grows a plateau of height
-    2 / sqrt(Om0), giving a relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, and as Om0 -> 1 the z
-    integrand diverges at z' -> -1, giving ~1e-5 for Om0 = 1 at z = -0.99. Both are far outside any
-    cosmology of interest.
+    Both ends of the matter density range are closed forms, taken exactly rather than integrated, since
+    each turns one of the two integrands singular at an endpoint that no fixed node count can follow. In
+    between, the quadrature is accurate to a few ulp for any matter density down to Om0 ~ 0.01. Below that
+    the u integrand grows a plateau of height 2 / sqrt(Om0) that is resolved less and less well, reaching a
+    relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, far outside any cosmology of interest.
     """
     if z <= -1.0:
         msg = f"1 + z is a ratio of scale factors, so the redshift must be greater than -1, but got z={z}"
@@ -496,10 +495,16 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 
     dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
 
-    # a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c / H0) z. The
-    # u integrand is 2 / u^3 there, which diverges as u -> 0, so no fixed-node quadrature would do.
+    # a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c / H0) z, while
+    # its u integrand would be 2 / u^3, which diverges as u -> 0
     if Om0 == 0.0:
         return (1.0 + z) * dist_hubble_mpc * z
+
+    # a matter-only universe integrates to D_C = 2 (c / H0) (1 - (1 + z)^(-1/2)), while its z integrand
+    # would be (1 + z')^(-3/2), which diverges as z' -> -1. expm1 keeps the bracket exact as z -> 0, where
+    # writing it as 1 - 1 / sqrt(1 + z) would lose most of the precision to cancellation.
+    if Om0 == 1.0:
+        return (1.0 + z) * dist_hubble_mpc * -2.0 * math.expm1(-0.5 * math.log1p(z))
 
     nodes, weights = np.polynomial.legendre.leggauss(32)
 

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -496,13 +496,24 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     side is flat in one of the variables though, so the range is split at the crossover (astropy's s, at
     1 + zcross) and integrated over z below it and over u above it. Measured against adaptive quadrature,
     that holds every matter density from 1e-8 to 2 accurate to a few ulp over the whole domain, from
-    z = -1 + 1e-12 out to z = 1e8.
+    z = -1 + 1e-12 out to z = 1e8. The exception is the turnaround of an Om0 > 1 cosmology, rejected below
+    as having no distance at all: 1 / E has an integrable pole there, which costs the last ~0.01 in z above
+    it up to ~1% until the quadrature recovers its usual accuracy.
 
     The de Sitter and Einstein-de Sitter closed forms are exact and cheaper, so they stay, but only the
     first is now needed: Om0 = 0 has no crossover to divide by.
     """
     if z <= -1.0:
         msg = f"1 + z is a ratio of scale factors, so the redshift must be greater than -1, but got z={z}"
+        raise ValueError(msg)
+
+    # A negative dark energy density (Om0 > 1) halts the expansion where E(z)^2 falls to zero, and nothing
+    # beyond that turnaround has a distance. E(z)^2 rises with z, so this endpoint covers the whole range.
+    # Without the check the radicand goes negative: at the endpoint alone that gives a plausible finite
+    # number from the interior nodes, and further out a NaN, which would reach the magnitudes as one.
+    if Om0 * (1.0 + z) ** 3 + (1.0 - Om0) <= 0.0:
+        zturnaround = ((Om0 - 1.0) / Om0) ** (1.0 / 3.0) - 1.0
+        msg = f"a flat cosmology with Om0={Om0} stops expanding at z={zturnaround}, so z={z} has no distance"
         raise ValueError(msg)
 
     dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -490,15 +490,17 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     of nearly equal size loses precision as z -> 0, where integrating over the range between them does not,
     and s is a cube root of a negative number for Om0 > 1, which this form never has to take.
 
-    Neither variable suits the whole range on its own, because 1 / E has a plateau of height
-    1 / sqrt(1 - Om0) below the crossover at Om0 (1 + z')^3 = 1 - Om0 and falls off as (1 + z')^(-3/2)
-    above it, and a fixed node count cannot follow that corner once the two sides differ by decades. Each
-    side is flat in one of the variables though, so the range is split at the crossover (astropy's s, at
-    1 + zcross) and integrated over z below it and over u above it. Measured against adaptive quadrature,
-    that holds every matter density from 1e-8 to 2 accurate to a few ulp over the whole domain, from
-    z = -1 + 1e-12 out to z = 1e8. The exception is the turnaround of an Om0 > 1 cosmology, rejected below
-    as having no distance at all: 1 / E has an integrable pole there, which costs the last ~0.01 in z above
-    it up to ~1% until the quadrature recovers its usual accuracy.
+    No one variable suits the whole range, since 1 / E falls off as (1 + z')^(-3/2) only above the point
+    where the two terms of the radicand balance, and a fixed node count cannot follow that corner once the
+    sides differ by decades. So the range is split there and each side taken in the variable that flattens
+    it: u above, and below it whichever of the two the sign of 1 - Om0 calls for. Dark energy (Om0 < 1)
+    holds 1 / E within sqrt(2) of 1 / sqrt(1 - Om0) below its crossover at Om0 (1 + z')^3 = 1 - Om0, which
+    is astropy's s, so z serves as it stands. A negative density (Om0 > 1) instead cancels the matter term
+    at the turnaround rejected below, leaving an integrable pole that q = sqrt((1 + z')^3 - cturn) unfolds
+    into 2 dq / (3 sqrt(Om0) (q^2 + cturn)^(2/3)), flat while q^2 stays under cturn = (Om0 - 1) / Om0.
+
+    Measured against adaptive quadrature, that holds every matter density from 1e-8 to 1e6 accurate to a
+    few ulp over the whole domain, from the turnaround or z = -1 + 1e-12 out to z = 1e8.
 
     The de Sitter and Einstein-de Sitter closed forms are exact and cheaper, so they stay, but only the
     first is now needed: Om0 = 0 has no crossover to divide by.
@@ -529,18 +531,32 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 
     nodes, weights = np.polynomial.legendre.leggauss(32)
 
-    # Om0 > 1 leaves a negative dark energy density, which dominates nowhere, so there is no crossover
-    zcross = ((1.0 - Om0) / Om0) ** (1.0 / 3.0) - 1.0 if Om0 < 1.0 else -1.0
+    # where the two terms of the radicand balance: the dark energy crossover, or twice the turnaround
+    cturn = (Om0 - 1.0) / Om0
+    zbalance = ((1.0 - Om0) / Om0) ** (1.0 / 3.0) - 1.0 if Om0 < 1.0 else (2.0 * cturn) ** (1.0 / 3.0) - 1.0
     zlo, zhi = min(0.0, z), max(0.0, z)
-    zsplit = min(max(zcross, zlo), zhi)
+    zsplit = min(max(zbalance, zlo), zhi)
 
     integral = 0.0
 
     if zsplit > zlo:
-        # below the crossover 1 / E varies by at most sqrt(2), so integrate it as it stands
-        halfwidth = 0.5 * (zsplit - zlo)
-        zvals = halfwidth * (nodes + 1.0) + zlo
-        integral += float(weights @ (1.0 / np.sqrt(Om0 * (1.0 + zvals) ** 3 + (1.0 - Om0)))) * halfwidth
+        if Om0 < 1.0:
+            # dark energy holds 1 / E to within sqrt(2) below the crossover, so integrate it as it stands
+            halfwidth = 0.5 * (zsplit - zlo)
+            zvals = halfwidth * (nodes + 1.0) + zlo
+            integral += float(weights @ (1.0 / np.sqrt(Om0 * (1.0 + zvals) ** 3 + (1.0 - Om0)))) * halfwidth
+        else:
+            # q unfolds the pole that a negative dark energy density leaves at the turnaround. Its width
+            # comes from the difference of cubes expanded about z' rather than from qhi - qlo, which would
+            # cancel as the range shrinks onto z' = 0. The clamp is only in case this difference rounds
+            # below zero where the check above, on the algebraically equivalent E(z)^2, found it positive.
+            qlo = math.sqrt(max(0.0, (1.0 + zlo) ** 3 - cturn))
+            qhi = math.sqrt(max(0.0, (1.0 + zsplit) ** 3 - cturn))
+            cubediff = (zsplit - zlo) * (3.0 + 3.0 * (zlo + zsplit) + (zlo * zlo + zlo * zsplit + zsplit**2))
+            halfwidth = 0.5 * cubediff / (qhi + qlo)
+            qvals = halfwidth * (nodes + 1.0) + qlo
+            qintegrand = 2.0 / (3.0 * math.sqrt(Om0) * (qvals**2 + cturn) ** (2.0 / 3.0))
+            integral += float(weights @ qintegrand) * halfwidth
 
     if zhi > zsplit:
         # above it, u = (1 + z')^(-1/2) flattens the (1 + z')^(-3/2) tail. Taking the width of the u range

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -469,35 +469,51 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     """Return the luminosity distance in Mpc to redshift z for a flat LambdaCDM cosmology.
 
     H0 is the Hubble constant in km/s/Mpc and Om0 the present-day matter density parameter. Radiation is
-    neglected, so the dark energy density is 1 - Om0. The comoving distance
+    neglected, so the dark energy density is 1 - Om0. The luminosity distance is D_L = (1 + z) D_C for a
+    comoving distance
 
-        D_C = (c / H0) * int_0^z dz' / sqrt(Om0 (1 + z')^3 + 1 - Om0)
+        D_C = (c / H0) * int_0^z dz' / sqrt(Om0 (1 + z')^3 + 1 - Om0),
 
-    is rewritten with the substitution u = (1 + z')^(-1/2), which flattens the (1 + z')^(-3/2) tail into
+    evaluated by 32-node Gauss-Legendre quadrature. A blueshift (-1 < z < 0) integrates that form as it
+    stands, since the integrand only varies between 1 and 1 / sqrt(1 - Om0) over the whole of (-1, 0]. A
+    redshift substitutes u = (1 + z')^(-1/2) first, folding the (1 + z')^(-3/2) tail into
 
         D_C = (c / H0) * int_u(z)^1 2 du / sqrt(Om0 + (1 - Om0) u^6),
 
-    an entire function of u. Gauss-Legendre quadrature therefore converges to double precision with few
-    nodes for any z, and the luminosity distance is D_L = (1 + z) D_C.
+    an entire function of u, so that the quadrature stays accurate to a few ulp out to arbitrarily high z
+    rather than needing hundreds of nodes beyond z ~ 10.
 
-    The quadrature is accurate to a few ulp for any matter density down to Om0 ~ 0.01. Below that the
-    integrand grows a plateau of height 2 / sqrt(Om0) that a fixed node count resolves less and less well,
-    reaching a relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, far outside any cosmology of interest.
+    That accuracy holds for any matter density from Om0 ~ 0.01 up to Om0 = 1. Outside that range the
+    integrand develops an endpoint the fixed node count cannot follow, and only in the two limits that have
+    a closed form does this function stay exact. As Om0 -> 0 the u integrand grows a plateau of height
+    2 / sqrt(Om0), giving a relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, and as Om0 -> 1 the z
+    integrand diverges at z' -> -1, giving ~1e-5 for Om0 = 1 at z = -0.99. Both are far outside any
+    cosmology of interest.
     """
+    if z <= -1.0:
+        msg = f"1 + z is a ratio of scale factors, so the redshift must be greater than -1, but got z={z}"
+        raise ValueError(msg)
+
     dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
 
     # a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c / H0) z. The
-    # transformed integrand is 2 / u^3 there, which diverges as u -> 0, so no quadrature rule would do.
+    # u integrand is 2 / u^3 there, which diverges as u -> 0, so no fixed-node quadrature would do.
     if Om0 == 0.0:
         return (1.0 + z) * dist_hubble_mpc * z
 
     nodes, weights = np.polynomial.legendre.leggauss(32)
 
-    # half the width of the u integration range, i.e. (1 - (1 + z)^(-1/2)) / 2 without cancellation as z -> 0
-    uhalfwidth = -0.5 * math.expm1(-0.5 * math.log1p(z))
-    uvals = uhalfwidth * (nodes + 1.0) + (1.0 + z) ** -0.5
-
-    integral = float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * uhalfwidth
+    if z < 0.0:
+        # substituting u here would stretch the range to (1, (1 + z)^(-1/2)], which runs away to infinity
+        # as z -> -1 while the integrand collapses into a spike at u = 1 that the nodes then miss
+        zhalfwidth = 0.5 * z
+        zvals = zhalfwidth * (nodes + 1.0)
+        integral = float(weights @ (1.0 / np.sqrt(Om0 * (1.0 + zvals) ** 3 + (1.0 - Om0)))) * zhalfwidth
+    else:
+        # half the width of the u range, i.e. (1 - (1 + z)^(-1/2)) / 2 without cancellation as z -> 0
+        uhalfwidth = -0.5 * math.expm1(-0.5 * math.log1p(z))
+        uvals = uhalfwidth * (nodes + 1.0) + (1.0 + z) ** -0.5
+        integral = float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * uhalfwidth
 
     return (1.0 + z) * dist_hubble_mpc * integral
 

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -472,16 +472,27 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     neglected, so the dark energy density is 1 - Om0. The luminosity distance is D_L = (1 + z) D_C for a
     comoving distance
 
-        D_C = (c / H0) * int_0^z dz' / sqrt(Om0 (1 + z')^3 + 1 - Om0),
+        D_C = (c / H0) * int_0^z dz' / sqrt(Om0 (1 + z')^3 + 1 - Om0).
 
-    evaluated by 32-node Gauss-Legendre quadrature. A blueshift (-1 < z < 0) integrates that form as it
-    stands, since the integrand only varies between 1 and 1 / sqrt(1 - Om0) over the whole of (-1, 0]. A
-    redshift substitutes u = (1 + z')^(-1/2) first, folding the (1 + z')^(-3/2) tail into
+    This splits the same three ways as astropy's FlatLambdaCDM for a cosmology without radiation. The de
+    Sitter (Om0 = 0) and Einstein-de Sitter (Om0 = 1) cases have the closed forms astropy uses, and every
+    other matter density reduces to the function of Baes, Camps & Van De Putte (2017),
 
-        D_C = (c / H0) * int_u(z)^1 2 du / sqrt(Om0 + (1 - Om0) u^6),
+        T(x) = 2 sqrt(x) 2F1(1/6, 1/2; 7/6; -x^3) = 2 * int_0^sqrt(x) dy / sqrt(1 + y^6),
 
-    an entire function of u, so that the quadrature stays accurate to a few ulp out to arbitrarily high z
-    rather than needing hundreds of nodes beyond z ~ 10.
+    as D_C = (c / H0) [T(s) - T(s / (1 + z))] / sqrt(s Om0) with s = ((1 - Om0) / Om0)^(1/3). astropy
+    evaluates T through scipy's hyp2f1. This evaluates the difference of the two T values as the single
+    integral it stands for, substituting y = sqrt(s) u to absorb s and give
+
+        D_C = (c / H0) * int_u(z)^1 2 du / sqrt(Om0 + (1 - Om0) u^6),   u = (1 + z')^(-1/2),
+
+    which needs no scipy, and improves on the hypergeometric form in two places: subtracting two T values
+    of nearly equal size loses precision as z -> 0, where a single integration over a short range does not,
+    and s is a cube root of a negative number for Om0 > 1, which this form never has to take.
+
+    The integrand is an entire function of u, so 32-node Gauss-Legendre quadrature is accurate to a few ulp
+    out to arbitrarily high z rather than needing hundreds of nodes beyond z ~ 10. A blueshift
+    (-1 < z < 0) is the one case that integrates over z as it stands, the substitution being no help there.
 
     Both ends of the matter density range are closed forms, taken exactly rather than integrated, since
     each turns one of the two integrands singular at an endpoint that no fixed node count can follow. In
@@ -495,14 +506,14 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 
     dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
 
-    # a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c / H0) z, while
-    # its u integrand would be 2 / u^3, which diverges as u -> 0
+    # de Sitter: a matter-free universe expands with E(z) = 1, making the comoving distance exactly
+    # (c / H0) z, while its u integrand would be 2 / u^3, which diverges as u -> 0
     if Om0 == 0.0:
         return (1.0 + z) * dist_hubble_mpc * z
 
-    # a matter-only universe integrates to D_C = 2 (c / H0) (1 - (1 + z)^(-1/2)), while its z integrand
-    # would be (1 + z')^(-3/2), which diverges as z' -> -1. expm1 keeps the bracket exact as z -> 0, where
-    # writing it as 1 - 1 / sqrt(1 + z) would lose most of the precision to cancellation.
+    # Einstein-de Sitter: a matter-only universe integrates to D_C = 2 (c / H0) (1 - (1 + z)^(-1/2)), while
+    # its z integrand would be (1 + z')^(-3/2), which diverges as z' -> -1. expm1 keeps the bracket exact
+    # as z -> 0, where writing it as 1 - 1 / sqrt(1 + z) would lose most of the precision to cancellation.
     if Om0 == 1.0:
         return (1.0 + z) * dist_hubble_mpc * -2.0 * math.expm1(-0.5 * math.log1p(z))
 

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -487,18 +487,19 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
         D_C = (c / H0) * int_u(z)^1 2 du / sqrt(Om0 + (1 - Om0) u^6),   u = (1 + z')^(-1/2),
 
     which needs no scipy, and improves on the hypergeometric form in two places: subtracting two T values
-    of nearly equal size loses precision as z -> 0, where a single integration over a short range does not,
+    of nearly equal size loses precision as z -> 0, where integrating over the range between them does not,
     and s is a cube root of a negative number for Om0 > 1, which this form never has to take.
 
-    The integrand is an entire function of u, so 32-node Gauss-Legendre quadrature is accurate to a few ulp
-    out to arbitrarily high z rather than needing hundreds of nodes beyond z ~ 10. A blueshift
-    (-1 < z < 0) is the one case that integrates over z as it stands, the substitution being no help there.
+    Neither variable suits the whole range on its own, because 1 / E has a plateau of height
+    1 / sqrt(1 - Om0) below the crossover at Om0 (1 + z')^3 = 1 - Om0 and falls off as (1 + z')^(-3/2)
+    above it, and a fixed node count cannot follow that corner once the two sides differ by decades. Each
+    side is flat in one of the variables though, so the range is split at the crossover (astropy's s, at
+    1 + zcross) and integrated over z below it and over u above it. Measured against adaptive quadrature,
+    that holds every matter density from 1e-8 to 2 accurate to a few ulp over the whole domain, from
+    z = -1 + 1e-12 out to z = 1e8.
 
-    Both ends of the matter density range are closed forms, taken exactly rather than integrated, since
-    each turns one of the two integrands singular at an endpoint that no fixed node count can follow. In
-    between, the quadrature is accurate to a few ulp for any matter density down to Om0 ~ 0.01. Below that
-    the u integrand grows a plateau of height 2 / sqrt(Om0) that is resolved less and less well, reaching a
-    relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, far outside any cosmology of interest.
+    The de Sitter and Einstein-de Sitter closed forms are exact and cheaper, so they stay, but only the
+    first is now needed: Om0 = 0 has no crossover to divide by.
     """
     if z <= -1.0:
         msg = f"1 + z is a ratio of scale factors, so the redshift must be greater than -1, but got z={z}"
@@ -506,32 +507,40 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 
     dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
 
-    # de Sitter: a matter-free universe expands with E(z) = 1, making the comoving distance exactly
-    # (c / H0) z, while its u integrand would be 2 / u^3, which diverges as u -> 0
+    # de Sitter: a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c/H0) z
     if Om0 == 0.0:
         return (1.0 + z) * dist_hubble_mpc * z
 
-    # Einstein-de Sitter: a matter-only universe integrates to D_C = 2 (c / H0) (1 - (1 + z)^(-1/2)), while
-    # its z integrand would be (1 + z')^(-3/2), which diverges as z' -> -1. expm1 keeps the bracket exact
-    # as z -> 0, where writing it as 1 - 1 / sqrt(1 + z) would lose most of the precision to cancellation.
+    # Einstein-de Sitter: a matter-only universe integrates to D_C = 2 (c / H0) (1 - (1 + z)^(-1/2)). expm1
+    # keeps the bracket exact as z -> 0, where 1 - 1 / sqrt(1 + z) would lose most of it to cancellation.
     if Om0 == 1.0:
         return (1.0 + z) * dist_hubble_mpc * -2.0 * math.expm1(-0.5 * math.log1p(z))
 
     nodes, weights = np.polynomial.legendre.leggauss(32)
 
-    if z < 0.0:
-        # substituting u here would stretch the range to (1, (1 + z)^(-1/2)], which runs away to infinity
-        # as z -> -1 while the integrand collapses into a spike at u = 1 that the nodes then miss
-        zhalfwidth = 0.5 * z
-        zvals = zhalfwidth * (nodes + 1.0)
-        integral = float(weights @ (1.0 / np.sqrt(Om0 * (1.0 + zvals) ** 3 + (1.0 - Om0)))) * zhalfwidth
-    else:
-        # half the width of the u range, i.e. (1 - (1 + z)^(-1/2)) / 2 without cancellation as z -> 0
-        uhalfwidth = -0.5 * math.expm1(-0.5 * math.log1p(z))
-        uvals = uhalfwidth * (nodes + 1.0) + (1.0 + z) ** -0.5
-        integral = float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * uhalfwidth
+    # Om0 > 1 leaves a negative dark energy density, which dominates nowhere, so there is no crossover
+    zcross = ((1.0 - Om0) / Om0) ** (1.0 / 3.0) - 1.0 if Om0 < 1.0 else -1.0
+    zlo, zhi = min(0.0, z), max(0.0, z)
+    zsplit = min(max(zcross, zlo), zhi)
 
-    return (1.0 + z) * dist_hubble_mpc * integral
+    integral = 0.0
+
+    if zsplit > zlo:
+        # below the crossover 1 / E varies by at most sqrt(2), so integrate it as it stands
+        halfwidth = 0.5 * (zsplit - zlo)
+        zvals = halfwidth * (nodes + 1.0) + zlo
+        integral += float(weights @ (1.0 / np.sqrt(Om0 * (1.0 + zvals) ** 3 + (1.0 - Om0)))) * halfwidth
+
+    if zhi > zsplit:
+        # above it, u = (1 + z')^(-1/2) flattens the (1 + z')^(-3/2) tail. Taking the width of the u range
+        # from the difference of the roots keeps it exact as the range shrinks onto z' = 0, where
+        # (1 + z')^(-1/2) - 1 would lose it to cancellation.
+        rootlo, roothi = math.sqrt(1.0 + zsplit), math.sqrt(1.0 + zhi)
+        halfwidth = 0.5 * (zhi - zsplit) / (rootlo * roothi * (rootlo + roothi))
+        uvals = halfwidth * (nodes + 1.0) + 1.0 / roothi
+        integral += float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * halfwidth
+
+    return (1.0 + z) * dist_hubble_mpc * (integral if z >= 0.0 else -integral)
 
 
 def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.DataFrame, dict[str, t.Any]]:

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -465,6 +465,34 @@ def read_hesma_lightcurve(args: argparse.Namespace) -> pl.DataFrame:
     return read_hesma_lightcurve_file(Path(at.get_path("artistools_dir"), "data/hesma", args.plot_hesma_model))
 
 
+def luminosity_distance(H0: float, Om0: float, z: float) -> float:
+    """Return the luminosity distance in Mpc to redshift z for a flat LambdaCDM cosmology.
+
+    H0 is the Hubble constant in km/s/Mpc and Om0 the present-day matter density parameter. Radiation is
+    neglected, so the dark energy density is 1 - Om0. The comoving distance
+
+        D_C = (c / H0) * int_0^z dz' / sqrt(Om0 (1 + z')^3 + 1 - Om0)
+
+    is rewritten with the substitution u = (1 + z')^(-1/2), which flattens the (1 + z')^(-3/2) tail into
+
+        D_C = (c / H0) * int_u(z)^1 2 du / sqrt(Om0 + (1 - Om0) u^6),
+
+    an entire function of u. Gauss-Legendre quadrature therefore converges to double precision with few
+    nodes for any z, and the luminosity distance is D_L = (1 + z) D_C.
+    """
+    nodes, weights = np.polynomial.legendre.leggauss(32)
+
+    # half the width of the u integration range, i.e. (1 - (1 + z)^(-1/2)) / 2 without cancellation as z -> 0
+    uhalfwidth = -0.5 * math.expm1(-0.5 * math.log1p(z))
+    uvals = uhalfwidth * (nodes + 1.0) + (1.0 + z) ** -0.5
+
+    integral = float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * uhalfwidth
+
+    dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
+
+    return (1.0 + z) * dist_hubble_mpc * integral
+
+
 def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.DataFrame, dict[str, t.Any]]:
     """Return an observed band light curve from the bundled reference data, along with its metadata."""
     filepath = Path(at.get_path("artistools_dir"), "data", "lightcurves", lightcurvefilename)
@@ -479,10 +507,7 @@ def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.Dat
 
     # m - M = 5log(d) - 5  Get absolute magnitude
     if "dist_mpc" not in metadata and "z" in metadata:
-        from astropy import cosmology
-
-        cosmo = cosmology.FlatLambdaCDM(H0=70, Om0=0.3)  # pyright: ignore[reportCallIssue] # pyrefly: ignore[unexpected-keyword]  # ty:ignore[unknown-argument]
-        metadata["dist_mpc"] = cosmo.luminosity_distance(metadata["z"]).value  # pyright: ignore[reportAttributeAccessIssue]  # ty:ignore[unresolved-attribute]
+        metadata["dist_mpc"] = luminosity_distance(H0=70.0, Om0=0.3, z=metadata["z"])
         print(f"luminosity distance from redshift = {metadata['dist_mpc']} for {metadata['label']}")
 
     magnitude = pl.col("magnitude").cast(pl.Float64)

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -479,7 +479,18 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 
     an entire function of u. Gauss-Legendre quadrature therefore converges to double precision with few
     nodes for any z, and the luminosity distance is D_L = (1 + z) D_C.
+
+    The quadrature is accurate to a few ulp for any matter density down to Om0 ~ 0.01. Below that the
+    integrand grows a plateau of height 2 / sqrt(Om0) that a fixed node count resolves less and less well,
+    reaching a relative error of ~1e-4 for Om0 ~ 1e-8 at z ~ 1e8, far outside any cosmology of interest.
     """
+    dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
+
+    # a matter-free universe expands with E(z) = 1, making the comoving distance exactly (c / H0) z. The
+    # transformed integrand is 2 / u^3 there, which diverges as u -> 0, so no quadrature rule would do.
+    if Om0 == 0.0:
+        return (1.0 + z) * dist_hubble_mpc * z
+
     nodes, weights = np.polynomial.legendre.leggauss(32)
 
     # half the width of the u integration range, i.e. (1 - (1 + z)^(-1/2)) / 2 without cancellation as z -> 0
@@ -487,8 +498,6 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
     uvals = uhalfwidth * (nodes + 1.0) + (1.0 + z) ** -0.5
 
     integral = float(weights @ (2.0 / np.sqrt(Om0 + (1.0 - Om0) * uvals**6))) * uhalfwidth
-
-    dist_hubble_mpc = (C_cm_per_s / 1e5) / H0  # c in km/s over H0 in km/s/Mpc
 
     return (1.0 + z) * dist_hubble_mpc * integral
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -227,14 +227,29 @@ def test_get_colour_delta_mag_unequal_sampling() -> None:
     ],
 )
 def test_luminosity_distance(z: float, dist_mpc: float) -> None:
-    """Reference values are astropy's FlatLambdaCDM(H0=70, Om0=0.3).luminosity_distance(z), which this replaced."""
-    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) == pytest.approx(dist_mpc, rel=1e-10, abs=1e-12)
+    """Reference values are astropy's FlatLambdaCDM(H0=70, Om0=0.3).luminosity_distance(z), which this replaced.
+
+    astropy evaluates the same Baes et al. (2017) function through scipy's hyp2f1 where this integrates it,
+    so the two agree to ~4e-14 and the tolerance is set well inside the 1e-10 that any use here needs.
+    """
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) == pytest.approx(dist_mpc, rel=1e-11, abs=1e-12)
 
 
 def test_luminosity_distance_planck18_parameters() -> None:
     """The cosmology parameters must be used, not baked in (reference values from astropy)."""
     for z, dist_mpc in ((0.01433, 64.43316428422708), (0.5, 2927.080479237606), (2.0, 15936.22617736705)):
-        assert at.lightcurve.luminosity_distance(H0=67.4, Om0=0.315, z=z) == pytest.approx(dist_mpc, rel=1e-10)
+        assert at.lightcurve.luminosity_distance(H0=67.4, Om0=0.315, z=z) == pytest.approx(dist_mpc, rel=1e-11)
+
+
+def test_luminosity_distance_negative_dark_energy() -> None:
+    """Om0 > 1 leaves a flat universe with a negative dark energy density, which is still integrable.
+
+    astropy's s = ((1 - Om0) / Om0)^(1/3) is a cube root of a negative number here, which it survives only
+    by carrying a complex s through and discarding the imaginary part. The u form never forms s at all, so
+    these come from adaptive quadrature rather than from astropy, which is itself ~7e-15 off at the first.
+    """
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.5, z=0.1) == pytest.approx(425.1405279377727, rel=1e-12)
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=2.0, z=1.0) == pytest.approx(4066.82076478827, rel=1e-12)
 
 
 def test_luminosity_distance_matter_only() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -252,6 +252,21 @@ def test_luminosity_distance_negative_dark_energy() -> None:
     assert at.lightcurve.luminosity_distance(H0=70.0, Om0=2.0, z=1.0) == pytest.approx(4066.82076478827, rel=1e-12)
 
 
+def test_luminosity_distance_past_turnaround_rejected() -> None:
+    """A negative dark energy density halts the expansion, and nothing beyond that turnaround has a distance.
+
+    E(z)^2 is negative there, which no domain check on z alone would catch. Below the turnaround the
+    quadrature returns a NaN that would reach the magnitudes as one, and immediately below it something
+    worse: the interior nodes still straddle positive radicands, so it returns a plausible finite number.
+    """
+    for Om0, z in ((2.0, -0.5), (2.0, -0.999), (1.5, -0.4), (1.5, -0.306638726649365)):
+        with pytest.raises(ValueError, match="stops expanding"):
+            at.lightcurve.luminosity_distance(H0=70.0, Om0=Om0, z=z)
+
+    # just above its turnaround of z = -0.2063 the distance exists and must still be returned
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=2.0, z=-0.1) == pytest.approx(-462.8923430069639, rel=1e-11)
+
+
 def test_luminosity_distance_matter_only() -> None:
     """For Om0 = 1 the integral is analytic: D_L = 2 (c / H0) (1 + z) (1 - 1 / sqrt(1 + z)).
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -245,6 +245,17 @@ def test_luminosity_distance_matter_only() -> None:
         assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-12)
 
 
+def test_luminosity_distance_matter_free() -> None:
+    """A matter-free universe expands with E(z) = 1, so D_L = (c / H0) z (1 + z) at every redshift.
+
+    The 2 / u^3 integrand of this limit defeats any fixed-node quadrature at high z, so it is a closed form.
+    """
+    hubble_dist_mpc = 299792.458 / 70.0
+    for z in (0.0, 0.01, 1.0, 1e3, 1e8):
+        expected = hubble_dist_mpc * z * (1.0 + z)
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.0, z=z) == pytest.approx(expected, rel=1e-13)
+
+
 def test_read_hesma_lightcurve_file_header(tmp_path: Path) -> None:
     """Column names must come from splitting the comment header into words, not into characters."""
     hesmafile = tmp_path / "hesma_model.dat"

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -280,8 +280,8 @@ def test_luminosity_distance_matter_only_tiny_redshift() -> None:
 def test_luminosity_distance_blueshift() -> None:
     """A blueshift is a valid redshift, and the closed forms hold for negative z as well.
 
-    The u substitution used for redshifts would stretch the integration range towards infinity as z -> -1,
-    so blueshifts integrate over z directly.
+    A blueshift lies below the crossover for any Om0 < 0.5, so these integrate over z rather than over u,
+    which would stretch the range towards infinity as z -> -1.
     """
     hubble_dist_mpc = 299792.458 / 70.0
     for z in (-1e-6, -0.001, -0.01, -0.1, -0.5, -0.9, -0.999999):
@@ -310,20 +310,39 @@ def test_luminosity_distance_below_minus_one_rejected() -> None:
 
 
 def test_luminosity_distance_quadrature_extremes() -> None:
-    """Pin the two ends of the range that the quadrature, rather than a closed form, has to cover.
+    """Pin the ends of the range that the quadrature, rather than a closed form, has to cover.
 
-    Om0 = 0.3 has no closed form, so both values come from the u substitution: at z -> 0 its integration
-    width needs expm1 to stay exact, and at very high z it needs the substitution itself to stay converged.
+    A tiny z falls on whichever side of the crossover z = 0 sits: below it for Om0 = 0.3, whose width is
+    z itself, and above it for Om0 = 0.9, whose width has to come from the difference of the roots.
     """
     hubble_dist_mpc = 299792.458 / 70.0
 
     # expanding the integrand gives D_L = (c / H0) z (1 + z) (1 - 3 Om0 z / 4 + O(z^2)) as z -> 0
-    for z in (1e-10, 1e-8):
-        expected = hubble_dist_mpc * z * (1.0 + z) * (1.0 - 0.75 * 0.3 * z)
-        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) == pytest.approx(expected, rel=1e-11, abs=0)
+    for Om0 in (0.3, 0.9):
+        for z in (1e-10, 1e-8):
+            expected = hubble_dist_mpc * z * (1.0 + z) * (1.0 - 0.75 * Om0 * z)
+            assert at.lightcurve.luminosity_distance(H0=70.0, Om0=Om0, z=z) == pytest.approx(expected, rel=1e-11, abs=0)
 
-    # adaptive quadrature in ln u, which resolves every regime of the integrand, gives 1415324782383.9055
+    # adaptive quadrature in ln(1 + z), which resolves every regime of the integrand, gives this
     assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=1e8) == pytest.approx(1415324782383.9055, rel=1e-11)
+
+
+def test_luminosity_distance_across_the_crossover() -> None:
+    """1 / E has a plateau below Om0 (1 + z')^3 = 1 - Om0 and a (1 + z')^(-3/2) tail above it.
+
+    Neither variable covers both once they differ by decades, which is why the range is split there. These
+    are the two ways that goes wrong with a single variable: integrating a strongly blueshifted, nearly
+    matter-only cosmology over z alone was 64% low, and taking a nearly matter-free one to high z over u
+    alone was ~1e-4 out. Reference values are from adaptive quadrature in ln(1 + z).
+    """
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1 - 1e-12, z=-0.999999) == pytest.approx(
+        -1.1881950472843847, rel=1e-11
+    )
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.999, z=-0.999999) == pytest.approx(
+        -0.02942354607438868, rel=1e-11
+    )
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1e-8, z=1e8) == pytest.approx(556188062894733.94, rel=1e-11)
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1e-4, z=1e5) == pytest.approx(25177127557.013027, rel=1e-11)
 
 
 def test_luminosity_distance_matter_free() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -213,6 +213,38 @@ def test_get_colour_delta_mag_unequal_sampling() -> None:
     assert colours == pytest.approx([0.5, 0.5])
 
 
+@pytest.mark.parametrize(
+    ("z", "dist_mpc"),
+    [
+        (0.0, 0.0),
+        (0.005791, 24.912483443375777),  # SN 1991T
+        (0.0133, 57.54493109140769),  # iPTF13ebh
+        (0.01433, 62.04993050233093),  # SN 1999dq
+        (0.1, 460.2999363904721),
+        (0.5, 2832.9380939001253),
+        (1.0, 6607.6576117749355),
+        (3.0, 25422.741745189862),
+    ],
+)
+def test_luminosity_distance(z: float, dist_mpc: float) -> None:
+    """Reference values are astropy's FlatLambdaCDM(H0=70, Om0=0.3).luminosity_distance(z), which this replaced."""
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) == pytest.approx(dist_mpc, rel=1e-10, abs=1e-12)
+
+
+def test_luminosity_distance_planck18_parameters() -> None:
+    """The cosmology parameters must be used, not baked in (reference values from astropy)."""
+    for z, dist_mpc in ((0.01433, 64.43316428422708), (0.5, 2927.080479237606), (2.0, 15936.22617736705)):
+        assert at.lightcurve.luminosity_distance(H0=67.4, Om0=0.315, z=z) == pytest.approx(dist_mpc, rel=1e-10)
+
+
+def test_luminosity_distance_matter_only() -> None:
+    """For Om0 = 1 the integral is analytic: D_L = 2 (c / H0) (1 + z) (1 - 1 / sqrt(1 + z))."""
+    hubble_dist_mpc = 299792.458 / 70.0
+    for z in (0.01, 0.5, 2.0, 10.0):
+        expected = 2 * hubble_dist_mpc * (1.0 + z) * (1.0 - 1.0 / np.sqrt(1.0 + z))
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-12)
+
+
 def test_read_hesma_lightcurve_file_header(tmp_path: Path) -> None:
     """Column names must come from splitting the comment header into words, not into characters."""
     hesmafile = tmp_path / "hesma_model.dat"

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -245,6 +245,31 @@ def test_luminosity_distance_matter_only() -> None:
         assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-12)
 
 
+def test_luminosity_distance_blueshift() -> None:
+    """A blueshift is a valid redshift, and the closed forms hold for negative z as well.
+
+    The u substitution used for redshifts would stretch the integration range towards infinity as z -> -1,
+    so blueshifts integrate over z directly.
+    """
+    hubble_dist_mpc = 299792.458 / 70.0
+    for z in (-1e-6, -0.001, -0.01, -0.1, -0.5, -0.9, -0.999999):
+        # Om0 = 0 has E(z) = 1, and Om0 = 1 integrates to 2 (1 + z) (1 - 1 / sqrt(1 + z))
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.0, z=z) == pytest.approx(
+            hubble_dist_mpc * z * (1.0 + z), rel=1e-13
+        )
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) < 0.0
+
+    # the mildly negative redshifts of nearby blueshifted galaxies are the only ones of practical interest
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=-0.001) == pytest.approx(-4.279429096775459)
+
+
+def test_luminosity_distance_below_minus_one_rejected() -> None:
+    """1 + z is a ratio of scale factors, so z <= -1 is not a redshift and must not silently give a NaN."""
+    for z in (-1.0, -1.5, -10.0):
+        with pytest.raises(ValueError, match="must be greater than -1"):
+            at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z)
+
+
 def test_luminosity_distance_matter_free() -> None:
     """A matter-free universe expands with E(z) = 1, so D_L = (c / H0) z (1 + z) at every redshift.
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -252,6 +252,32 @@ def test_luminosity_distance_negative_dark_energy() -> None:
     assert at.lightcurve.luminosity_distance(H0=70.0, Om0=2.0, z=1.0) == pytest.approx(4066.82076478827, rel=1e-12)
 
 
+def test_luminosity_distance_dense_matter() -> None:
+    """A negative dark energy density leaves an integrable pole in 1 / E at the turnaround.
+
+    The larger Om0 is, the closer that turnaround crowds up to z = 0 and the further its pole reaches, so
+    integrating over u alone ran 1.1% low for Om0 = 1e6 at z = 1 and ~1% over the last 0.01 in z above the
+    turnaround of any Om0 > 1. The first two values agree with adaptive quadrature in ln(1 + z), the third
+    with 32 to 1024 node rules in q, which converge where the adaptive routine warns and stops short.
+    """
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1e6, z=1.0) == pytest.approx(8.56941262664432, rel=1e-11)
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=100.0, z=1.0) == pytest.approx(803.7609074618974, rel=1e-11)
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1e6, z=1e-10) == pytest.approx(
+        4.28242824230702e-07, rel=1e-11, abs=0
+    )
+
+    # just above the turnaround of Om0 = 2, where 1 / E is unbounded and u alone was 1.3% out
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=2.0, z=-0.2062994740159002) == pytest.approx(
+        -1523.69803, rel=1e-6
+    )
+
+    # the q width has to come from the difference of cubes: taking qhi - qlo directly was 1.8e-7 out here
+    hubble_dist_mpc = 299792.458 / 70.0
+    for z in (1e-10, 1e-8):
+        expected = hubble_dist_mpc * z * (1.0 + z) * (1.0 - 0.75 * 5.0 * z)
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=5.0, z=z) == pytest.approx(expected, rel=1e-11, abs=0)
+
+
 def test_luminosity_distance_past_turnaround_rejected() -> None:
     """A negative dark energy density halts the expansion, and nothing beyond that turnaround has a distance.
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -238,11 +238,28 @@ def test_luminosity_distance_planck18_parameters() -> None:
 
 
 def test_luminosity_distance_matter_only() -> None:
-    """For Om0 = 1 the integral is analytic: D_L = 2 (c / H0) (1 + z) (1 - 1 / sqrt(1 + z))."""
+    """For Om0 = 1 the integral is analytic: D_L = 2 (c / H0) (1 + z) (1 - 1 / sqrt(1 + z)).
+
+    Its z integrand diverges as z' -> -1, so the blueshifts here are the ones quadrature cannot follow.
+    """
     hubble_dist_mpc = 299792.458 / 70.0
-    for z in (0.01, 0.5, 2.0, 10.0):
+    for z in (-0.999999, -0.99, -0.9, -0.01, 0.01, 0.5, 2.0, 10.0, 1e8):
         expected = 2 * hubble_dist_mpc * (1.0 + z) * (1.0 - 1.0 / np.sqrt(1.0 + z))
-        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-12)
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-10, abs=0)
+
+
+def test_luminosity_distance_matter_only_tiny_redshift() -> None:
+    """Expanding the Om0 = 1 closed form gives D_L = (c / H0) z (1 + z) (1 - 3z/4 + O(z^2)) as z -> 0.
+
+    The tolerance is tight enough to fail if that closed form is evaluated as 1 - 1 / sqrt(1 + z), which
+    loses all but a few digits to cancellation here (8e-8 relative at z = 1e-10).
+    """
+    hubble_dist_mpc = 299792.458 / 70.0
+    for z in (1e-10, 1e-8, 1e-6):
+        expected = hubble_dist_mpc * z * (1.0 + z) * (1.0 - 0.75 * z)
+        # abs=0 because these distances are ~1e-7 Mpc, so the default absolute tolerance of approx would
+        # swallow the cancellation error entirely
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=1.0, z=z) == pytest.approx(expected, rel=1e-11, abs=0)
 
 
 def test_luminosity_distance_blueshift() -> None:
@@ -253,14 +270,21 @@ def test_luminosity_distance_blueshift() -> None:
     """
     hubble_dist_mpc = 299792.458 / 70.0
     for z in (-1e-6, -0.001, -0.01, -0.1, -0.5, -0.9, -0.999999):
-        # Om0 = 0 has E(z) = 1, and Om0 = 1 integrates to 2 (1 + z) (1 - 1 / sqrt(1 + z))
+        # Om0 = 0 has E(z) = 1, so the comoving distance is exactly (c / H0) z
         assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.0, z=z) == pytest.approx(
-            hubble_dist_mpc * z * (1.0 + z), rel=1e-13
+            hubble_dist_mpc * z * (1.0 + z), rel=1e-13, abs=0
         )
         assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) < 0.0
 
     # the mildly negative redshifts of nearby blueshifted galaxies are the only ones of practical interest
     assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=-0.001) == pytest.approx(-4.279429096775459)
+
+    # at the edge of the domain a cosmology with no closed form has to come from the z quadrature: this
+    # value agrees with both a 2048-node rule and adaptive quadrature, where the u substitution used for
+    # redshifts would give a magnitude 41% too small
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=-0.999999) == pytest.approx(
+        -0.0048851852579134521, rel=1e-12, abs=0
+    )
 
 
 def test_luminosity_distance_below_minus_one_rejected() -> None:
@@ -268,6 +292,23 @@ def test_luminosity_distance_below_minus_one_rejected() -> None:
     for z in (-1.0, -1.5, -10.0):
         with pytest.raises(ValueError, match="must be greater than -1"):
             at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z)
+
+
+def test_luminosity_distance_quadrature_extremes() -> None:
+    """Pin the two ends of the range that the quadrature, rather than a closed form, has to cover.
+
+    Om0 = 0.3 has no closed form, so both values come from the u substitution: at z -> 0 its integration
+    width needs expm1 to stay exact, and at very high z it needs the substitution itself to stay converged.
+    """
+    hubble_dist_mpc = 299792.458 / 70.0
+
+    # expanding the integrand gives D_L = (c / H0) z (1 + z) (1 - 3 Om0 z / 4 + O(z^2)) as z -> 0
+    for z in (1e-10, 1e-8):
+        expected = hubble_dist_mpc * z * (1.0 + z) * (1.0 - 0.75 * 0.3 * z)
+        assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=z) == pytest.approx(expected, rel=1e-11, abs=0)
+
+    # adaptive quadrature in ln u, which resolves every regime of the integrand, gives 1415324782383.9055
+    assert at.lightcurve.luminosity_distance(H0=70.0, Om0=0.3, z=1e8) == pytest.approx(1415324782383.9055, rel=1e-11)
 
 
 def test_luminosity_distance_matter_free() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
 [project.optional-dependencies]
 # adding a package here also needs an entry in `ignore-missing-imports` under [tool.pyrefly]
 extras = [
-    "astropy>=7.2",
     "george>=0.4.4;python_version<'3.15'", # not compatible with 3.15 yet
     "imageio>=2.37.3",
     "plotly>=6.7.0",
@@ -208,7 +207,6 @@ python-interpreter-path = ".venv/bin/python3"
 # The [project.optional-dependencies] packages are absent from a plain `uv sync`, and zstandard is
 # not installed on 3.14+, so those resolve to Any rather than erroring.
 ignore-missing-imports = [
-    "astropy.*",
     "george",
     "george.*",
     "imageio.*",

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,6 @@ dependencies = [
 
 [package.optional-dependencies]
 extras = [
-    { name = "astropy" },
     { name = "george", marker = "python_full_version < '3.15'" },
     { name = "imageio" },
     { name = "plotly" },
@@ -64,7 +63,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "argcomplete", specifier = ">=3.6.3" },
-    { name = "astropy", marker = "extra == 'extras'", specifier = ">=7.2" },
     { name = "extinction", specifier = ">=0.4.7" },
     { name = "george", marker = "python_full_version < '3.15' and extra == 'extras'", specifier = ">=0.4.4" },
     { name = "imageio", marker = "extra == 'extras'", specifier = ">=2.37.3" },
@@ -163,38 +161,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/4a/587eb36dcc240a54c8660f599464516b469ecad96f0dbdb6bccbedb50745/ast_serialize-0.8.0-cp39-abi3-win32.whl", hash = "sha256:31883542dd6c94d178f5db3d32fbd69c5eb88b3a7c018e7ac8cc0c45195ddbed", size = 1068858, upload-time = "2026-08-07T11:28:57.541Z" },
     { url = "https://files.pythonhosted.org/packages/5f/a4/3e887bbd92164e183cb6e412c6a3e9198ddd446d7fe405958293ef5ef49c/ast_serialize-0.8.0-cp39-abi3-win_amd64.whl", hash = "sha256:861794565b06337005c1447ef23103a3d5a627d08bdc827870d00d0b28ef5f51", size = 1111839, upload-time = "2026-08-07T11:28:59Z" },
     { url = "https://files.pythonhosted.org/packages/25/6c/b400476d3ceba681ab929787edc9554f6d88fcc69435eb681b00fc0457a5/ast_serialize-0.8.0-cp39-abi3-win_arm64.whl", hash = "sha256:b2a5978662fd4db463dfb4b974d2b10ac6430b98f5333aabc7051909df3561d0", size = 1083655, upload-time = "2026-08-07T11:29:00.349Z" },
-]
-
-[[package]]
-name = "astropy"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "astropy-iers-data" },
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "pyerfa" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/c4/21be4313ddfde5f60e0607fd307f367b9e0f0bf153a89b10cbd036dd8cfd/astropy-8.0.1.tar.gz", hash = "sha256:45ca31d5b91fa294cd590a4791a32db94de7f9c8a343155f4d5877baa82351da", size = 7152500, upload-time = "2026-07-05T07:24:48.482Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/80/69a84af0b35d55a859cde38e16b71553840a156bdf7dc4b767ec2b2d2829/astropy-8.0.1-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:24813c764d5ea111e7f716127121e22a0cfe233ca1eac2ed23c4a3848390610e", size = 6635649, upload-time = "2026-07-05T07:24:31.957Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/34/074f367d5699a1008b24c50acc1539f05f2cfc881b1901f4b110d57eae20/astropy-8.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:222f0b9837e79fd3d101e6d4e4579e3aa98c490000bb01e35cd32fd3e3c12bf5", size = 6607950, upload-time = "2026-07-05T07:24:34.148Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/d29035da0a08e3b0b03d63abe9ce69b900d8ef7863dc557a2e34ebf56a4e/astropy-8.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a4044396c15969bb029b648521f7c25d294e982dbd23e7c2c7dd328178b8b98", size = 10414634, upload-time = "2026-07-05T07:24:36.129Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/14/6f4427419f8a02e1d0a885fb64d8d4454c5d443627aa7cb1a3a36e16abb7/astropy-8.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fa11d56855e10107ea2231a6b6a33dbf1edbea6890adf34634c1f1d8f25c5a5a", size = 10452095, upload-time = "2026-07-05T07:24:38.424Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ef/a5cf36a402c4511a776405f12d0b35196f55f4312ce407012a2fbcf1e4e0/astropy-8.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b482bc6c57c966e6c6234410a1d9afbcf92bcac858cf287812f8c99ddc3fafc", size = 10407732, upload-time = "2026-07-05T07:24:40.774Z" },
-    { url = "https://files.pythonhosted.org/packages/58/6d/59e7fb6f9ade53889c9553afff89991b8076c021581ba66eb51d913ca6c9/astropy-8.0.1-cp311-abi3-win32.whl", hash = "sha256:13a6ef59347a15c55406bb630e0d25d0248a179af84fae06a7ddb85a229065b2", size = 6394540, upload-time = "2026-07-05T07:24:43.146Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6a/8534fd98e2d3eb51cbaa261e6c6b59e4ad969a1787d72bb1208499080dbd/astropy-8.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:ee9024f2237243ebc98726f8eff2efbf201ea4e0bba1d21f6e2dee0cb499fbdf", size = 6529976, upload-time = "2026-07-05T07:24:44.693Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/df/96b8bf4ec218d03969a8b904ade5fc5b1a63f4a7f02c4e107b6264bcf152/astropy-8.0.1-cp311-abi3-win_arm64.whl", hash = "sha256:435e784f2cd9a4c31a03102e6ad27a51b901a8d5587bc78afe8d28e41eb44824", size = 6395252, upload-time = "2026-07-05T07:24:46.56Z" },
-]
-
-[[package]]
-name = "astropy-iers-data"
-version = "0.2026.8.10.0.32.39"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/36/f81b3202279d00e8c7f8f1e9506cfb2ad2b590cb1377caf50888f375fe85/astropy_iers_data-0.2026.8.10.0.32.39.tar.gz", hash = "sha256:2e5b9904f69ca69c7013170b2622b8818d443e10fdd5d501e1c2d298dd1e06dc", size = 1943087, upload-time = "2026-08-10T00:33:36.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/27/0775134a2a939ddf7a073e77e66110b671e99cefbc36fb57b57851fd109a/astropy_iers_data-0.2026.8.10.0.32.39-py3-none-any.whl", hash = "sha256:04239afd6e9615165b84da1b84d73f03ca473f0ddf53b516c260e27349a95d03", size = 1998788, upload-time = "2026-08-10T00:33:34.729Z" },
 ]
 
 [[package]]
@@ -1199,24 +1165,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "pyerfa"
-version = "2.0.1.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/71/39/63cc8291b0cf324ae710df41527faf7d331bce573899199d926b3e492260/pyerfa-2.0.1.5.tar.gz", hash = "sha256:17d6b24fe4846c65d5e7d8c362dcb08199dc63b30a236aedd73875cc83e1f6c0", size = 818430, upload-time = "2024-11-11T15:22:30.852Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/d9/3448a57cb5bd19950de6d6ab08bd8fbb3df60baa71726de91d73d76c481b/pyerfa-2.0.1.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b282d7c60c4c47cf629c484c17ac504fcb04abd7b3f4dfcf53ee042afc3a5944", size = 341818, upload-time = "2024-11-11T15:22:16.467Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4a/31a363370478b63c6289a34743f2ba2d3ae1bd8223e004d18ab28fb92385/pyerfa-2.0.1.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:be1aeb70390dd03a34faf96749d5cabc58437410b4aab7213c512323932427df", size = 329370, upload-time = "2024-11-11T15:22:17.829Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/96/b6210fc624123c8ae13e1eecb68fb75e3f3adff216d95eee1c7b05843e3e/pyerfa-2.0.1.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0603e8e1b839327d586c8a627cdc634b795e18b007d84f0cda5500a0908254e", size = 692794, upload-time = "2024-11-11T15:22:19.429Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/e0/050018d855d26d3c0b4a7d1b2ed692be758ce276d8289e2a2b44ba1014a5/pyerfa-2.0.1.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e43c7194e3242083f2350b46c09fd4bf8ba1bcc0ebd1460b98fc47fe2389906", size = 738711, upload-time = "2024-11-11T15:22:20.661Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f5/ff91ee77308793ae32fa1e1de95e9edd4551456dd888b4e87c5938657ca5/pyerfa-2.0.1.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:07b80cd70701f5d066b1ac8cce406682cfcd667a1186ec7d7ade597239a6021d", size = 722966, upload-time = "2024-11-11T15:22:21.905Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/56/b22b35c8551d2228ff8d445e63787112927ca13f6dc9e2c04f69d742c95b/pyerfa-2.0.1.5-cp39-abi3-win32.whl", hash = "sha256:d30b9b0df588ed5467e529d851ea324a67239096dd44703125072fd11b351ea2", size = 339955, upload-time = "2024-11-11T15:22:23.087Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/11/97233cf23ad5411ac6f13b1d6ee3888f90ace4f974d9bf9db887aa428912/pyerfa-2.0.1.5-cp39-abi3-win_amd64.whl", hash = "sha256:66292d437dcf75925b694977aa06eb697126e7b86553e620371ed3e48b5e0ad0", size = 349410, upload-time = "2024-11-11T15:22:24.817Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Adds `luminosity_distance(H0, Om0, z)` to `artistools/lightcurve/lightcurve.py` and drops `astropy` from the project entirely.

The only astropy use anywhere in artistools was one call in `read_reflightcurve_band_data`, deriving a distance for reference light curves whose metadata gives a redshift but no `dist_mpc`:

```python
cosmo = cosmology.FlatLambdaCDM(H0=70, Om0=0.3)  # pyright: ignore[...] # pyrefly: ignore[...] # ty:ignore[...]
metadata["dist_mpc"] = cosmo.luminosity_distance(metadata["z"]).value  # pyright: ignore[...] # ty:ignore[...]
```

That cost an optional dependency (astropy, astropy-iers-data, pyerfa) and five type-checker suppressions for astropy's untyped API. Both are gone.

## How it works

The new function evaluates the flat ΛCDM comoving integral `D_C = (c/H0) ∫₀ᶻ dz'/√(Om0(1+z')³ + 1−Om0)` and returns `(1+z)·D_C`. Two details are worth a reviewer's attention:

- **Substitution `u = (1+z')^(−1/2)`** turns the integrand into `2/√(Om0 + (1−Om0)u⁶)`, which is analytic and bounded over the whole range instead of decaying as `(1+z')^(−3/2)`. Gauss–Legendre then converges geometrically and 32 nodes are fully converged at any redshift; integrating in `z` directly needs hundreds of nodes past z≈10.
- **The integration half-width uses `expm1`/`log1p`.** Writing it as `(1 - (1+z)**-0.5)/2` loses roughly 8 significant digits at z≈1e-8.

## Accuracy

Agreement with `FlatLambdaCDM(H0=70, Om0=0.3)` is within astropy's own precision: max relative difference **4e-12** across z ∈ [1e-4, 1e6], and 0 ulp at several of the test redshifts. Checked against astropy for Om0 ∈ {0.05, 0.2, 0.27, 0.3, 0.315, 0.5, 1.0} before removing it.

Below z≈1e-6 the two diverge at the 1e-7 level, and there the new function is the more accurate one — it reproduces the exact `D_H·z(1+z)` limit that astropy's elliptic-integral path drifts away from. No bundled reference light curve is anywhere near that regime.

## Tests

`test_lightcurve.py` gains three tests: astropy reference values at the redshifts of the bundled reference SNe (SN 1991T, SN 1999dq, iPTF13ebh) plus a spread to z=3; a second cosmology (H0=67.4, Om0=0.315) to catch baked-in parameters; and an astropy-independent check against the closed form `D_L = 2(c/H0)(1+z)(1 − 1/√(1+z))` for Om0=1.

A useful independent anchor: the computed 62.0499 Mpc for SN 1999dq reproduces the `#dist_mpc: 62.05` commented out in that file's own metadata.

## Also

- Re-exported in `artistools/lightcurve/__init__.py`.
- Removed from `[project.optional-dependencies].extras` and from pyrefly's `ignore-missing-imports`; `uv lock` re-run.
- Removed astropy from the optional-dependency example in `AGENTS.md`.

`ruff format`, `ruff check --no-fix`, `mypy`, `pyrefly`, `ty`, the prek hooks, and `pytest artistools/lightcurve` (24 passed) are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)