### PR TITLE
Give the reference light curves the grey colours

### DIFF
--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -135,6 +135,7 @@ from artistools.misc import parallel_map as parallel_map
 from artistools.misc import parse_cli_args as parse_cli_args
 from artistools.misc import parse_range as parse_range
 from artistools.misc import parse_range_list as parse_range_list
+from artistools.misc import path_is_artis_model as path_is_artis_model
 from artistools.misc import print_saved as print_saved
 from artistools.misc import print_theta_phi_definitions as print_theta_phi_definitions
 from artistools.misc import read_rank_outputfiles as read_rank_outputfiles

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -3,6 +3,7 @@
 __all__ = ["plot", "plotlightcurve"]
 
 from artistools.lightcurve import plotlightcurve
+from artistools.lightcurve.lightcurve import find_bol_reflightcurve_file as find_bol_reflightcurve_file
 from artistools.lightcurve.lightcurve import generate_band_lightcurve_data as generate_band_lightcurve_data
 from artistools.lightcurve.lightcurve import get_band_lightcurve as get_band_lightcurve
 from artistools.lightcurve.lightcurve import get_colour_delta_mag as get_colour_delta_mag
@@ -10,6 +11,7 @@ from artistools.lightcurve.lightcurve import get_filter_data as get_filter_data
 from artistools.lightcurve.lightcurve import get_from_packets as get_from_packets
 from artistools.lightcurve.lightcurve import get_phillips_relation_data as get_phillips_relation_data
 from artistools.lightcurve.lightcurve import luminosity_distance as luminosity_distance
+from artistools.lightcurve.lightcurve import path_is_reference_lightcurve as path_is_reference_lightcurve
 from artistools.lightcurve.lightcurve import read_bol_reflightcurve_data as read_bol_reflightcurve_data
 from artistools.lightcurve.lightcurve import read_hesma_lightcurve as read_hesma_lightcurve
 from artistools.lightcurve.lightcurve import read_hesma_lightcurve_file as read_hesma_lightcurve_file

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -19,6 +19,8 @@ import artistools as at
 from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
+from artistools.misc import path_is_artis_model
+from artistools.misc.fileio import find_compressed
 
 # ARTIS writes the Sloan filters with a trailing "s"; map them back to the conventional single-letter names
 FILTERNAME_ALIASES: t.Final[Mapping[str, str]] = MappingProxyType({"rs": "r", "gs": "g", "is": "i", "zs": "z"})
@@ -599,21 +601,27 @@ def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.Dat
 
 
 def find_bol_reflightcurve_file(lightcurvefilename: str | Path) -> Path | None:
-    """Return the path of a bolometric reference light curve file, or None if no such file exists.
+    """Return the path of a file with a reference light curve, or None if no such file exists.
 
     The file is either at the given path, or in the bundled data/lightcurves/bollightcurves folder.
