### PR TITLE
Free the linelist before the code bins the contributions

### DIFF
--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -1394,6 +1394,9 @@ def get_flux_contributions_from_packets(
         dfpackets = dfpackets.join(
             emtypelabels.select(emtypecolumn, "emissiontype_str").collect(), on=emtypecolumn, how="left"
         ).drop(emtypecolumn)
+        # get_line_labels() puts the columns of the linelist in the plan of this frame. Delete the frame here,
+        # because the linelist is not free while a plan holds it, and the linelist can be hundreds of megabytes.
+        del emtypelabels
 
         if vpkt_match_emission_exclusion_to_opac and directionbins_are_vpkt_observers:
             assert vpkt_config is not None
@@ -1420,9 +1423,12 @@ def get_flux_contributions_from_packets(
         ])
 
         dfpackets = dfpackets.join(abstypelabels.collect(), on="absorption_type", how="left").drop("absorption_type")
+        del abstypelabels
 
     # The label column and the frequency column of each type of contribution.
     # When the code bins one type, it removes the columns of the other type.
+    del dflines
+
     emission_columns = ("emissiontype_str", dirbin_nu_column)
     absorption_columns = ("absorptiontype_str", "absorption_freq")
 
@@ -1451,7 +1457,7 @@ def get_flux_contributions_from_packets(
     if getabsorption:
         absorptiongroups = group_by_label(dfpackets, absorption_columns, emission_columns)
 
-    del dfpackets, dflines
+    del dfpackets
 
     group_e_rf_sum: dict[str, float] = {}
     for groups in (emissiongroups, absorptiongroups):


### PR DESCRIPTION
## The problem

`get_line_labels()` puts the columns of the linelist into the query plan of the label frame, as literals. The emission label frame and the absorption label frame therefore hold the linelist until the function returns. A linelist can be hundreds of megabytes, and a delete of the linelist name alone does not make that memory free, because the two plans still refer to it.

## The change

The code deletes each label frame after its join, and the linelist before it bins the groups. That is seven lines.

## The results

The contributions and the times do not change. These are the peak memory values, from four runs of each command with the first run discarded.

| Model | Group | Before | After |
|---|---|---|---|
| kilonova, 2e8 packets, 48.8M lines | ion | 3.17 GB | **2.86 GB** (−10%) |
| kilonova | line | 3.36 GB | **2.75 GB** (−18%) |
| W7, 2e9 packets, 2.8M lines | ion | 1.45 GB | **1.41 GB** (−3%) |
| W7 | line | 1.51 GB | **1.49 GB** (−1%) |

The gain follows the size of the linelist. A model with a large linelist gains; W7 has a linelist 17 times shorter and gains little.

## What this pull request no longer contains

An earlier version of this branch also binned every contribution group in one operation. That method made the line group 1.8 times faster, but it made the ion group 5% slower and it needed five new concepts to read: an Enum label code, one group operation on two integers, a sparse result, a scatter into a dense array, and a discard row. Three review rounds found twelve defects in it. The owner judged that the cost in reading the code was higher than the gain, so this branch keeps the memory change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)