### PR TITLE
Report a missing absolute path as a file not found error

### DIFF
--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -270,7 +270,8 @@ def firstexisting(
                             return thispath
                         fullpaths.append(thispath)
 
-    strfilelist = "\n  ".join([str(x.relative_to(folder)) for x in fullpaths])
+    # an absolute path is not below the folder, thus the message shows the full path for it
+    strfilelist = "\n  ".join([str(x.relative_to(folder)) if x.is_relative_to(folder) else str(x) for x in fullpaths])
     orsub = " or subfolders" if search_subfolders else ""
     msg = f"None of these files exist in {folder}{orsub}: \n  {strfilelist}"
     raise FileNotFoundError(msg)

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -329,6 +329,18 @@ def test_firstexisting_anyexist(tmp_path: Path) -> None:
     assert at.firstexisting_or_none(["nope.txt"], folder=firstdir) is None
 
 
+def test_firstexisting_with_an_absolute_path(tmp_path: Path) -> None:
+    """An absolute path is not below the default folder, but the message must not raise a ValueError."""
+    (tmp_path / "here.txt").write_text("here")
+    assert at.firstexisting(tmp_path / "here.txt") == tmp_path / "here.txt"
+
+    missingpath = tmp_path / "notafile.txt"
+    with pytest.raises(FileNotFoundError, match=str(missingpath)):
+        at.firstexisting(missingpath)
+
+    assert at.firstexisting_or_none(missingpath) is None
+
+
 def test_readnoncommentline() -> None:
     stream = io.StringIO("\n# a comment\n   # indented comment\nreal data line\nsecond\n")
     assert at.readnoncommentline(stream) == "real data line\n"


### PR DESCRIPTION
## What changed

`firstexisting` (artistools/misc/fileio.py) built its error message with `relative_to`, which raises a `ValueError` if the path is absolute and the folder is the work directory:

```python
strfilelist = "\n  ".join([str(x.relative_to(folder)) for x in fullpaths])
```

The message now shows the full path if the path is not below the folder.

## Why

`firstexisting_or_none` catches only the `FileNotFoundError`, thus the `ValueError` went to the caller in place of a `None` result:

```sh
uv run -- python -c "import artistools as at; print(at.firstexisting_or_none('/tmp/definitely_not_a_file.txt'))"
```

Before this change that command ends with `ValueError: '/tmp/definitely_not_a_file.txt' is not in the subpath of '.'`. It now prints `None`.

## Notes for a reviewer

- A relative path stays relative in the message, thus the text of the usual error does not change.
- `test_firstexisting_with_an_absolute_path` covers the file that exists, the message of the file that does not exist, and the `None` result of `firstexisting_or_none`.
- `ruff format`, `ruff check --no-fix`, `mypy`, `pyrefly check`, `ty check`, and the full pytest suite (308 tests) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)