+    A compressed file with the same name is also accepted.
     """
-    if Path(lightcurvefilename).is_file():
-        return Path(lightcurvefilename)
+    bundledfolder = Path(at.get_path("artistools_dir"), "data/lightcurves/bollightcurves")
+    for folder in (Path(), bundledfolder):
+        filepath = Path(folder, lightcurvefilename)
+        if filepath.is_file():
+            return filepath
 
-    bundledpath = Path(at.get_path("artistools_dir"), "data/lightcurves/bollightcurves", lightcurvefilename)
+        compressedfile = find_compressed(filepath)
+        if compressedfile is not None:
+            return compressedfile[1]
 
-    return bundledpath if bundledpath.is_file() else None
+    return None
 
 
 def path_is_reference_lightcurve(filepath: str | Path) -> bool:
     """Return whether the path is a bolometric reference light curve file and not an ARTIS model."""
-    return not at.path_is_artis_model(filepath) and find_bol_reflightcurve_file(filepath) is not None
+    return not path_is_artis_model(filepath) and find_bol_reflightcurve_file(filepath) is not None
 
 
 def read_bol_reflightcurve_data(lightcurvefilename: str | Path) -> tuple[pl.DataFrame, dict[str, t.Any]]:

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -598,13 +598,30 @@ def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.Dat
     return lightcurve_data, metadata
 
 
+def find_bol_reflightcurve_file(lightcurvefilename: str | Path) -> Path | None:
+    """Return the path of a bolometric reference light curve file, or None if no such file exists.
+
+    The file is either at the given path, or in the bundled data/lightcurves/bollightcurves folder.
+    """
+    if Path(lightcurvefilename).is_file():
+        return Path(lightcurvefilename)
+
+    bundledpath = Path(at.get_path("artistools_dir"), "data/lightcurves/bollightcurves", lightcurvefilename)
+
+    return bundledpath if bundledpath.is_file() else None
+
+
+def path_is_reference_lightcurve(filepath: str | Path) -> bool:
+    """Return whether the path is a bolometric reference light curve file and not an ARTIS model."""
+    return not at.path_is_artis_model(filepath) and find_bol_reflightcurve_file(filepath) is not None
+
+
 def read_bol_reflightcurve_data(lightcurvefilename: str | Path) -> tuple[pl.DataFrame, dict[str, t.Any]]:
     """Return an observed bolometric light curve and its metadata, from a given path or the bundled reference data."""
-    data_path = (
-        Path(lightcurvefilename)
-        if Path(lightcurvefilename).is_file()
-        else Path(at.get_path("artistools_dir"), "data/lightcurves/bollightcurves", lightcurvefilename)
-    )
+    data_path = find_bol_reflightcurve_file(lightcurvefilename)
+    if data_path is None:
+        msg = f"Reference light curve file not found: {lightcurvefilename}"
+        raise FileNotFoundError(msg)
 
     metadata = at.get_file_metadata(data_path)
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -27,6 +27,7 @@ from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Msun_to_g
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
+from artistools.lightcurve.lightcurve import path_is_reference_lightcurve
 from artistools.misc import add_axis_limit_args
 from artistools.misc import add_figscale_args
 from artistools.misc import add_filter_args
@@ -35,6 +36,7 @@ from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_series_style_args
 from artistools.misc import print_theta_phi_definitions
+from artistools.plottools import get_series_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 
@@ -558,18 +560,18 @@ def make_lightcurve_plot(
         for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"])
         if f"C{i}" not in args.color and color not in args.color
     ]
-    axis.set_prop_cycle(color=colors)
-    reflightcurveindex = 0
+    if colors:
+        axis.set_prop_cycle(color=colors)
 
     plottedsomething = False
     lcindex = 0
     for modelpath in modelpaths:
-        if not Path(modelpath).is_dir() and not Path(modelpath).exists() and "." in str(modelpath):
+        if path_is_reference_lightcurve(modelpath):
             bolreflightcurve = Path(modelpath)
 
             dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
             lightcurvelabel = args.label[lcindex] or metadata.get("label", bolreflightcurve)
-            color = args.color[lcindex] or ["0.0", "0.5", "0.7"][reflightcurveindex]
+            color = args.color[lcindex]
             if (
                 "luminosity_errminus_erg/s" in dflightcurve.columns
                 and "luminosity_errplus_erg/s" in dflightcurve.columns
@@ -593,7 +595,6 @@ def make_lightcurve_plot(
                     zorder=0,
                 )
             print(f"====> {lightcurvelabel}")
-            reflightcurveindex += 1
             plottedsomething = True
 
         else:
@@ -661,7 +662,7 @@ def make_lightcurve_plot(
             lcindex += 1
 
     if args.reflightcurves:
-        for bolreflightcurve in args.reflightcurves:
+        for refindex, bolreflightcurve in enumerate(args.reflightcurves):
             if args.Lsun:
                 print("Check units - trying to plot ref light curve in erg/s")
                 sys.exit(1)
@@ -670,7 +671,7 @@ def make_lightcurve_plot(
                 bollightcurve_data["time_days"],
                 bollightcurve_data["luminosity_erg/s"],
                 label=metadata.get("label", bolreflightcurve),
-                color="k",
+                color=args.refspeccolors[refindex],
             )
             plottedsomething = True
 
@@ -1011,23 +1012,19 @@ def make_band_lightcurves_plot(
                         print("already plotted reflightcurve")
                     else:
                         assert isinstance(ax, mplax.Axes)
-                        define_colours_list = args.refspeccolors
                         markers = args.refspecmarkers
                         for i, reflightcurve in enumerate(args.reflightcurves):
                             plot_lightcurve_from_refdata(
                                 list(band_lightcurve_data.keys()),
                                 reflightcurve,
-                                define_colours_list[i],
-                                markers[i],
+                                args.refspeccolors[i],
+                                markers[i % len(markers)],
                                 ax,
                                 plotnumber,
                             )
 
                 if len(dirbins) == 1:
-                    if args.color:
-                        plotkwargs["color"] = args.color[modelnumber]
-                    else:
-                        plotkwargs["color"] = define_colours_list[modelnumber]
+                    plotkwargs["color"] = args.color[modelnumber]
 
                 if args.colorbarcostheta or args.colorbarphi:
                     # Update plotkwargs with viewing angle colour
@@ -1121,7 +1118,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                                 filter_names,
                                 reflightcurve,
                                 args.refspeccolors[i],
-                                args.refspecmarkers[i],
+                                args.refspecmarkers[i % len(args.refspecmarkers)],
                                 ax,
                                 plotnumber,
                                 args,
@@ -1315,7 +1312,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         helptext="Path(s) to ARTIS folders with light_curve.out or packets files (may include wildcards such as * and **)",
     )
 
-    add_series_style_args(parser, colordefault=[f"C{i}" for i in range(10)])
+    add_series_style_args(parser)
 
     parser.add_argument("--nolegend", action="store_true", help="Suppress the legend from the plot")
 
@@ -1432,9 +1429,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Also plot reference lightcurves from these files",
     )
 
-    parser.add_argument(
-        "-refspeccolors", default=["0.0", "0.3", "0.5"], nargs="*", help="Set a list of color for reference spectra"
-    )
+    parser.add_argument("-refspeccolors", default=[], nargs="*", help="Set a list of color for reference spectra")
 
     parser.add_argument(
         "-refspecmarkers", default=["o", "s", "h"], nargs="*", help="Set a list of markers for reference spectra"
@@ -1577,6 +1572,18 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     args.color, args.label, args.linestyle, args.dashes, args.linewidth = at.trim_or_pad(
         len(args.modelpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth
     )
+
+    # the reference data get black and greys, and the ARTIS models get the colour cycle
+    defaultcolors = get_series_colors([path_is_reference_lightcurve(path) for path in args.modelpath])
+    args.color = [color or defaultcolor for color, defaultcolor in zip(args.color, defaultcolors, strict=True)]
+
+    if args.reflightcurves:
+        # a -refspeccolors list that is too short gets the default colours for the remaining series
+        refcolors = at.trim_or_pad(len(args.reflightcurves), args.refspeccolors)[0]
+        defaultrefcolors = get_series_colors([True] * len(args.reflightcurves))
+        args.refspeccolors = [
+            color or defaultcolor for color, defaultcolor in zip(refcolors, defaultrefcolors, strict=True)
+        ]
 
     if args.rpkt is False and not args.gamma:
         # if we're not plotting gamma, then we want to plot the r-packets by default

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -35,10 +35,13 @@ from artistools.misc import add_maxpacketfiles_arg
 from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_series_style_args
+from artistools.misc import makelist
 from artistools.misc import print_theta_phi_definitions
+from artistools.misc import trim_or_pad
 from artistools.plottools import get_series_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
+from artistools.plottools import set_prop_cycle_unusedcolors
 
 
 def plot_deposition_thermalisation(
@@ -554,18 +557,10 @@ def make_lightcurve_plot(
     else:
         axistherm = None
 
-    # take any specified colours out of the cycle
-    colors = [
-        color
-        for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"])
-        if f"C{i}" not in args.color and color not in args.color
-    ]
-    if colors:
-        axis.set_prop_cycle(color=colors)
+    set_prop_cycle_unusedcolors([axis], [*args.color, *args.refspeccolors])
 
     plottedsomething = False
-    lcindex = 0
-    for modelpath in modelpaths:
+    for lcindex, modelpath in enumerate(modelpaths):
         if path_is_reference_lightcurve(modelpath):
             bolreflightcurve = Path(modelpath)
 
@@ -658,9 +653,6 @@ def make_lightcurve_plot(
 
         print()
 
-        if plottedsomething:
-            lcindex += 1
-
     if args.reflightcurves:
         for refindex, bolreflightcurve in enumerate(args.reflightcurves):
             if args.Lsun:
@@ -675,7 +667,7 @@ def make_lightcurve_plot(
             )
             plottedsomething = True
 
-    assert plottedsomething
+    assert plottedsomething, "No light curve was plotted"
 
     if not args.nolegend:
         axis.legend(loc="best", handlelength=2, frameon=args.legendframeon, numpoints=1, prop={"size": 9})
@@ -1012,13 +1004,12 @@ def make_band_lightcurves_plot(
                         print("already plotted reflightcurve")
                     else:
                         assert isinstance(ax, mplax.Axes)
-                        markers = args.refspecmarkers
                         for i, reflightcurve in enumerate(args.reflightcurves):
                             plot_lightcurve_from_refdata(
                                 list(band_lightcurve_data.keys()),
                                 reflightcurve,
                                 args.refspeccolors[i],
-                                markers[i % len(markers)],
+                                args.refspecmarkers[i],
                                 ax,
                                 plotnumber,
                             )
@@ -1118,7 +1109,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                                 filter_names,
                                 reflightcurve,
                                 args.refspeccolors[i],
-                                args.refspecmarkers[i % len(args.refspecmarkers)],
+                                args.refspecmarkers[i],
                                 ax,
                                 plotnumber,
                                 args,
@@ -1429,10 +1420,12 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Also plot reference lightcurves from these files",
     )
 
-    parser.add_argument("-refspeccolors", default=[], nargs="*", help="Set a list of color for reference spectra")
+    parser.add_argument(
+        "-refspeccolors", default=[], nargs="*", help="Set a list of colors for the reference light curves"
+    )
 
     parser.add_argument(
-        "-refspecmarkers", default=["o", "s", "h"], nargs="*", help="Set a list of markers for reference spectra"
+        "-refspecmarkers", default=[], nargs="*", help="Set a list of markers for the reference light curves"
     )
 
     add_filter_args(parser)
@@ -1569,21 +1562,27 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     modelpaths = args.modelpath
 
-    args.color, args.label, args.linestyle, args.dashes, args.linewidth = at.trim_or_pad(
+    args.color, args.label, args.linestyle, args.dashes, args.linewidth = trim_or_pad(
         len(args.modelpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth
     )
 
-    # the reference data get black and greys, and the ARTIS models get the colour cycle
-    defaultcolors = get_series_colors([path_is_reference_lightcurve(path) for path in args.modelpath])
-    args.color = [color or defaultcolor for color, defaultcolor in zip(args.color, defaultcolors, strict=True)]
+    args.reflightcurves = makelist(args.reflightcurves)
+    args.refspeccolors, args.refspecmarkers = trim_or_pad(
+        len(args.reflightcurves), args.refspeccolors, args.refspecmarkers
+    )
 
-    if args.reflightcurves:
-        # a -refspeccolors list that is too short gets the default colours for the remaining series
-        refcolors = at.trim_or_pad(len(args.reflightcurves), args.refspeccolors)[0]
-        defaultrefcolors = get_series_colors([True] * len(args.reflightcurves))
-        args.refspeccolors = [
-            color or defaultcolor for color, defaultcolor in zip(refcolors, defaultrefcolors, strict=True)
-        ]
+    # the reference data get black and greys, and the ARTIS models get the colours of the cycle
+    isreference = [path_is_reference_lightcurve(path) for path in args.modelpath]
+    seriescolors = get_series_colors(
+        [*isreference, *([True] * len(args.reflightcurves))], [*args.color, *args.refspeccolors]
+    )
+    args.color = seriescolors[: len(args.modelpath)]
+    args.refspeccolors = seriescolors[len(args.modelpath) :]
+
+    defaultmarkers = ("o", "s", "h")
+    args.refspecmarkers = [
+        marker or defaultmarkers[i % len(defaultmarkers)] for i, marker in enumerate(args.refspecmarkers)
+    ]
 
     if args.rpkt is False and not args.gamma:
         # if we're not plotting gamma, then we want to plot the r-packets by default

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -418,3 +418,19 @@ def test_read_hesma_lightcurve_file_no_header(tmp_path: Path) -> None:
 
     assert list(dfhesma.columns) == ["time", "bol"]
     assert dfhesma["bol"].to_list() == [2.0, 4.0]
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_lightcurve_plot_reference_colors(mockplot: t.Any, mockerrorbar: t.Any) -> None:
+    """The reference light curves get black and then grey, and the model keeps the first colour of the cycle."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=["AT2017gfo_smarttetal2017.txt", modelpath, "AT2017gfo_waxmanetal2018.txt"],
+        outputfile=outputpath,
+    )
+
+    assert [callargs.kwargs["color"] for callargs in mockerrorbar.call_args_list] == ["0.0", "0.4"]
+
+    modelcolors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list if "color" in callargs.kwargs]
+    assert modelcolors == ["C0"]

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -434,3 +434,46 @@ def test_lightcurve_plot_reference_colors(mockplot: t.Any, mockerrorbar: t.Any) 
 
     modelcolors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list if "color" in callargs.kwargs]
     assert modelcolors == ["C0"]
