### PR TITLE
Use importlib.metadata for version instead of version.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
               run: |
                   rustup update stable
                   python3 set_version.py
-                  version=$(python3 -c "import runpy; print(runpy.run_path('artistools/version.py')['version'])")
+                  version=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
                   echo "version=${version}" >> "$GITHUB_OUTPUT"
 
             # an existing tag would be reused as-is by gh release create, which ignores --target
@@ -65,10 +65,11 @@ jobs:
               env:
                   VERSION: ${{ steps.setversion.outputs.version }}
               run: |
-                  # version.py holds nothing but the version, so lockfile churn alone cannot produce a
-                  # "Set version to" commit. With the checks above, an unchanged version.py means an
-                  # earlier run pushed the bump but failed before drafting the release
-                  if git diff --quiet -- artistools/version.py; then
+                  # set_version.py is the only thing that edits pyproject.toml here, and the lockfiles
+                  # it also refreshes are separate files, so churn alone cannot produce a "Set version
+                  # to" commit. With the checks above, an unchanged pyproject.toml means an earlier
+                  # run pushed the bump but failed before drafting the release
+                  if git diff --quiet -- pyproject.toml; then
                       echo "Version ${VERSION} is already committed, so only the draft release is missing"
                       exit 0
                   fi

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -50,7 +50,6 @@ from artistools import radfield as radfield
 from artistools import rustext as rustext
 from artistools import spectra as spectra
 from artistools import transitions as transitions
-from artistools import version as version
 from artistools import viewing_angles_visualization as viewing_angles_visualization
 from artistools import writecomparisondata as writecomparisondata
 from artistools.atomic import decode_roman_numeral as decode_roman_numeral

--- a/artistools/__main__.py
+++ b/artistools/__main__.py
@@ -10,10 +10,11 @@ from collections.abc import Sequence
 
 def build_parser() -> argparse.ArgumentParser:
     """Construct the top-level artistools argument parser."""
+    from importlib.metadata import version
+
     from artistools.commands import addsubparsers
     from artistools.commands import CustomArgHelpFormatter
     from artistools.commands import subcommandtree
-    from artistools.version import version
 
     parserkwargs: dict[str, t.Any] = {
         "formatter_class": CustomArgHelpFormatter,
@@ -22,7 +23,7 @@ def build_parser() -> argparse.ArgumentParser:
     if sys.version_info >= (3, 14):
         parserkwargs["suggest_on_error"] = True  # suggest close matches for mistyped subcommands
     parser = argparse.ArgumentParser(**parserkwargs)
-    parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {version}")
+    parser.add_argument("--version", "-V", action="version", version=f"%(prog)s {version('artistools')}")
 
     addsubparsers(parser, "artistools", subcommandtree)
 

--- a/artistools/commands.py
+++ b/artistools/commands.py
@@ -266,9 +266,9 @@ def setup_completions(*args: t.Any, **kwargs: t.Any) -> None:  # ruff:ignore[unu
 
 def show_version(*args: t.Any, **kwargs: t.Any) -> None:  # ruff:ignore[unused-function-argument]
     """Print the artistools version."""
-    from artistools.version import version
+    from importlib.metadata import version
 
-    print(f"artistools {version}")
+    print(f"artistools {version('artistools')}")
 
 
 def get_path(key: str) -> Path:

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -205,15 +205,17 @@ def test_hidden_duplicate_commands() -> None:
 
 
 def test_cli_version(capsys: pytest.CaptureFixture[str]) -> None:
+    from importlib.metadata import version
+
     import artistools.__main__
 
     artistools.__main__.main(argsraw=["version"])
-    assert f"artistools {at.version.version}" in capsys.readouterr().out
+    assert f"artistools {version('artistools')}" in capsys.readouterr().out
 
     with pytest.raises(SystemExit) as excinfo:
         artistools.__main__.main(argsraw=["--version"])
     assert excinfo.value.code == 0
-    assert at.version.version in capsys.readouterr().out
+    assert version("artistools") in capsys.readouterr().out
 
 
 def test_cli_unknown_command() -> None:

--- a/artistools/version.py
+++ b/artistools/version.py
@@ -1,3 +1,0 @@
-"""Package version, updated by set_version.py at release time."""
-
-version = "2026.8.8"

--- a/set_version.py
+++ b/set_version.py
@@ -42,12 +42,6 @@ def main() -> None:
     replace_line(repo_path / "CITATION.cff", r"^version: .*$", f"version: {version}")
     replace_line(repo_path / "CITATION.cff", r"^date-released: .*$", f"date-released: {date_released}")
 
-    # version.py is regenerated in full, so it must carry its own docstring or ruff's D100 fails after a release
-    (repo_path / "artistools" / "version.py").write_text(
-        f'"""Package version, updated by set_version.py at release time."""\n\nversion = "{version}"\n',
-        encoding="utf-8",
-    )
-
     subprocess.check_call(["uv", "lock"], cwd=repo_path)
 
 


### PR DESCRIPTION
Replace the manually-maintained `artistools/version.py` file with dynamic version retrieval from package metadata using `importlib.metadata.version()`. This eliminates the need to regenerate a version file at release time and simplifies version management.

## Changes

- **Removed `artistools/version.py`**: This file was regenerated by `set_version.py` at each release and only contained a version string.
- **Updated version retrieval**: Changed all version lookups to use `importlib.metadata.version('artistools')` instead of importing from `artistools.version`.
  - `artistools/__main__.py`: Updated argument parser to call `version('artistools')`
  - `artistools/commands.py`: Updated `show_version()` command to use `importlib.metadata`
  - `artistools/test_artistools.py`: Updated test assertions to use `importlib.metadata`
- **Simplified `set_version.py`**: Removed the code that regenerated `version.py`, since version is now sourced from `pyproject.toml` at runtime.
- **Updated release workflow**: Changed version extraction in `.github/workflows/release.yml` to read directly from `pyproject.toml` using `tomllib` instead of importing from `version.py`.
- **Updated version check in release workflow**: Changed the git diff check from `artistools/version.py` to `pyproject.toml` to detect whether a version bump was already committed.
- **Removed version module export**: Deleted the `from artistools import version as version` re-export from `artistools/__init__.py`.

## Implementation details

The version is now sourced from the `[project]` table in `pyproject.toml` at runtime, which is the standard location for Python package metadata. This approach:
- Eliminates file regeneration at release time
- Reduces git churn (no version.py changes to commit)
- Follows Python packaging best practices
- Maintains the same user-facing behavior for `artistools --version` and `artistools version` commands

https://claude.ai/code/session_01DCNKgRzexhdw3bM4vcUuvd