+
+
+@mock.patch.object(mplax.Axes, "scatter", side_effect=mplax.Axes.scatter, autospec=True)
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_lightcurve_plot_reflightcurves_continue_the_greys(mockerrorbar: t.Any, mockscatter: t.Any) -> None:
+    """A -reflightcurves file follows the reference files of the model path list, thus no two series are black."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath, "AT2017gfo_smarttetal2017.txt"],
+        reflightcurves=["AT2017gfo_waxmanetal2018.txt"],
+        outputfile=outputpath,
+    )
+
+    assert [callargs.kwargs["color"] for callargs in mockerrorbar.call_args_list] == ["0.0"]
+    assert [callargs.kwargs["color"] for callargs in mockscatter.call_args_list] == ["0.4"]
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_lightcurve_plot_colors_survive_a_skipped_model(mockplot: t.Any, mockerrorbar: t.Any) -> None:
+    """A model path that plots nothing must not shift the colour of every later series."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=["nonexistentmodelfolder", "AT2017gfo_smarttetal2017.txt", modelpath],
+        outputfile=outputpath,
+    )
+
+    assert [callargs.kwargs["color"] for callargs in mockerrorbar.call_args_list] == ["0.0"]
+
+    modelcolors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list if "color" in callargs.kwargs]
+    assert modelcolors == ["C1"]
+
+
+def test_find_bol_reflightcurve_file_reads_a_compressed_file(tmp_path: Path) -> None:
+    """A reference light curve that is compressed must be found under the name of the plain file."""
+    import lzma
+
+    with lzma.open(tmp_path / "myref.txt.xz", "wt", encoding="utf-8") as compressedfile:
+        compressedfile.write("#time_days lum\n1.0 2.0\n")
+
+    assert at.lightcurve.find_bol_reflightcurve_file(tmp_path / "myref.txt") == tmp_path / "myref.txt.xz"
+    assert at.lightcurve.path_is_reference_lightcurve(tmp_path / "myref.txt")
+    assert at.lightcurve.find_bol_reflightcurve_file(tmp_path / "notafile.txt") is None

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -41,6 +41,7 @@ from artistools.misc.fileio import firstexisting as firstexisting
 from artistools.misc.fileio import firstexisting_or_none as firstexisting_or_none
 from artistools.misc.fileio import get_file_metadata as get_file_metadata
 from artistools.misc.fileio import merge_pdf_files as merge_pdf_files
+from artistools.misc.fileio import path_is_artis_model as path_is_artis_model
 from artistools.misc.fileio import print_saved as print_saved
 from artistools.misc.fileio import read_wsv as read_wsv
 from artistools.misc.fileio import readnoncommentline as readnoncommentline

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -302,6 +302,11 @@ def stripallsuffixes(f: Path) -> Path:
     return f_nosuffixes
 
 
+def path_is_artis_model(filepath: Path | str) -> bool:
+    """Return whether the path is an ARTIS model and not a reference data file."""
+    return Path(filepath).name.endswith((".out", ".out.zst")) or Path(filepath).is_dir()
+
+
 def readnoncommentline(file: io.TextIOBase) -> str:
     """Read a line from the text file, skipping blank and comment lines that begin with #.
 

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -303,8 +303,13 @@ def stripallsuffixes(f: Path) -> Path:
 
 
 def path_is_artis_model(filepath: Path | str) -> bool:
-    """Return whether the path is an ARTIS model and not a reference data file."""
-    return Path(filepath).name.endswith((".out", ".out.zst")) or Path(filepath).is_dir()
+    """Return whether the path is an ARTIS model and not a reference data file.
+
+    An ARTIS model is a folder, or an output file of ARTIS that is possibly compressed.
+    """
+    filepath = Path(filepath)
+
+    return filepath.is_dir() or filepath.name.endswith((".out", *(f".out{ext}" for ext in COMPRESSED_EXTENSIONS)))
 
 
 def readnoncommentline(file: io.TextIOBase) -> str:

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -282,30 +282,51 @@ glasbey_category20_nogreys = [
     color for color in glasbey_category20 if color[0] != color[1] or color[1] != color[2] or color[0] != color[2]
 ]
 
-# the plot colours of the reference data series, in the order that they are used
+# the plot colours of the reference data series, in the order that the code uses them
 refseries_colors = ("0.0", "0.4", "0.6", "0.7")
 
 
-def get_series_colors(isreference: Sequence[bool]) -> list[str]:
-    """Return the default plot colour of each data series.
+def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | None] = ()) -> list[str]:
+    """Return the plot colour of each data series.
 
-    The first reference data series get black and then lighter greys. The other series, and the reference
-    series after the greys, get the colours of the matplotlib colour cycle in order.
+    A colour in usercolors has priority. The first reference data series get black and then lighter greys.
+    The other series, and the reference series after the greys, get the colours of the matplotlib cycle.
+    The code skips a colour of the cycle that the user asked for, thus two series do not get one colour.
     """
-    cyclecolorcount = len(plt.rcParams["axes.prop_cycle"])
+    askedfor = {color for color in usercolors if color}
     colors: list[str] = []
     refindex = 0
     cycleindex = 0
-    for isref in isreference:
-        if isref and refindex < len(refseries_colors):
+    for seriesindex, isref in enumerate(isreference):
+        usercolor = usercolors[seriesindex] if seriesindex < len(usercolors) else None
+        if usercolor:
+            colors.append(usercolor)
+        elif isref and refindex < len(refseries_colors):
             colors.append(refseries_colors[refindex])
-        else:
-            colors.append(f"C{cycleindex % cyclecolorcount}")
-            cycleindex += 1
-        if isref:
             refindex += 1
+        else:
+            while f"C{cycleindex}" in askedfor:
+                cycleindex += 1
+            colors.append(f"C{cycleindex}")
+            cycleindex += 1
 
     return colors
+
+
+def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequence[str | None]) -> None:
+    """Remove the colours of seriescolors from the colour cycle of each axis.
+
+    A series that gets its colour from the cycle, e.g. an extra direction bin, then does not
+    repeat the colour of another series.
+    """
+    colors = [
+        color
+        for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+        if f"C{i}" not in seriescolors and color not in seriescolors
+    ]
+    if colors:
+        for axis in axes:
+            axis.set_prop_cycle(color=colors)
 
 
 def set_mpl_style() -> None:

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -3,6 +3,7 @@
 import argparse
 import typing as t
 from collections.abc import Iterable
+from collections.abc import Sequence
 
 import matplotlib.axes as mplax
 import matplotlib.axis as mplaxis
@@ -280,6 +281,31 @@ glasbey_category20 = [
 glasbey_category20_nogreys = [
     color for color in glasbey_category20 if color[0] != color[1] or color[1] != color[2] or color[0] != color[2]
 ]
+
+# the plot colours of the reference data series, in the order that they are used
+refseries_colors = ("0.0", "0.4", "0.6", "0.7")
+
+
+def get_series_colors(isreference: Sequence[bool]) -> list[str]:
+    """Return the default plot colour of each data series.
+
+    The first reference data series get black and then lighter greys. The other series, and the reference
+    series after the greys, get the colours of the matplotlib colour cycle in order.
+    """
+    cyclecolorcount = len(plt.rcParams["axes.prop_cycle"])
+    colors: list[str] = []
+    refindex = 0
+    cycleindex = 0
+    for isref in isreference:
+        if isref and refindex < len(refseries_colors):
+            colors.append(refseries_colors[refindex])
+        else:
+            colors.append(f"C{cycleindex % cyclecolorcount}")
+            cycleindex += 1
+        if isref:
+            refindex += 1
+
+    return colors
 
 
 def set_mpl_style() -> None:

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -291,9 +291,16 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
 
     A colour in usercolors has priority. The first reference data series get black and then lighter greys.
     The other series, and the reference series after the greys, get the colours of the matplotlib cycle.
-    The code skips a colour of the cycle that the user asked for, thus two series do not get one colour.
+    The code steps over a colour that the user asked for, thus two series do not get one colour.
     """
     askedfor = {color for color in usercolors if color}
+    cyclecolors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+
+    # the colours of the cycle that no series has, by either the name CN or the colour value
+    freecycleindices = [
+        i for i in range(len(cyclecolors)) if f"C{i}" not in askedfor and cyclecolors[i] not in askedfor
+    ] or list(range(max(len(cyclecolors), 1)))
+
     colors: list[str] = []
     refindex = 0
     cycleindex = 0
@@ -301,13 +308,17 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
         usercolor = usercolors[seriesindex] if seriesindex < len(usercolors) else None
         if usercolor:
             colors.append(usercolor)
-        elif isref and refindex < len(refseries_colors):
+            continue
+
+        # step over a colour that the user asked for, thus two series do not get one colour
+        while isref and refindex < len(refseries_colors) and refseries_colors[refindex] in askedfor:
+            refindex += 1
+
+        if isref and refindex < len(refseries_colors):
             colors.append(refseries_colors[refindex])
             refindex += 1
         else:
-            while f"C{cycleindex}" in askedfor:
-                cycleindex += 1
-            colors.append(f"C{cycleindex}")
+            colors.append(f"C{freecycleindices[cycleindex % len(freecycleindices)]}")
             cycleindex += 1
 
     return colors

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -59,6 +59,7 @@ from artistools.plottools import get_series_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_mpl_style
 from artistools.plottools import set_plot_title
+from artistools.plottools import set_prop_cycle_unusedcolors
 from artistools.spectra.writespectra import write_flambda_spectra
 
 if t.TYPE_CHECKING:
@@ -630,13 +631,8 @@ def make_spectrum_plot(
     refspecindex = 0
     seriesindex = 0
 
-    # take any specified colours our of the cycle
-    colors = [
-        color for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"]) if f"C{i}" not in args.color
-    ]
+    set_prop_cycle_unusedcolors(axes, args.color)
     for axis in axes:
-        if colors:
-            axis.set_prop_cycle(color=colors)
         axis.margins(0.0, 0.0)
 
     for seriesindex, specpath in enumerate(speclist):
@@ -1505,9 +1501,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.multispecplot = True
         args.timedays = args.timedayslist[0]
 
-    if not args.color:
-        # the reference spectra get black and greys, and the ARTIS models get the colour cycle
-        args.color = get_series_colors([not path_is_artis_model(filepath) for filepath in args.specpath])
+    # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
+    args.color = get_series_colors([not path_is_artis_model(filepath) for filepath in args.specpath], args.color)
 
     if args.distmpc is None:
         for filepath in args.specpath:

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -45,6 +45,7 @@ from artistools.misc import get_model_name
 from artistools.misc import get_time_range
 from artistools.misc import get_vpkt_config
 from artistools.misc import get_vspec_dir_labels
+from artistools.misc import makelist
 from artistools.misc import match_closest_time
 from artistools.misc import normalize_path_list
 from artistools.misc import parse_cli_args
@@ -1502,7 +1503,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.timedays = args.timedayslist[0]
 
     # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
-    args.color = get_series_colors([not path_is_artis_model(filepath) for filepath in args.specpath], args.color)
+    args.color = get_series_colors(
+        [not path_is_artis_model(filepath) for filepath in args.specpath], makelist(args.color)
+    )
 
     if args.distmpc is None:
         for filepath in args.specpath:

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -48,12 +48,14 @@ from artistools.misc import get_vspec_dir_labels
 from artistools.misc import match_closest_time
 from artistools.misc import normalize_path_list
 from artistools.misc import parse_cli_args
+from artistools.misc import path_is_artis_model
 from artistools.misc import print_saved
 from artistools.misc import print_theta_phi_definitions
 from artistools.misc import read_wsv
 from artistools.misc import resolve_outputfile
 from artistools.misc import trim_or_pad
 from artistools.plottools import ExponentLabelFormatter
+from artistools.plottools import get_series_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_mpl_style
 from artistools.plottools import set_plot_title
@@ -62,11 +64,6 @@ from artistools.spectra.writespectra import write_flambda_spectra
 if t.TYPE_CHECKING:
     import matplotlib.artist as mplartist
     import matplotlib.typing as mplt
-
-
-def path_is_artis_model(filepath: str | Path) -> bool:
-    """Return whether the path is an ARTIS model rather than a reference spectrum file."""
-    return Path(filepath).name.endswith((".out", ".out.zst")) or Path(filepath).is_dir()
 
 
 def find_reference_spectrum_file(filename: Path | str) -> Path:
@@ -638,7 +635,8 @@ def make_spectrum_plot(
         color for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"]) if f"C{i}" not in args.color
     ]
     for axis in axes:
-        axis.set_prop_cycle(color=colors)
+        if colors:
+            axis.set_prop_cycle(color=colors)
         axis.margins(0.0, 0.0)
 
     for seriesindex, specpath in enumerate(speclist):
@@ -1508,15 +1506,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.timedays = args.timedayslist[0]
 
     if not args.color:
-        args.color = []
-        refspeccolors = ["0.0", "0.4", "0.6", "0.7"]
-        refspecnum = 0
-        for filepath in args.specpath:
-            if path_is_artis_model(filepath):
-                args.color.append(None)
-            else:
-                args.color.append(refspeccolors[refspecnum])
-                refspecnum += 1
+        # the reference spectra get black and greys, and the ARTIS models get the colour cycle
+        args.color = get_series_colors([not path_is_artis_model(filepath) for filepath in args.specpath])
 
     if args.distmpc is None:
         for filepath in args.specpath:

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1089,3 +1089,10 @@ def test_write_lbol_edep_ntimes_matches_rows(tmp_path: Path) -> None:
     assert lines[0] == f"#NTIMES: {len(datalines)}"
     # timestep 9999 does not exist, so it must not be counted
     assert len(datalines) == 4
+
+
+def test_get_series_colors_greys_then_cycle() -> None:
+    """More reference series than greys must fall back to the colour cycle instead of an IndexError."""
+    colors = at.plottools.get_series_colors([False, True, True, False, True, True, True, True])
+
+    assert colors == ["C0", "0.0", "0.4", "C1", "0.6", "0.7", "C2", "C3"]

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1099,9 +1099,26 @@ def test_get_series_colors_greys_then_cycle() -> None:
 
 
 def test_get_series_colors_keeps_the_colours_of_the_user() -> None:
-    """A colour of the user has priority, and no other series gets that colour of the cycle."""
+    """A colour of the user has priority, and no other series gets that colour."""
     assert at.plottools.get_series_colors([False, False, True], ["C1"]) == ["C1", "C0", "0.0"]
     assert at.plottools.get_series_colors([False, True], [None, "red"]) == ["C0", "red"]
+
+    # a grey that the user asked for goes out of the sequence of the reference series
+    assert at.plottools.get_series_colors([True, True], ["0.0"]) == ["0.0", "0.4"]
+    assert at.plottools.get_series_colors([True, True], [None, "0.0"]) == ["0.4", "0.0"]
+    assert at.plottools.get_series_colors([False, True], ["0.0"]) == ["0.0", "0.4"]
+
+    # a colour that is not a grey does not take a grey of the sequence
+    assert at.plottools.get_series_colors([True, True], ["red"]) == ["red", "0.0"]
+
+
+def test_get_series_colors_knows_the_value_of_a_cycle_colour() -> None:
+    """A colour value of the cycle that the user asked for must go out of the cycle, like the name CN."""
+    at.set_mpl_style()
+    cyclecolors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+
+    assert at.plottools.get_series_colors([False, False], [cyclecolors[0]]) == [cyclecolors[0], "C1"]
+    assert at.plottools.get_series_colors([False, False], [cyclecolors[1]]) == [cyclecolors[1], "C0"]
 
 
 def test_path_is_artis_model_accepts_a_compressed_output_file() -> None:

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1096,3 +1096,15 @@ def test_get_series_colors_greys_then_cycle() -> None:
     colors = at.plottools.get_series_colors([False, True, True, False, True, True, True, True])
 
     assert colors == ["C0", "0.0", "0.4", "C1", "0.6", "0.7", "C2", "C3"]
+
+
+def test_get_series_colors_keeps_the_colours_of_the_user() -> None:
+    """A colour of the user has priority, and no other series gets that colour of the cycle."""
+    assert at.plottools.get_series_colors([False, False, True], ["C1"]) == ["C1", "C0", "0.0"]
+    assert at.plottools.get_series_colors([False, True], [None, "red"]) == ["C0", "red"]
+
+
+def test_path_is_artis_model_accepts_a_compressed_output_file() -> None:
+    """A compressed ARTIS output file is a model, and not a reference data file."""
+    assert all(at.path_is_artis_model(f"light_curve.out{ext}") for ext in ("", ".zst", ".gz", ".xz"))
+    assert not at.path_is_artis_model("AT2017gfo_smarttetal2017.txt")


### PR DESCRIPTION
## What changed

`at lc` plotted a reference (non-ARTIS) light curve in a colour of the matplotlib cycle. The reference data now get black, then greys, and the ARTIS models keep the cycle.

- `artistools/plottools.py`: new `refseries_colors = ("0.0", "0.4", "0.6", "0.7")` and `get_series_colors()`. It gives the greys to the reference series, and the colours of the cycle to the models and to the reference series after the greys.
- `artistools/misc/fileio.py`: `path_is_artis_model` moves here from `plotspectra.py`, thus `at lc` and `at spec` use one function.
- `artistools/lightcurve/lightcurve.py`: new `find_bol_reflightcurve_file` and `path_is_reference_lightcurve`.
- `artistools/lightcurve/plotlightcurve.py`: `main` gives the default colour of each series. The `-reflightcurves` data follow the same sequence in place of the fixed black. The unreachable `define_colours_list` fallback is deleted.
- `artistools/spectra/plotspectra.py`: uses the shared function.

## Why

The `-color` default of `at lc` was `C0` to `C9`, thus `args.color[lcindex]` always had a value and the grey list in `make_lightcurve_plot` was unreachable. One counter also gave the colours to the models and to the reference files together, thus a reference file took a colour of the cycle away from the models.

## Notes for a reviewer

- More than three reference light curves, or more than four reference spectra, caused an `IndexError`. Such series now get the colours of the cycle.
- The old test for a reference light curve path was `not exists() and "." in name`, which rejected a reference file that is in the work directory. `path_is_reference_lightcurve` accepts a local file or a bundled file.
- The ARTIS spectra get the names `C0`, `C1`, ... in place of `None`. The colour of a single direction bin does not change. The extra direction bins get different colours, because the code removes the named colours from the cycle.
- New tests: `test_lightcurve_plot_reference_colors` and `test_get_series_colors_greys_then_cycle`.
- `ruff format`, `ruff check --no-fix`, `mypy`, `pyrefly check`, `ty check`, and the full pytest suite (309 tests) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)