### PR TITLE
Plot bolometric reference light curves in the units of the y axis, and take line colours from args.color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,11 +23,12 @@ uv run -- ruff check --no-fix     # --no-fix shows what CI sees (config sets fix
 uv run -- mypy
 uv run -- pyrefly check
 uv run -- ty check
+uv run -- refurb artistools --quiet -- --follow-imports=skip   # --follow-imports=skip avoids a mypy crash on pyvista
 uv run -- python -m pytest artistools/<area> -n auto   # e.g. artistools/spectra
 cargo clippy --all-features -- -D warnings -D clippy::pedantic   # in rust/, for Rust changes
 ```
 
-All four type checkers must be clean, and a change that satisfies one must not break another. `.github/workflows/pytest.yml` is the authority on what CI runs; it also runs the `prek` hooks from `.pre-commit-config.yaml`.
+All four type checkers must be clean, and a change that satisfies one must not break another. refurb is a separate linter that CI fails on, so run it too. `.github/workflows/pytest.yml` is the authority on what CI runs; it also runs the `prek` hooks from `.pre-commit-config.yaml`, which `uv run -- prek run --all-files` reproduces.
 
 Never report that checks passed when you could not run them. If the environment lacks the tools, the venv, the network, or the test data, say which checks were skipped and why.
 

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -115,6 +115,7 @@ from artistools.misc import get_nprocs as get_nprocs
 from artistools.misc import get_nu_grid as get_nu_grid
 from artistools.misc import get_phi_bins as get_phi_bins
 from artistools.misc import get_runfolders as get_runfolders
+from artistools.misc import get_series_label as get_series_label
 from artistools.misc import get_time_range as get_time_range
 from artistools.misc import get_timestep_of_timedays as get_timestep_of_timedays
 from artistools.misc import get_timestep_time as get_timestep_time

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -104,6 +104,7 @@ from artistools.misc import get_deposition as get_deposition
 from artistools.misc import get_dirbin_labels as get_dirbin_labels
 from artistools.misc import get_dirbins as get_dirbins
 from artistools.misc import get_escaped_arrivalrange as get_escaped_arrivalrange
+from artistools.misc import get_file_identity as get_file_identity
 from artistools.misc import get_file_metadata as get_file_metadata
 from artistools.misc import get_filterfunc as get_filterfunc
 from artistools.misc import get_grid_mapping as get_grid_mapping

--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import string
 import time
@@ -19,9 +20,13 @@ import artistools as at
 from artistools.commands import get_path
 from artistools.constants import hc_in_ev_angstrom
 from artistools.misc.fileio import firstexisting
+from artistools.misc.fileio import get_file_identity
 from artistools.misc.fileio import write_parquet_atomic
 from artistools.misc.fileio import zopen
 from artistools.misc.fileio import zopen_unshadowed
+
+if t.TYPE_CHECKING:
+    import os
 
 
 def parse_adata(
@@ -713,7 +718,12 @@ def get_linelist_pldf(modelpath: Path | str) -> pl.LazyFrame:
     textfile = firstexisting("linestat.out", folder=modelpath)
     # the .tmp suffix marks this as a regenerable cache, matching every other parquet file artistools writes
     parquetfile = Path(modelpath, "linelist.out.parquet.tmp")
-    if not parquetfile.is_file() or parquetfile.stat().st_mtime < textfile.stat().st_mtime:
+    parquetstat: os.stat_result | None = None
+    with contextlib.suppress(FileNotFoundError):
+        parquetstat = parquetfile.stat()
+    if parquetstat is None or parquetstat.st_mtime < textfile.stat().st_mtime:
+        # the identity comes from the stat that showed the cache is out of date, so only that file is replaced
+        outdatedparquet = get_file_identity(parquetstat) if parquetstat else None
         lambda_angstroms, atomic_numbers, ion_stages, upper_levels, lower_levels = read_linestatfile(textfile)
 
         pldf = (
@@ -728,7 +738,7 @@ def get_linelist_pldf(modelpath: Path | str) -> pl.LazyFrame:
             .with_row_index(name="lineindex")
             .with_columns(cs.integer().cast(pl.Int32), cs.float().cast(pl.Float32))
         )
-        write_parquet_atomic(pldf, parquetfile, compression_level=8)
+        write_parquet_atomic(pldf, parquetfile, compression_level=8, replaces=outdatedparquet)
         print(f"Wrote {parquetfile}")
     else:
         print(f"Reading {parquetfile}")

--- a/artistools/constants.py
+++ b/artistools/constants.py
@@ -19,5 +19,6 @@ km_to_cm = 1e5  # Kilometre [cm], also converts a velocity in km/s to cm/s
 megaparsec_to_cm = 3.085677581491367e24  # Megaparsec [cm]
 Msun_to_g = 1.989e33  # Solar mass [g]
 Lsun_to_erg_per_s = 3.826e33  # Solar luminosity [erg/s]
+Mbol_sun = 4.74  # Absolute bolometric magnitude of the Sun
 
 day_to_s = 86400.0  # Day [s]

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -17,6 +17,9 @@ from polars import selectors as cs
 import artistools as at
 from artistools.constants import K_B_ev_per_K
 
+if t.TYPE_CHECKING:
+    import os
+
 
 def get_variableunits(key: str) -> str | None:
     """Return the unit string for an estimator variable, or None if it is dimensionless or unknown."""
@@ -108,12 +111,19 @@ def get_estimators_rankbatch_parquetfile(
     )
     assert len(set(batch_mpiranks)) == len(batch_mpiranks), "batch_mpiranks must not contain duplicates"
 
-    if not parquetfilepath.exists():
+    parquetstat: os.stat_result | None = None
+    with contextlib.suppress(FileNotFoundError):
+        parquetstat = parquetfilepath.stat()
+
+    outdatedparquet: tuple[int, int] | None = None
+    if parquetstat is None:
         generate_parquet = True
-    elif textsource_mtime and textsource_mtime > parquetfilepath.stat().st_mtime:
-        # leave the stale file in place: write_parquet_atomic() swaps the new one in with a rename, so the path
-        # always resolves to a complete parquet. Deleting it first opens a window in which a concurrent reader
-        # finds it missing or half-swapped
+    elif textsource_mtime and textsource_mtime > parquetstat.st_mtime:
+        # leave the stale file in place: write_parquet_atomic() puts the new one at the path in one step, so
+        # the path always resolves to a complete parquet. Deleting it first opens a window in which a
+        # concurrent reader finds it missing or half-swapped. The identity comes from the stat that showed
+        # the file is stale, so only that exact file can be replaced by this rewrite
+        outdatedparquet = at.get_file_identity(parquetstat)
         print(
             f"  {parquetfilepath.relative_to(modelpath.parent)} is older than the estimator text files."
             " File will be regenerated..."
@@ -155,6 +165,7 @@ def get_estimators_rankbatch_parquetfile(
                 "batch_rank_max": str(max(batch_mpiranks)),
                 "batchindex": str(batchindex),
             },
+            replaces=outdatedparquet,
         )
 
         print(f"took {time.perf_counter() - time_start:.1f} s.")

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -347,7 +347,9 @@ def process_trajectory(
         traj_df = pl.concat([main, last_row])
         traj_df = traj_df.fill_null(0.0).fill_nan(0.0)
 
-        at.write_parquet_atomic(traj_df, traj_parquet_dir / f"decay_powers_{traj_ID}.parquet")
+        # an output file overwrites whatever a previous run left at the path
+        trajparquetpath = traj_parquet_dir / f"decay_powers_{traj_ID}.parquet"
+        at.write_parquet_atomic(traj_df, trajparquetpath, replaces=at.get_file_identity(trajparquetpath))
     return decay_powers
 
 
@@ -467,7 +469,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         if args.parquet:
             assert parquet_dir is not None
             traj_set_df = pl.DataFrame(decay_powers)
-            at.write_parquet_atomic(traj_set_df, parquet_dir / f"decay_powers_{labelfull}.parquet")
+            # an output file overwrites whatever a previous run left at the path
+            setparquetpath = parquet_dir / f"decay_powers_{labelfull}.parquet"
+            at.write_parquet_atomic(traj_set_df, setparquetpath, replaces=at.get_file_identity(setparquetpath))
 
         fig, axes = plt.subplots(
             nrows=2, ncols=1, figsize=(6, 10), tight_layout={"pad": 0.4, "w_pad": 0.0, "h_pad": 0.0}

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -1,6 +1,7 @@
 """Read, write, and derive columns for ARTIS model.txt and abundance input files."""
 
 import calendar
+import contextlib
 import datetime
 import errno
 import gc
@@ -25,6 +26,7 @@ from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.misc import firstexisting
+from artistools.misc import get_file_identity
 from artistools.misc import read_wsv
 from artistools.misc import resolve_outputfile
 from artistools.misc import stripallsuffixes
@@ -420,7 +422,9 @@ def get_modeldata(
 
     textsource_mtime = Path(textfilepath).stat().st_mtime
     parquetfilepath = stripallsuffixes(Path(textfilepath)).with_suffix(".txt.parquet.tmp")
-    hadcachefile = parquetfilepath.is_file()
+    # the identity of the cache that a rewrite replaces, from the same moment as the existence check
+    outdatedparquet = get_file_identity(parquetfilepath)
+    hadcachefile = outdatedparquet is not None
 
     cached = read_model_parquet_cache(parquetfilepath, textsource_mtime, printwarningsonly=printwarningsonly)
     dfmodel: pl.LazyFrame | None = None
@@ -441,6 +445,7 @@ def get_modeldata(
             write_parquet_atomic(
                 dfmodel,
                 parquetfilepath,
+                replaces=outdatedparquet,
                 metadata={
                     "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
                     "textsource_mtime": str(textsource_mtime),
@@ -1006,12 +1011,15 @@ def get_initelemabundances(modelpath: Path | str = ".", printwarningsonly: bool 
     textfilepath = firstexisting("abundances.txt", folder=modelpath, tryzipped=True)
     parquetfilepath = stripallsuffixes(Path(textfilepath)).with_suffix(".txt.parquet.tmp")
 
-    # leave a stale cache in place rather than deleting it: write_parquet_atomic() swaps the new one in with a
-    # rename, so the path always resolves to a complete parquet even while another process is regenerating it
-    cache_is_current = (
-        parquetfilepath.is_file() and Path(textfilepath).stat().st_mtime <= parquetfilepath.stat().st_mtime
-    )
-    if parquetfilepath.is_file() and not cache_is_current:
+    # leave a stale cache in place rather than deleting it: write_parquet_atomic() puts the new one at the
+    # path in one step, so the path always resolves to a complete parquet while another process regenerates it
+    parquetstat: os.stat_result | None = None
+    with contextlib.suppress(FileNotFoundError):
+        parquetstat = parquetfilepath.stat()
+    cache_is_current = parquetstat is not None and Path(textfilepath).stat().st_mtime <= parquetstat.st_mtime
+    # the identity comes from the stat that showed the cache is out of date, so only that file is replaced
+    outdatedparquet = get_file_identity(parquetstat) if parquetstat and not cache_is_current else None
+    if parquetstat is not None and not cache_is_current:
         print(f"{textfilepath} has been modified after {parquetfilepath}. Regenerating out of date parquet file.")
 
     if cache_is_current:
@@ -1033,7 +1041,7 @@ def get_initelemabundances(modelpath: Path | str = ".", printwarningsonly: bool 
         mebibyte = 1024 * 1024
         if textfilepath.stat().st_size > 2 * mebibyte:
             print(f"Saving {parquetfilepath}")
-            write_parquet_atomic(abundancedata, parquetfilepath, compression_level=8)
+            write_parquet_atomic(abundancedata, parquetfilepath, compression_level=8, replaces=outdatedparquet)
             print("  Done.")
             del abundancedata
             gc.collect()

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -67,8 +67,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     args.color, args.label = at.trim_or_pad(len(args.modelpath), args.color, args.label)
     args.label = [
-        at.get_model_name(modelpath) if label is None else label
-        for modelpath, label in zip(args.modelpath, args.label, strict=True)
+        at.get_series_label(args.label, index, at.get_model_name(modelpath))
+        for index, modelpath in enumerate(args.modelpath)
     ]
 
     max_vmax_on_c = float("-inf")

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -3,7 +3,6 @@
 __all__ = ["plot", "plotlightcurve"]
 
 from artistools.lightcurve import plotlightcurve
-from artistools.lightcurve.lightcurve import derived_lum_unit_cols as derived_lum_unit_cols
 from artistools.lightcurve.lightcurve import find_bol_reflightcurve_file as find_bol_reflightcurve_file
 from artistools.lightcurve.lightcurve import generate_band_lightcurve_data as generate_band_lightcurve_data
 from artistools.lightcurve.lightcurve import get_band_lightcurve as get_band_lightcurve

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -11,6 +11,7 @@ from artistools.lightcurve.lightcurve import get_colour_delta_mag as get_colour_
 from artistools.lightcurve.lightcurve import get_filter_data as get_filter_data
 from artistools.lightcurve.lightcurve import get_from_packets as get_from_packets
 from artistools.lightcurve.lightcurve import get_phillips_relation_data as get_phillips_relation_data
+from artistools.lightcurve.lightcurve import lum_lsun_to_mag as lum_lsun_to_mag
 from artistools.lightcurve.lightcurve import luminosity_distance as luminosity_distance
 from artistools.lightcurve.lightcurve import path_is_reference_lightcurve as path_is_reference_lightcurve
 from artistools.lightcurve.lightcurve import read_bol_reflightcurve_data as read_bol_reflightcurve_data

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -3,6 +3,7 @@
 __all__ = ["plot", "plotlightcurve"]
 
 from artistools.lightcurve import plotlightcurve
+from artistools.lightcurve.lightcurve import derived_lum_unit_cols as derived_lum_unit_cols
 from artistools.lightcurve.lightcurve import find_bol_reflightcurve_file as find_bol_reflightcurve_file
 from artistools.lightcurve.lightcurve import generate_band_lightcurve_data as generate_band_lightcurve_data
 from artistools.lightcurve.lightcurve import get_band_lightcurve as get_band_lightcurve

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -19,6 +19,7 @@ import artistools as at
 from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
+from artistools.constants import Mbol_sun
 
 # ARTIS writes the Sloan filters with a trailing "s"; map them back to the conventional single-letter names
 FILTERNAME_ALIASES: t.Final[Mapping[str, str]] = MappingProxyType({"rs": "r", "gs": "g", "is": "i", "zs": "z"})
@@ -34,7 +35,7 @@ def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
         has_header=False,
         new_columns=["time_days", "luminosity_Lsun", "luminosity_cmf_Lsun"],
     ).with_columns(
-        (4.74 - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
+        (Mbol_sun - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
         (cs.ends_with("_Lsun") * Lsun_to_erg_per_s).name.replace("_Lsun", "_erg/s"),
     )
     if "_res" in Path(filepath).stem:
@@ -180,7 +181,7 @@ def get_from_packets(
             .rename({"tmid_days": "time_days"})
             .drop("twidth_days")
             .with_columns(
-                (4.74 - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
+                (Mbol_sun - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
                 (cs.ends_with("_Lsun") * Lsun_to_erg_per_s).name.replace("_Lsun", "_erg/s"),
             )
         )

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -221,6 +221,7 @@ def generate_band_lightcurve_data(
     args: argparse.Namespace | None = None,
     dirbin: int = -1,
     modelnumber: int | None = None,  # ruff:ignore[unused-function-argument]
+    filternames: Sequence[str] | None = None,
     **kwargs: t.Any,
 ) -> dict[str, t.Any]:
     """Integrate spectra to get band magnitude vs time. Method adapted from https://github.com/cinserra/S3/blob/master/src/s3/SMS.py."""
@@ -260,10 +261,14 @@ def generate_band_lightcurve_data(
             timearray = list(dict.fromkeys(fspec.readline().split()[1:]))
 
     filters_dict = {}
-    if not args.filter:
-        args.filter = ["B"]
+    if filternames is None:
+        # the colour evolution plot integrates the bands of every filter pair at once, so it names them here
+        # rather than by assigning args.filter, which also selects the subplot layout and the plot type
+        if not args.filter:
+            args.filter = ["B"]
+        filternames = args.filter
 
-    filters_list = args.filter
+    filters_list = filternames
 
     for filter_name in filters_list:
         if filter_name == "bol":

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -25,6 +25,17 @@ from artistools.constants import Mbol_sun
 FILTERNAME_ALIASES: t.Final[Mapping[str, str]] = MappingProxyType({"rs": "r", "gs": "g", "is": "i", "zs": "z"})
 
 
+def derived_lum_unit_cols() -> list[pl.Expr]:
+    """Return the expressions adding the bolometric magnitude and erg/s columns to a luminosity in Lsun.
+
+    Every loader must produce the same set of unit columns, since the plotting code selects one of them by name.
+    """
+    return [
+        (Mbol_sun - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
+        (cs.ends_with("_Lsun") * Lsun_to_erg_per_s).name.replace("_Lsun", "_erg/s"),
+    ]
+
+
 def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
     """Read an ARTIS light curve file."""
     print(f"Reading {filepath}")
@@ -34,10 +45,7 @@ def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
         separator=" ",
         has_header=False,
         new_columns=["time_days", "luminosity_Lsun", "luminosity_cmf_Lsun"],
-    ).with_columns(
-        (Mbol_sun - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
-        (cs.ends_with("_Lsun") * Lsun_to_erg_per_s).name.replace("_Lsun", "_erg/s"),
-    )
+    ).with_columns(derived_lum_unit_cols())
     if "_res" in Path(filepath).stem:
         # get a dict of dfs with light curves at each viewing direction bin
         lcdata = at.split_multitable_dataframe(lzdf)
@@ -177,13 +185,7 @@ def get_from_packets(
             )
 
         lcdata[dirbin] = (
-            lcdata[dirbin]
-            .rename({"tmid_days": "time_days"})
-            .drop("twidth_days")
-            .with_columns(
-                (Mbol_sun - (2.5 * pl.col("luminosity_Lsun").log10())).alias("mag"),
-                (cs.ends_with("_Lsun") * Lsun_to_erg_per_s).name.replace("_Lsun", "_erg/s"),
-            )
+            lcdata[dirbin].rename({"tmid_days": "time_days"}).drop("twidth_days").with_columns(derived_lum_unit_cols())
         )
 
     return lcdata
@@ -351,7 +353,6 @@ def bolometric_magnitude(
                 )[angle].collect()
             integrated_flux = np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"])
             integrated_luminosity = integrated_flux * 4 * np.pi * np.power(Mpc_to_cm, 2)
-            Mbol_sun = 4.74
             with np.errstate(divide="ignore"):
                 magnitude = Mbol_sun - (2.5 * np.log10(integrated_luminosity / Lsun_to_erg_per_s))
             magnitudes.append(magnitude)

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -53,9 +53,10 @@ def readfile(
     """Read an ARTIS light curve file, optionally averaging its direction bins over phi or theta.
 
     The averaging belongs here rather than to the caller because the magnitude column is not linear in the
-    bin contributions: averaging without rebuilding it plots the mean of the magnitudes, where a single dark
-    bin sends the whole averaged bin to inf.
+    bin contributions. Deriving it only after the averaging leaves no way to plot the mean of the
+    magnitudes, where a single dark bin sends the whole averaged bin to inf.
     """
+    at.check_averaging_angles(average_over_phi, average_over_theta)
     print(f"Reading {filepath}")
     lcdata: dict[int, pl.LazyFrame] = {}
     lzdf = pl.scan_csv(
@@ -63,7 +64,7 @@ def readfile(
         separator=" ",
         has_header=False,
         new_columns=["time_days", "luminosity_Lsun", "luminosity_cmf_Lsun"],
-    ).with_columns(derived_lum_unit_cols())
+    )
     if "_res" in Path(filepath).stem:
         # get a dict of dfs with light curves at each viewing direction bin
         lcdata = at.split_multitable_dataframe(lzdf)
@@ -75,12 +76,16 @@ def readfile(
             lcdata[-1] = lcdata[-1].select(pl.all().slice(0, pl.len() // 2))
 
     if average_over_phi:
-        lcdata = at.average_direction_bins(lcdata, overangle="phi", derivedcols=derived_lum_unit_cols())
+        lcdata = at.average_direction_bins(lcdata, overangle="phi")
 
     if average_over_theta:
-        lcdata = at.average_direction_bins(lcdata, overangle="theta", derivedcols=derived_lum_unit_cols())
+        lcdata = at.average_direction_bins(lcdata, overangle="theta")
 
-    return lcdata
+    # after the averaging, never before it: a magnitude is not linear in the bin contributions, so the mean
+    # of the magnitudes of the bins is not the magnitude of their mean luminosity
+    unitcols = derived_lum_unit_cols()
+
+    return {dirbin: lzdf.with_columns(unitcols) for dirbin, lzdf in lcdata.items()}
 
 
 def get_from_packets(
@@ -281,9 +286,7 @@ def generate_band_lightcurve_data(
             args.filter = ["B"]
         filternames = args.filter
 
-    filters_list = filternames
-
-    for filter_name in filters_list:
+    for filter_name in filternames:
         if filter_name == "bol":
             times, bol_magnitudes = bolometric_magnitude(
                 Path(modelpath),
@@ -303,7 +306,7 @@ def generate_band_lightcurve_data(
 
     filterdir = Path(at.get_path("artistools_dir"), "data/filters/")
 
-    for filter_name in filters_list:
+    for filter_name in filternames:
         if filter_name == "bol":
             continue
         zeropointenergyflux, wavefilter, transmission, wavefilter_min, wavefilter_max = get_filter_data(

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -47,8 +47,15 @@ def lum_lsun_to_mag(lum_lsun: npt.NDArray[np.floating[t.Any]]) -> npt.NDArray[np
         return Mbol_sun - (2.5 * np.log10(lum_lsun))
 
 
-def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
-    """Read an ARTIS light curve file."""
+def readfile(
+    filepath: str | Path, average_over_phi: bool = False, average_over_theta: bool = False
+) -> dict[int, pl.LazyFrame]:
+    """Read an ARTIS light curve file, optionally averaging its direction bins over phi or theta.
+
+    The averaging belongs here rather than to the caller because the magnitude column is not linear in the
+    bin contributions: averaging without rebuilding it plots the mean of the magnitudes, where a single dark
+    bin sends the whole averaged bin to inf.
+    """
     print(f"Reading {filepath}")
     lcdata: dict[int, pl.LazyFrame] = {}
     lzdf = pl.scan_csv(
@@ -66,6 +73,12 @@ def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
         # if the light_curve.out file repeats x values, keep the first half only
         if lcdata[-1].select(pl.col("time_days").n_unique() < pl.len()).collect().item():
             lcdata[-1] = lcdata[-1].select(pl.all().slice(0, pl.len() // 2))
+
+    if average_over_phi:
+        lcdata = at.average_direction_bins(lcdata, overangle="phi", derivedcols=derived_lum_unit_cols())
+
+    if average_over_theta:
+        lcdata = at.average_direction_bins(lcdata, overangle="theta", derivedcols=derived_lum_unit_cols())
 
     return lcdata
 

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -38,6 +38,15 @@ def derived_lum_unit_cols() -> list[pl.Expr]:
     ]
 
 
+def lum_lsun_to_mag(lum_lsun: npt.NDArray[np.floating[t.Any]]) -> npt.NDArray[np.floating[t.Any]]:
+    """Return the bolometric magnitude of a luminosity in solar luminosities.
+
+    A zero or negative luminosity has no magnitude, so it becomes inf or nan rather than warning.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return Mbol_sun - (2.5 * np.log10(lum_lsun))
+
+
 def readfile(filepath: str | Path) -> dict[int, pl.LazyFrame]:
     """Read an ARTIS light curve file."""
     print(f"Reading {filepath}")
@@ -355,8 +364,7 @@ def bolometric_magnitude(
                 )[angle].collect()
             integrated_flux = np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"])
             integrated_luminosity = integrated_flux * 4 * np.pi * np.power(Mpc_to_cm, 2)
-            with np.errstate(divide="ignore"):
-                magnitude = Mbol_sun - (2.5 * np.log10(integrated_luminosity / Lsun_to_erg_per_s))
+            magnitude = float(lum_lsun_to_mag(np.asarray(integrated_luminosity / Lsun_to_erg_per_s)))
             magnitudes.append(magnitude)
             times.append(time)
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -14,6 +14,7 @@ import matplotlib.axes as mplax
 import matplotlib.cm as mplcm
 import matplotlib.colors as mplcolors
 import matplotlib.figure as mplfig
+import matplotlib.markers as mplmarkers
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mplticker
 import numpy as np
@@ -159,7 +160,7 @@ def plot_bol_reflightcurve(
         if unbounded.any():
             # matplotlib draws only one side of a bar it is told is a limit, so the open faint side is a
             # second, zero-length bar whose arrow head sits on the point the bar above already reaches
-            axis.errorbar(
+            limitbars = axis.errorbar(
                 time_days[unbounded],
                 yvalues[unbounded],
                 yerr=np.zeros(int(unbounded.sum())),
@@ -168,6 +169,12 @@ def plot_bol_reflightcurve(
                 color=color,
                 zorder=0,
             )
+            # matplotlib picks the direction of the arrow from the orientation of the axis as it is now, and
+            # a magnitude axis is inverted only after every series is drawn, so point it at the faint side.
+            # The cast is for the marker constant, which matplotlib types as an int that its own setter rejects
+            caretdown = t.cast("t.Literal[11]", mplmarkers.CARETDOWNBASE)
+            for capline in limitbars.lines[1]:
+                capline.set_marker(caretdown)
     else:
         axis.scatter(time_days, yvalues, label=plotlabel, color=color, zorder=0)
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -39,36 +39,107 @@ from artistools.misc import print_theta_phi_definitions
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 
+type LumUnit = t.Literal["mag", "Lsun", "erg/s"]
+
+
+def get_plot_lum_unit(args: argparse.Namespace) -> LumUnit:
+    """Return the luminosity unit that the command-line arguments select for the y axis.
+
+    This is the single source of truth for the unit choice: the light curve column to plot, the conversion
+    applied to reference and deposition data, and the y axis label are all derived from it.
+    """
+    if args.magnitude:
+        return "mag"
+
+    return "Lsun" if args.Lsun else "erg/s"
+
+
+def get_plot_lum_column(args: argparse.Namespace) -> str:
+    """Return the light curve dataframe column holding the luminosity in the y axis units."""
+    return {"mag": "mag", "Lsun": "luminosity_Lsun", "erg/s": "luminosity_erg/s"}[get_plot_lum_unit(args)]
+
 
 def convert_lum_lsun_to_plotunits(
     lum_lsun: npt.NDArray[np.floating[t.Any]], args: argparse.Namespace
 ) -> npt.NDArray[np.floating[t.Any]]:
     """Convert a luminosity in solar luminosities to the y axis units: bolometric magnitude, Lsun, or erg/s."""
-    if args.magnitude:
-        return Mbol_sun - 2.5 * np.log10(lum_lsun)
+    lumunit = get_plot_lum_unit(args)
+    if lumunit == "mag":
+        # a zero or negative luminosity has no magnitude, so let it become inf/nan instead of warning
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return Mbol_sun - 2.5 * np.log10(lum_lsun)
 
-    return lum_lsun if args.Lsun else lum_lsun * Lsun_to_erg_per_s
+    return lum_lsun if lumunit == "Lsun" else lum_lsun * Lsun_to_erg_per_s
+
+
+def convert_lum_ergs_to_plotunits(
+    lum_erg_per_s: npt.NDArray[np.floating[t.Any]], args: argparse.Namespace
+) -> npt.NDArray[np.floating[t.Any]]:
+    """Convert a luminosity in erg/s to the y axis units: bolometric magnitude, Lsun, or erg/s."""
+    if get_plot_lum_unit(args) == "erg/s":
+        return lum_erg_per_s
+
+    return convert_lum_lsun_to_plotunits(lum_erg_per_s / Lsun_to_erg_per_s, args)
 
 
 def get_reflightcurve_yerr(
-    lum_lsun: npt.NDArray[np.floating[t.Any]],
-    errminus_lsun: npt.NDArray[np.floating[t.Any]],
-    errplus_lsun: npt.NDArray[np.floating[t.Any]],
+    lum_erg_per_s: npt.NDArray[np.floating[t.Any]],
+    errminus_erg_per_s: npt.NDArray[np.floating[t.Any]],
+    errplus_erg_per_s: npt.NDArray[np.floating[t.Any]],
     args: argparse.Namespace,
 ) -> list[npt.NDArray[np.floating[t.Any]]]:
-    """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in Lsun and its errors."""
+    """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in erg/s and its errors."""
     if args.magnitude:
         # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
-        mag = convert_lum_lsun_to_plotunits(lum_lsun, args)
+        mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, args)
         # an error bar reaching zero luminosity has no faintest magnitude, so leave it undefined
-        lum_faintest_lsun = np.where(lum_lsun > errminus_lsun, lum_lsun - errminus_lsun, np.nan)
+        lum_faintest = np.where(lum_erg_per_s > errminus_erg_per_s, lum_erg_per_s - errminus_erg_per_s, np.nan)
         return [
-            mag - convert_lum_lsun_to_plotunits(lum_lsun + errplus_lsun, args),
-            convert_lum_lsun_to_plotunits(lum_faintest_lsun, args) - mag,
+            mag - convert_lum_ergs_to_plotunits(lum_erg_per_s + errplus_erg_per_s, args),
+            convert_lum_ergs_to_plotunits(lum_faintest, args) - mag,
         ]
 
     # the conversion is a simple scaling, so it applies to the error sizes directly
-    return [convert_lum_lsun_to_plotunits(errminus_lsun, args), convert_lum_lsun_to_plotunits(errplus_lsun, args)]
+    return [
+        convert_lum_ergs_to_plotunits(errminus_erg_per_s, args),
+        convert_lum_ergs_to_plotunits(errplus_erg_per_s, args),
+    ]
+
+
+def plot_bol_reflightcurve(
+    axis: mplax.Axes, bolreflightcurve: str | Path, args: argparse.Namespace, color: str, label: str | None = None
+) -> None:
+    """Plot an observed bolometric reference light curve in the y axis units, with error bars where available."""
+    dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
+    plotlabel = label or metadata.get("label", str(bolreflightcurve))
+    lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
+
+    if "luminosity_errminus_erg/s" in dflightcurve.columns and "luminosity_errplus_erg/s" in dflightcurve.columns:
+        axis.errorbar(
+            dflightcurve["time_days"],
+            convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+            yerr=get_reflightcurve_yerr(
+                lum_erg_per_s,
+                dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
+                dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
+                args,
+            ),
+            fmt="o",
+            capsize=3,
+            label=plotlabel,
+            color=color,
+            zorder=0,
+        )
+    else:
+        axis.scatter(
+            dflightcurve["time_days"],
+            convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+            label=plotlabel,
+            color=color,
+            zorder=0,
+        )
+
+    print(f"====> {plotlabel}")
 
 
 def plot_deposition_thermalisation(
@@ -80,6 +151,12 @@ def plot_deposition_thermalisation(
     **plotkwargs: t.Any,
 ) -> None:
     """Plot the gamma-ray and positron deposition rates, and the thermalisation efficiencies when axistherm is given."""
+    # every curve below appends a suffix to the caller's label and picks its own linestyle and colour, so these
+    # must leave the kwargs splat or matplotlib gets them twice ("dashes" silently overrides "linestyle")
+    label = plotkwargs.pop("label")
+    for overridden in ("linestyle", "color", "dashes"):
+        plotkwargs.pop(overridden, None)
+
     if args.plotthermalisation:
         dfmodel, _ = at.inputmodel.get_modeldata(modelpath, derived_cols=["mass_g", "vel_r_mid", "kinetic_en_erg"])
 
@@ -95,7 +172,7 @@ def plot_deposition_thermalisation(
         depdata["tmid_days"],
         convert_lum_lsun_to_plotunits(depdata["gammadep_Lsun"].to_numpy(), args),
         **plotkwargs,
-        label=plotkwargs["label"] + r" $\dot{E}_{dep,\gamma}$",
+        label=label + r" $\dot{E}_{dep,\gamma}$",
         linestyle="dashed",
         color=color_gamma,
     )
@@ -107,7 +184,7 @@ def plot_deposition_thermalisation(
             depdata["tmid_days"],
             convert_lum_lsun_to_plotunits(depdata["eps_elec_Lsun"].to_numpy(), args),
             **plotkwargs,
-            label=plotkwargs["label"] + r" $\dot{E}_{rad,\beta^-}$",
+            label=label + r" $\dot{E}_{rad,\beta^-}$",
             linestyle="dotted",
             color=color_beta,
         )
@@ -117,7 +194,7 @@ def plot_deposition_thermalisation(
             depdata["tmid_days"],
             convert_lum_lsun_to_plotunits(depdata["elecdep_Lsun"].to_numpy(), args),
             **plotkwargs,
-            label=plotkwargs["label"] + r" $\dot{E}_{dep,\beta^-}$",
+            label=label + r" $\dot{E}_{dep,\beta^-}$",
             linestyle="dashed",
             color=color_beta,
         )
@@ -132,7 +209,7 @@ def plot_deposition_thermalisation(
                 depdata["tmid_days"],
                 convert_lum_lsun_to_plotunits(depdata["eps_alpha_ana_Lsun"].to_numpy(), args),
                 **plotkwargs,
-                label=plotkwargs["label"] + r" $\dot{E}_{rad,\alpha}$ analytical",
+                label=label + r" $\dot{E}_{rad,\alpha}$ analytical",
                 linestyle="solid",
                 color=color_alpha,
             )
@@ -142,7 +219,7 @@ def plot_deposition_thermalisation(
                 depdata["tmid_days"],
                 convert_lum_lsun_to_plotunits(depdata["eps_alpha_Lsun"].to_numpy(), args),
                 **plotkwargs,
-                label=plotkwargs["label"] + r" $\dot{E}_{rad,\alpha}$",
+                label=label + r" $\dot{E}_{rad,\alpha}$",
                 linestyle="dashed",
                 color=color_alpha,
             )
@@ -151,43 +228,30 @@ def plot_deposition_thermalisation(
             depdata["tmid_days"],
             convert_lum_lsun_to_plotunits(depdata["alphadep_Lsun"].to_numpy(), args),
             **plotkwargs,
-            label=plotkwargs["label"] + r" $\dot{E}_{dep,\alpha}$",
+            label=label + r" $\dot{E}_{dep,\alpha}$",
             linestyle="dotted",
             color=color_alpha,
         )
 
     if args.plotthermalisation:
         assert axistherm is not None
-        f_gamma = depdata["gammadep_Lsun"] / depdata["eps_gamma_Lsun"]
-        axistherm.plot(
-            depdata["tmid_days"],
-            f_gamma,
-            **plotkwargs,
-            label=modelname + r" $\left(\dot{E}_{dep,\gamma} \middle/ \dot{E}_{rad,\gamma}\right)$",
-            linestyle="solid",
-            color=color_gamma,
-        )
-
-        f_beta = depdata["elecdep_Lsun"] / depdata["eps_elec_Lsun"]
-        axistherm.plot(
-            depdata["tmid_days"],
-            f_beta,
-            **plotkwargs,
-            label=modelname + r" $\left(\dot{E}_{dep,\beta^-} \middle/ \dot{E}_{rad,\beta^-}\right)$",
-            linestyle="solid",
-            color=color_beta,
-        )
-
-        f_alpha = depdata["alphadep_Lsun"] / depdata["eps_alpha_Lsun"]
-
-        axistherm.plot(
-            depdata["tmid_days"],
-            f_alpha,
-            **plotkwargs,
-            label=modelname + r" $\left(\dot{E}_{dep,\alpha} \middle/ \dot{E}_{rad,\alpha}\right)$",
-            linestyle="solid",
-            color=color_alpha,
-        )
+        # an older deposition.out has only the gamma columns, so skip any ratio whose columns are absent
+        thermalisation_ratios = [
+            ("gammadep_Lsun", "eps_gamma_Lsun", r"\dot{E}_{dep,\gamma} \middle/ \dot{E}_{rad,\gamma}", color_gamma),
+            ("elecdep_Lsun", "eps_elec_Lsun", r"\dot{E}_{dep,\beta^-} \middle/ \dot{E}_{rad,\beta^-}", color_beta),
+            ("alphadep_Lsun", "eps_alpha_Lsun", r"\dot{E}_{dep,\alpha} \middle/ \dot{E}_{rad,\alpha}", color_alpha),
+        ]
+        for depcol, epscol, ratiolabel, ratiocolor in thermalisation_ratios:
+            if depcol not in depdata or epscol not in depdata:
+                continue
+            axistherm.plot(
+                depdata["tmid_days"],
+                depdata[depcol] / depdata[epscol],
+                **plotkwargs,
+                label=modelname + rf" $\left({ratiolabel}\right)$",
+                linestyle="solid",
+                color=ratiocolor,
+            )
 
         ejecta_ke_erg: float | int = dfmodel.select("kinetic_en_erg").sum().collect().item()
 
@@ -432,13 +496,7 @@ def plot_artis_lightcurve(
         if pellet_nucname is not None:
             plotkwargs["color"] = None
 
-        if args.magnitude:
-            # convert to bol magnitude
-            ycolumn = "mag"
-        elif args.Lsun:
-            ycolumn = "luminosity_Lsun"
-        else:
-            ycolumn = "luminosity_erg/s"
+        ycolumn = get_plot_lum_column(args)
 
         if (
             args.average_over_phi_angle
@@ -527,6 +585,14 @@ def plot_artis_lightcurve(
     return lcdataframes
 
 
+def set_time_axis_limits(axis: mplax.Axes, args: argparse.Namespace) -> None:
+    """Apply the requested time limits, leaving an unset side to autoscale to the plotted data."""
+    if args.timemin is not None:
+        axis.set_xlim(left=args.timemin)
+    if args.timemax is not None:
+        axis.set_xlim(right=args.timemax)
+
+
 def make_lightcurve_plot(
     modelpaths: Sequence[str | Path],
     filenameout: str | Path,
@@ -553,17 +619,6 @@ def make_lightcurve_plot(
         tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0},
     )
     axis.margins(x=0.0)
-    if args.magnitude:
-        axis.invert_yaxis()
-
-    if args.timemin is not None:
-        axis.set_xlim(xmin=args.timemin)
-    if args.timemax is not None:
-        axis.set_xlim(xmax=args.timemax)
-    if args.ymin is not None:
-        axis.set_ylim(ymin=args.ymin)
-    if args.ymax is not None:
-        axis.set_ylim(ymax=args.ymax)
 
     if args.plotthermalisation:
         figtherm, axistherm = plt.subplots(
@@ -576,11 +631,6 @@ def make_lightcurve_plot(
 
         axistherm.set_ylabel("Thermalisation ratio")
         axistherm.set_xlabel(r"Time [days]")
-        if args.timemin is not None:
-            axistherm.set_xlim(left=args.timemin)
-        if args.timemax is not None:
-            axistherm.set_xlim(right=args.timemax)
-        axistherm.set_ylim(bottom=0.0)
     else:
         axistherm = None
 
@@ -597,40 +647,15 @@ def make_lightcurve_plot(
     lcindex = 0
     for modelpath in modelpaths:
         if not Path(modelpath).is_dir() and not Path(modelpath).exists() and "." in str(modelpath):
-            bolreflightcurve = Path(modelpath)
-
-            dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
-            lightcurvelabel = args.label[lcindex] or metadata.get("label", bolreflightcurve)
-            color = args.color[lcindex] or ["0.0", "0.5", "0.7"][reflightcurveindex]
-            lum_lsun = dflightcurve["luminosity_erg/s"].to_numpy() / Lsun_to_erg_per_s
-            if (
-                "luminosity_errminus_erg/s" in dflightcurve.columns
-                and "luminosity_errplus_erg/s" in dflightcurve.columns
-            ):
-                axis.errorbar(
-                    dflightcurve["time_days"],
-                    convert_lum_lsun_to_plotunits(lum_lsun, args),
-                    yerr=get_reflightcurve_yerr(
-                        lum_lsun,
-                        dflightcurve["luminosity_errminus_erg/s"].to_numpy() / Lsun_to_erg_per_s,
-                        dflightcurve["luminosity_errplus_erg/s"].to_numpy() / Lsun_to_erg_per_s,
-                        args,
-                    ),
-                    fmt="o",
-                    capsize=3,
-                    label=lightcurvelabel,
-                    color=color,
-                    zorder=0,
-                )
-            else:
-                axis.scatter(
-                    dflightcurve["time_days"],
-                    convert_lum_lsun_to_plotunits(lum_lsun, args),
-                    label=lightcurvelabel,
-                    color=color,
-                    zorder=0,
-                )
-            print(f"====> {lightcurvelabel}")
+            # cycle the default greys so a fourth reference curve does not run off the end of the list
+            refcolors = ["0.0", "0.5", "0.7"]
+            plot_bol_reflightcurve(
+                axis,
+                Path(modelpath),
+                args,
+                color=args.color[lcindex] or refcolors[reflightcurveindex % len(refcolors)],
+                label=args.label[lcindex],
+            )
             reflightcurveindex += 1
             plottedsomething = True
 
@@ -700,15 +725,7 @@ def make_lightcurve_plot(
 
     if args.reflightcurves:
         for bolreflightcurve in args.reflightcurves:
-            bollightcurve_data, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
-            axis.scatter(
-                bollightcurve_data["time_days"],
-                convert_lum_lsun_to_plotunits(
-                    bollightcurve_data["luminosity_erg/s"].to_numpy() / Lsun_to_erg_per_s, args
-                ),
-                label=metadata.get("label", bolreflightcurve),
-                color="k",
-            )
+            plot_bol_reflightcurve(axis, bolreflightcurve, args, color="k")
             plottedsomething = True
 
     assert plottedsomething
@@ -723,13 +740,20 @@ def make_lightcurve_plot(
 
     axis.set_xlabel(r"Time [days]")
 
-    if args.magnitude:
-        axis.set_ylabel("Absolute Bolometric Magnitude")
+    # plot_deposition_thermalisation draws the deposition rates on the main axis for either flag
+    showsdeposition = args.plotdeposition or args.plotthermalisation
+
+    lumunit = get_plot_lum_unit(args)
+    if lumunit == "mag":
+        # deposition rates are converted onto the same magnitude axis, so say so when they are drawn
+        axis.set_ylabel(
+            r"Absolute Bolometric Magnitude ($L$ or $\dot{E}$)" if showsdeposition else "Absolute Bolometric Magnitude"
+        )
     else:
-        str_units = r" [{}$\mathrm{{L}}_\odot$]" if args.Lsun else " [{}erg/s]"
+        str_units = r" [{}$\mathrm{{L}}_\odot$]" if lumunit == "Lsun" else " [{}erg/s]"
         if args.logscaley:
             str_units = str_units.replace("{}", "")
-        if args.plotdeposition:
+        if showsdeposition:
             yvarname = r"$L$ or $\dot{{E}}$"
         elif showgamma and not showuvoir:
             yvarname = r"$\mathrm{{L}}_\gamma$"
@@ -756,6 +780,22 @@ def make_lightcurve_plot(
 
     if args.logscaley:
         axis.set_yscale("log")
+
+    # set the limits only now that the data is drawn: on an empty axes matplotlib turns autoscaling off, so a
+    # one-sided limit would freeze the other side at the default 0-1 view instead of fitting the light curves
+    set_time_axis_limits(axis, args)
+    if args.ymin is not None:
+        axis.set_ylim(bottom=args.ymin)
+    if args.ymax is not None:
+        axis.set_ylim(top=args.ymax)
+    if args.magnitude:
+        # invert last: set_ylim always writes the limits back in ascending order, undoing an earlier inversion
+        axis.invert_yaxis()
+
+    if args.plotthermalisation:
+        assert axistherm is not None
+        set_time_axis_limits(axistherm, args)
+        axistherm.set_ylim(bottom=0.0)
 
     if args.show:
         plt.show()

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1151,6 +1151,15 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
         dirbins, dirbin_definition = at.lightcurve.parse_directionbin_args(modelpath, args)
 
         for index, dirbin in enumerate(dirbins):
+            if len(dirbins) > 1:
+                # -color has one colour per model, which cannot distinguish a model's direction bins, so take a
+                # colour per bin from the colour map instead, wrapping around when it runs out. The colour is
+                # chosen once per bin, so a bin keeps its colour across the subplots of the filter pairs.
+                dirbincolor = color_list[angle_counter % len(color_list)]
+                angle_counter += 1
+            else:
+                dirbincolor = args.color[modelnumber]
+
             for plotnumber, filters in enumerate(args.colour_evolution):
                 filter_names = filters.split("-")
                 args.filter = filter_names
@@ -1166,13 +1175,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 if filterfunc is not None:
                     colour_delta_mag = filterfunc(colour_delta_mag)
 
-                if len(dirbins) > 1:
-                    # -color has one colour per model, which cannot distinguish a model's direction bins, so
-                    # take a colour per line from the colour map instead, wrapping around when it runs out
-                    plotkwargs["color"] = color_list[angle_counter % len(color_list)]
-                    angle_counter += 1
-                else:
-                    plotkwargs["color"] = args.color[modelnumber]
+                plotkwargs["color"] = dirbincolor
                 plotkwargs["linestyle"] = args.linestyle[modelnumber]
 
                 if args.reflightcurves and modelnumber == 0:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -43,6 +43,7 @@ from artistools.misc import print_theta_phi_definitions
 from artistools.misc import trim_or_pad
 from artistools.plottools import get_series_colors
 from artistools.plottools import get_unused_colors
+from artistools.plottools import iter_axes
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 from artistools.plottools import set_prop_cycle_unusedcolors
@@ -65,6 +66,15 @@ def get_plot_lum_unit(args: argparse.Namespace) -> LumUnit:
 def get_plot_lum_column(lumunit: LumUnit) -> str:
     """Return the light curve dataframe column holding the luminosity in the y axis units."""
     return "mag" if lumunit == "mag" else f"luminosity_{lumunit}"
+
+
+def shows_deposition(args: argparse.Namespace) -> bool:
+    """Return whether plot_deposition_thermalisation draws deposition rates on the light curve axis.
+
+    Every deposition flag puts the gamma and beta curves on that axis, so the y axis label has to agree
+    with the same condition that decides whether to call it.
+    """
+    return bool(args.plotdeposition or args.plotalphadeposition or args.plotthermalisation)
 
 
 def convert_lum_lsun_to_plotunits(
@@ -176,7 +186,7 @@ def plot_deposition_thermalisation(
     at.plottools.get_next_color(axis)  # skip a colour so the deposition curves differ from the light curve
     color_gamma = at.plottools.get_next_color(axis)
     color_beta = at.plottools.get_next_color(axis)
-    color_alpha = "C1"
+    color_alpha = at.plottools.get_next_color(axis)
 
     depositioncurves = [
         ("gammadep_Lsun", r" $\dot{E}_{dep,\gamma}$", "dashed", color_gamma),
@@ -299,9 +309,14 @@ def plot_artis_lightcurve(
     args: argparse.Namespace | None = None,
     pellet_nucname: str | None = None,
     use_pellet_decay_time: bool = False,
+    showdeposition: bool = True,
     **plotkwargs: t.Any,
 ) -> dict[int, pl.DataFrame] | None:
-    """Plot one model's bolometric light curve, and return the plotted data per direction bin."""
+    """Plot one model's bolometric light curve, and return the plotted data per direction bin.
+
+    The deposition rates belong to the model rather than to one escape type or pellet nuclide, so a caller
+    that plots several series from one model asks for them on one series only, with showdeposition.
+    """
     if args is None:
         args = argparse.Namespace()
     if escape_type not in {"TYPE_RPKT", "TYPE_GAMMA"}:
@@ -551,7 +566,7 @@ def plot_artis_lightcurve(
                 **plotkwargs,
             )
 
-    if args.plotdeposition or args.plotalphadeposition or args.plotthermalisation:
+    if showdeposition and shows_deposition(args):
         # plotkwargs is whatever the direction bin loop above left behind, so build the deposition style from
         # the command line instead of inheriting one bin's colour, transparency, z order and line width
         depositionkwargs: dict[str, t.Any] = {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
@@ -566,8 +581,7 @@ def invert_magnitude_yaxis(ax: mplax.Axes | npt.NDArray[t.Any]) -> None:
     invert_yaxis() toggles rather than sets and the axes of a subplot grid share one y axis, so calling it once
     per plotted series flips the axis back and forth instead of inverting it.
     """
-    firstaxis = ax if isinstance(ax, mplax.Axes) else ax[0]
-    assert isinstance(firstaxis, mplax.Axes)
+    firstaxis = iter_axes(ax)[0]
     ymin, ymax = firstaxis.get_ylim()
     if ymin < ymax:
         firstaxis.invert_yaxis()
@@ -688,6 +702,9 @@ def make_lightcurve_plot(
                         args=args,
                         pellet_nucname=pellet_nucname,
                         use_pellet_decay_time=args.use_pellet_decay_time,
+                        # one model can contribute an r-packet series, a gamma series and one series per
+                        # nuclide, but it has a single set of deposition rates to draw
+                        showdeposition=escape_type == escape_types[0] and pellet_nucname is None,
                         linestyle=args.linestyle[lcindex]
                         if (escape_type == "TYPE_RPKT" or len(escape_types) == 1)
                         else ":",
@@ -715,8 +732,7 @@ def make_lightcurve_plot(
 
     axis.set_xlabel(r"Time [days]")
 
-    # plot_deposition_thermalisation draws the deposition rates on the main axis for either flag
-    showsdeposition = args.plotdeposition or args.plotalphadeposition or args.plotthermalisation
+    showsdeposition = shows_deposition(args)
 
     if lumunit == "mag":
         # the gamma-ray light curve and the deposition rates are converted onto this same magnitude axis, so
@@ -753,10 +769,11 @@ def make_lightcurve_plot(
 
     # set the limits only now that the data is drawn: on an empty axes matplotlib turns autoscaling off, so a
     # one-sided limit would freeze the other side at the default 0-1 view instead of fitting the light curves
-    set_time_axis_limits(axis, args)
     # the y limits, the log scales and the tick style are shared with the band and colour evolution figures.
     # This parser has no -xmin/-xmax (the time range is -timemin/-timemax), so it leaves the x limits alone
     at.plottools.set_axis_properties(axis, args)
+    # after the scales, so that a non-positive time limit on a log axis is rejected rather than applied
+    set_time_axis_limits(axis, args)
     if lumunit == "mag":
         # invert last: set_ylim re-sorts the limits into the order of the pair it is given, so an inversion
         # applied before a one-sided limit is lost
@@ -765,7 +782,9 @@ def make_lightcurve_plot(
     if args.plotthermalisation:
         assert axistherm is not None
         set_time_axis_limits(axistherm, args)
-        axistherm.set_ylim(bottom=0.0)
+        # a thermalisation efficiency is a ratio, so keep the physical range rather than letting a
+        # near-zero denominator at one timestep rescale every curve into the bottom of the panel
+        axistherm.set_ylim(0.0, 1.0)
 
     if args.show:
         plt.show()
@@ -983,7 +1002,7 @@ def make_band_lightcurves_plot(
 
     # a model with several direction bins takes its line colours from the cycle, so keep the cycle clear of
     # the colours that other series were given
-    set_prop_cycle_unusedcolors([ax] if isinstance(ax, mplax.Axes) else ax.tolist(), [*args.color, *args.refspeccolors])
+    set_prop_cycle_unusedcolors(iter_axes(ax), [*args.color, *args.refspeccolors])
 
     plotkwargs: dict[str, t.Any] = {}
 
@@ -1196,7 +1215,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
 
     invert_magnitude_yaxis(ax)
 
-    args.outputfile = Path(outputfolder, f"plotcolorevolution{filter_names[0]}-{filter_names[1]}.pdf")
+    args.outputfile = Path(outputfolder, f"plotcolorevolution{'_'.join(args.colour_evolution)}.pdf")
 
     if args.show:
         plt.show()

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1162,17 +1162,11 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 if filterfunc is not None:
                     colour_delta_mag = filterfunc(colour_delta_mag)
 
-                if args.color and args.plotviewingangle:
-                    print(
-                        "WARNING: -color argument will not work with viewing angles for colour evolution plots,"
-                        "colours are taken from color_list array instead"
-                    )
-                    # plotkwargs["color"] = color_list[angle_counter]  # index instead of angle_counter??
-                    angle_counter += 1
-                elif args.plotviewingangle:
+                if args.plotviewingangle:
+                    # one colour per direction bin, so the -color argument (one colour per model) is not used here
                     plotkwargs["color"] = color_list[angle_counter]
                     angle_counter += 1
-                elif args.color:
+                else:
                     plotkwargs["color"] = args.color[modelnumber]
                 if args.linestyle:
                     plotkwargs["linestyle"] = args.linestyle[modelnumber]

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1091,8 +1091,9 @@ def make_band_lightcurves_plot(
                                 plotnumber,
                             )
 
-                if len(dirbins) == 1:
-                    plotkwargs["color"] = args.color[modelnumber]
+                # a model with several direction bins has only one -color entry to share between them, so let
+                # matplotlib pick a colour per line. plotkwargs is reused, so clear any previous model's colour
+                plotkwargs["color"] = args.color[modelnumber] if len(dirbins) == 1 else None
 
                 if args.colorbarcostheta or args.colorbarphi:
                     # Update plotkwargs with viewing angle colour
@@ -1101,8 +1102,7 @@ def make_band_lightcurves_plot(
                         dirbin, costheta_viewing_angle_bins, phi_viewing_angle_bins, scaledmap, plotkwargs, args
                     )
 
-                if args.linestyle:
-                    plotkwargs["linestyle"] = args.linestyle[modelnumber]
+                plotkwargs["linestyle"] = args.linestyle[modelnumber]
 
                 axis.plot(time, brightness_in_mag, linewidth=4 if args.subplots else 3.5, **plotkwargs)
 
@@ -1162,14 +1162,14 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 if filterfunc is not None:
                     colour_delta_mag = filterfunc(colour_delta_mag)
 
-                if args.plotviewingangle:
-                    # one colour per direction bin, so the -color argument (one colour per model) is not used here
-                    plotkwargs["color"] = color_list[angle_counter]
+                if len(dirbins) > 1:
+                    # -color has one colour per model, which cannot distinguish a model's direction bins, so
+                    # take a colour per line from the colour map instead, wrapping around when it runs out
+                    plotkwargs["color"] = color_list[angle_counter % len(color_list)]
                     angle_counter += 1
                 else:
                     plotkwargs["color"] = args.color[modelnumber]
-                if args.linestyle:
-                    plotkwargs["linestyle"] = args.linestyle[modelnumber]
+                plotkwargs["linestyle"] = args.linestyle[modelnumber]
 
                 if args.reflightcurves and modelnumber == 0:
                     if len(dirbins) > 1 and index > 0:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -26,7 +26,6 @@ from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Msun_to_g
-from artistools.lightcurve.lightcurve import derived_lum_unit_cols
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
 from artistools.lightcurve.lightcurve import lum_lsun_to_mag
 from artistools.lightcurve.lightcurve import path_is_reference_lightcurve
@@ -37,6 +36,7 @@ from artistools.misc import add_maxpacketfiles_arg
 from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_series_style_args
+from artistools.misc import color_arg
 from artistools.misc import get_series_label
 from artistools.misc import makelist
 from artistools.misc import print_theta_phi_definitions
@@ -102,23 +102,34 @@ def get_reflightcurve_yerr(
     errminus_erg_per_s: npt.NDArray[np.floating[t.Any]],
     errplus_erg_per_s: npt.NDArray[np.floating[t.Any]],
     lumunit: LumUnit,
-) -> list[npt.NDArray[np.floating[t.Any]]]:
-    """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in erg/s and its errors."""
-    if lumunit == "mag":
-        # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
-        mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit)
-        # an error bar reaching zero luminosity has no faintest magnitude, so leave it undefined
-        lum_faintest = np.where(lum_erg_per_s > errminus_erg_per_s, lum_erg_per_s - errminus_erg_per_s, np.nan)
+) -> tuple[list[npt.NDArray[np.floating[t.Any]]], npt.NDArray[np.bool_]]:
+    """Return the [lower, upper] error bar sizes in the y axis units, and which faint sides are unbounded.
+
+    A magnitude bar whose luminosity reaches zero has no faintest magnitude. Putting NaN there makes
+    matplotlib drop the whole bar, including the finite bright half, so that side is given zero length and
+    the point is flagged instead: the caller marks it with an arrow.
+    """
+    if lumunit != "mag":
+        # the conversion is a simple scaling, so it applies to the error sizes directly
         return [
+            convert_lum_ergs_to_plotunits(errminus_erg_per_s, lumunit),
+            convert_lum_ergs_to_plotunits(errplus_erg_per_s, lumunit),
+        ], np.zeros(len(lum_erg_per_s), dtype=np.bool_)
+
+    # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
+    mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit)
+    hasmag = np.isfinite(mag)
+    unbounded = (errminus_erg_per_s >= lum_erg_per_s) & hasmag
+    lum_faintest = np.where(unbounded, lum_erg_per_s, lum_erg_per_s - errminus_erg_per_s)
+
+    with np.errstate(invalid="ignore"):
+        yerr = [
             mag - convert_lum_ergs_to_plotunits(lum_erg_per_s + errplus_erg_per_s, lumunit),
             convert_lum_ergs_to_plotunits(lum_faintest, lumunit) - mag,
         ]
 
-    # the conversion is a simple scaling, so it applies to the error sizes directly
-    return [
-        convert_lum_ergs_to_plotunits(errminus_erg_per_s, lumunit),
-        convert_lum_ergs_to_plotunits(errplus_erg_per_s, lumunit),
-    ]
+    # a non-positive luminosity has no magnitude to draw a bar around, and inf bounds make matplotlib warn
+    return [np.where(hasmag, errside, 0.0) for errside in yerr], unbounded
 
 
 def plot_bol_reflightcurve(
@@ -131,31 +142,31 @@ def plot_bol_reflightcurve(
     dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(lightcurvefilename)
     plotlabel = label or str(metadata.get("label", lightcurvefilename))
     lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
+    time_days = dflightcurve["time_days"].to_numpy()
+    yvalues = convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit)
 
     if {"luminosity_errminus_erg/s", "luminosity_errplus_erg/s"}.issubset(dflightcurve.columns):
-        axis.errorbar(
-            dflightcurve["time_days"],
-            convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit),
-            yerr=get_reflightcurve_yerr(
-                lum_erg_per_s,
-                dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
-                dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
-                lumunit,
-            ),
-            fmt="o",
-            capsize=3,
-            label=plotlabel,
-            color=color,
-            zorder=0,
+        yerr, unbounded = get_reflightcurve_yerr(
+            lum_erg_per_s,
+            dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
+            dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
+            lumunit,
         )
+        axis.errorbar(time_days, yvalues, yerr=yerr, fmt="o", capsize=3, label=plotlabel, color=color, zorder=0)
+        if unbounded.any():
+            # matplotlib draws only one side of a bar it is told is a limit, so the open faint side is a
+            # second, zero-length bar whose arrow head sits on the point the bar above already reaches
+            axis.errorbar(
+                time_days[unbounded],
+                yvalues[unbounded],
+                yerr=np.zeros(int(unbounded.sum())),
+                lolims=True,
+                fmt="none",
+                color=color,
+                zorder=0,
+            )
     else:
-        axis.scatter(
-            dflightcurve["time_days"],
-            convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit),
-            label=plotlabel,
-            color=color,
-            zorder=0,
-        )
+        axis.scatter(time_days, yvalues, label=plotlabel, color=color, zorder=0)
 
     return plotlabel
 
@@ -381,16 +392,9 @@ def plot_artis_lightcurve(
             print(f"WARNING: Skipping because {lcfilename} does not exist")
             return None
 
-        lcdataframes = at.lightcurve.readfile(lcpath)
-
-        # averaging is linear, so the magnitude has to be rebuilt from the averaged luminosity
-        unitcols = derived_lum_unit_cols()
-
-        if average_over_phi:
-            lcdataframes = at.average_direction_bins(lcdataframes, overangle="phi", derivedcols=unitcols)
-
-        if average_over_theta:
-            lcdataframes = at.average_direction_bins(lcdataframes, overangle="theta", derivedcols=unitcols)
+        lcdataframes = at.lightcurve.readfile(
+            lcpath, average_over_phi=average_over_phi, average_over_theta=average_over_theta
+        )
 
     lumunit = get_plot_lum_unit(args)
     ycolumn = get_plot_lum_column(lumunit)
@@ -581,14 +585,6 @@ def invert_magnitude_yaxis(ax: mplax.Axes | npt.NDArray[t.Any]) -> None:
             axis.invert_yaxis()
 
 
-def set_time_axis_limits(axis: mplax.Axes, args: argparse.Namespace) -> None:
-    """Apply the requested time limits, leaving an unset side to autoscale to the plotted data."""
-    if args.timemin is not None:
-        axis.set_xlim(left=args.timemin)
-    if args.timemax is not None:
-        axis.set_xlim(right=args.timemax)
-
-
 def make_lightcurve_plot(
     modelpaths: Sequence[str | Path],
     filenameout: str | Path,
@@ -774,11 +770,7 @@ def make_lightcurve_plot(
 
     # set the limits only now that the data is drawn: on an empty axes matplotlib turns autoscaling off, so a
     # one-sided limit would freeze the other side at the default 0-1 view instead of fitting the light curves
-    # the y limits, the log scales and the tick style are shared with the band and colour evolution figures.
-    # This parser has no -xmin/-xmax (the time range is -timemin/-timemax), so it leaves the x limits alone
     at.plottools.set_axis_properties(axis, args)
-    # after the scales, so that a non-positive time limit on a log axis is rejected rather than applied
-    set_time_axis_limits(axis, args)
     if lumunit == "mag":
         # invert last: set_ylim re-sorts the limits into the order of the pair it is given, so an inversion
         # applied before a one-sided limit is lost
@@ -786,7 +778,8 @@ def make_lightcurve_plot(
 
     if args.plotthermalisation:
         assert axistherm is not None
-        set_time_axis_limits(axistherm, args)
+        # the second figure covers the same times as the first, so take its range rather than re-deriving it
+        axistherm.set_xlim(axis.get_xlim())
         # a thermalisation efficiency is a ratio, so keep the physical range rather than letting a
         # near-zero denominator at one timestep rescale every curve into the bottom of the panel
         axistherm.set_ylim(0.0, 1.0)
@@ -1195,12 +1188,6 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                     linewidth=4 if args.subplots else 3,
                 )
 
-            # UNCOMMENT TO ESTIMATE COLOUR AT TIME B MAX
-            # tmax_B = 17.0  # CHANGE TO TIME OF B MAX
-            # tmax_B = at.match_closest_time(tmax_B, plot_times)
-            # print(f'{filter_names[0]} - {filter_names[1]} at t_Bmax ({tmax_B}) = '
-            #       f'{diff[plot_times.index(tmax_B)]}')
-
     for plotnumber, filters in enumerate(args.colour_evolution):
         axes[plotnumber].annotate(
             filters,
@@ -1502,7 +1489,11 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "-refspeccolors", default=[], nargs="*", help="Set a list of colors for the reference light curves"
+        "-refspeccolors",
+        type=color_arg,
+        default=[],
+        nargs="*",
+        help="Set a list of colors for the reference light curves",
     )
 
     parser.add_argument(
@@ -1646,6 +1637,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     args.color, args.label, args.linestyle, args.dashes, args.linewidth = trim_or_pad(
         len(args.modelpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth
     )
+
+    # the x axis is the time axis, so the shared limit helpers see the time range under the name they read
+    args.xmin, args.xmax = args.timemin, args.timemax
 
     args.reflightcurves = makelist(args.reflightcurves)
     args.refspeccolors, args.refspecmarkers = trim_or_pad(

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -189,8 +189,7 @@ def plot_deposition_thermalisation(
         ("elecdep_Lsun", r" $\dot{E}_{dep,\beta^-}$", "dashed", color_beta),
     ]
 
-    plotalphadep = False
-    if plotalphadep:
+    if args.plotalphadeposition:
         depositioncurves += [
             ("eps_alpha_ana_Lsun", r" $\dot{E}_{rad,\alpha}$ analytical", "solid", color_alpha),
             ("eps_alpha_Lsun", r" $\dot{E}_{rad,\alpha}$", "dashed", color_alpha),
@@ -559,7 +558,7 @@ def plot_artis_lightcurve(
                 **plotkwargs,
             )
 
-    if args.plotdeposition or args.plotthermalisation:
+    if args.plotdeposition or args.plotalphadeposition or args.plotthermalisation:
         # plotkwargs is whatever the direction bin loop above left behind, so build the deposition style from
         # the command line instead of inheriting one bin's colour, transparency, z order and line width
         depositionkwargs: dict[str, t.Any] = {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
@@ -724,7 +723,7 @@ def make_lightcurve_plot(
     axis.set_xlabel(r"Time [days]")
 
     # plot_deposition_thermalisation draws the deposition rates on the main axis for either flag
-    showsdeposition = args.plotdeposition or args.plotthermalisation
+    showsdeposition = args.plotdeposition or args.plotalphadeposition or args.plotthermalisation
 
     lumunit = get_plot_lum_unit(args)
     if lumunit == "mag":
@@ -1128,7 +1127,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
         args.labelfontsize = 24
     angle_counter = 0
     # a direction bin must not repeat the colour that a whole model was given, since both go on the same axes
-    assignedcolors = {mplcolors.to_hex(color) for color in [*args.color, *args.refspeccolors] if color}
+    assignedcolors = {mplcolors.to_hex(color) for color in (*args.color, *args.refspeccolors) if color}
     tab20colors = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
     color_list = [color for color in tab20colors if mplcolors.to_hex(color) not in assignedcolors] or tab20colors
 
@@ -1425,6 +1424,10 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     )
 
     parser.add_argument("--plotdeposition", action="store_true", help="Plot model deposition rates")
+
+    parser.add_argument(
+        "--plotalphadeposition", action="store_true", help="Plot alpha decay energy release and deposition rates"
+    )
 
     parser.add_argument(
         "--plotthermalisation", action="store_true", help="Plot thermalisation rates (in separate plot)"

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -27,6 +27,7 @@ from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Mbol_sun
 from artistools.constants import Msun_to_g
+from artistools.lightcurve.lightcurve import derived_lum_unit_cols
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
 from artistools.lightcurve.lightcurve import path_is_reference_lightcurve
 from artistools.misc import add_axis_limit_args
@@ -43,6 +44,9 @@ from artistools.plottools import get_series_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 from artistools.plottools import set_prop_cycle_unusedcolors
+
+if t.TYPE_CHECKING:
+    from collections.abc import Mapping
 
 type LumUnit = t.Literal["mag", "Lsun", "erg/s"]
 
@@ -61,7 +65,9 @@ def get_plot_lum_unit(args: argparse.Namespace) -> LumUnit:
 
 def get_plot_lum_column(args: argparse.Namespace) -> str:
     """Return the light curve dataframe column holding the luminosity in the y axis units."""
-    return {"mag": "mag", "Lsun": "luminosity_Lsun", "erg/s": "luminosity_erg/s"}[get_plot_lum_unit(args)]
+    # annotated so that a unit added to LumUnit without a column here is a type error, not a plot-time KeyError
+    lumcolumns: Mapping[LumUnit, str] = {"mag": "mag", "Lsun": "luminosity_Lsun", "erg/s": "luminosity_erg/s"}
+    return lumcolumns[get_plot_lum_unit(args)]
 
 
 def convert_lum_lsun_to_plotunits(
@@ -94,7 +100,7 @@ def get_reflightcurve_yerr(
     args: argparse.Namespace,
 ) -> list[npt.NDArray[np.floating[t.Any]]]:
     """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in erg/s and its errors."""
-    if args.magnitude:
+    if get_plot_lum_unit(args) == "mag":
         # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
         mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, args)
         # an error bar reaching zero luminosity has no faintest magnitude, so leave it undefined
@@ -155,16 +161,15 @@ def plot_deposition_thermalisation(
     axistherm: mplax.Axes | None,
     modelpath: str | Path,
     modelname: str,
+    label: str,
     args: argparse.Namespace,
     **plotkwargs: t.Any,
 ) -> None:
-    """Plot the gamma-ray and positron deposition rates, and the thermalisation efficiencies when axistherm is given."""
-    # every curve below appends a suffix to the caller's label and picks its own linestyle and colour, so these
-    # must leave the kwargs splat or matplotlib gets them twice ("dashes" silently overrides "linestyle")
-    label = plotkwargs.pop("label")
-    for overridden in ("linestyle", "color", "dashes"):
-        plotkwargs.pop(overridden, None)
+    """Plot the gamma-ray and positron deposition rates, and the thermalisation efficiencies when axistherm is given.
 
+    Every curve below appends its own suffix to label and picks its own linestyle and colour, so plotkwargs must
+    carry none of those: matplotlib would receive them twice ("dashes" also silently overrides "linestyle").
+    """
     if args.plotthermalisation:
         dfmodel, _ = at.inputmodel.get_modeldata(modelpath, derived_cols=["mass_g", "vel_r_mid", "kinetic_en_erg"])
 
@@ -175,70 +180,34 @@ def plot_deposition_thermalisation(
 
     at.plottools.get_next_color(axis)  # skip a colour so the deposition curves differ from the light curve
     color_gamma = at.plottools.get_next_color(axis)
-
-    axis.plot(
-        depdata["tmid_days"],
-        convert_lum_lsun_to_plotunits(depdata["gammadep_Lsun"].to_numpy(), args),
-        **plotkwargs,
-        label=label + r" $\dot{E}_{dep,\gamma}$",
-        linestyle="dashed",
-        color=color_gamma,
-    )
-
     color_beta = at.plottools.get_next_color(axis)
-
-    if "eps_elec_Lsun" in depdata:
-        axis.plot(
-            depdata["tmid_days"],
-            convert_lum_lsun_to_plotunits(depdata["eps_elec_Lsun"].to_numpy(), args),
-            **plotkwargs,
-            label=label + r" $\dot{E}_{rad,\beta^-}$",
-            linestyle="dotted",
-            color=color_beta,
-        )
-
-    if "elecdep_Lsun" in depdata:
-        axis.plot(
-            depdata["tmid_days"],
-            convert_lum_lsun_to_plotunits(depdata["elecdep_Lsun"].to_numpy(), args),
-            **plotkwargs,
-            label=label + r" $\dot{E}_{dep,\beta^-}$",
-            linestyle="dashed",
-            color=color_beta,
-        )
-
-    # color_alpha = axis._get_lines.get_next_color()
     color_alpha = "C1"
+
+    depositioncurves = [
+        ("gammadep_Lsun", r" $\dot{E}_{dep,\gamma}$", "dashed", color_gamma),
+        ("eps_elec_Lsun", r" $\dot{E}_{rad,\beta^-}$", "dotted", color_beta),
+        ("elecdep_Lsun", r" $\dot{E}_{dep,\beta^-}$", "dashed", color_beta),
+    ]
 
     plotalphadep = False
     if plotalphadep:
-        if "eps_alpha_ana_Lsun" in depdata:
-            axis.plot(
-                depdata["tmid_days"],
-                convert_lum_lsun_to_plotunits(depdata["eps_alpha_ana_Lsun"].to_numpy(), args),
-                **plotkwargs,
-                label=label + r" $\dot{E}_{rad,\alpha}$ analytical",
-                linestyle="solid",
-                color=color_alpha,
-            )
+        depositioncurves += [
+            ("eps_alpha_ana_Lsun", r" $\dot{E}_{rad,\alpha}$ analytical", "solid", color_alpha),
+            ("eps_alpha_Lsun", r" $\dot{E}_{rad,\alpha}$", "dashed", color_alpha),
+            ("alphadep_Lsun", r" $\dot{E}_{dep,\alpha}$", "dotted", color_alpha),
+        ]
 
-        if "eps_alpha_Lsun" in depdata:
-            axis.plot(
-                depdata["tmid_days"],
-                convert_lum_lsun_to_plotunits(depdata["eps_alpha_Lsun"].to_numpy(), args),
-                **plotkwargs,
-                label=label + r" $\dot{E}_{rad,\alpha}$",
-                linestyle="dashed",
-                color=color_alpha,
-            )
-
+    # an older deposition.out has only the gamma columns, so skip any curve whose column is absent
+    for depcol, labelsuffix, curvelinestyle, curvecolor in depositioncurves:
+        if depcol not in depdata:
+            continue
         axis.plot(
             depdata["tmid_days"],
-            convert_lum_lsun_to_plotunits(depdata["alphadep_Lsun"].to_numpy(), args),
+            convert_lum_lsun_to_plotunits(depdata[depcol].to_numpy(), args),
             **plotkwargs,
-            label=label + r" $\dot{E}_{dep,\alpha}$",
-            linestyle="dotted",
-            color=color_alpha,
+            label=label + labelsuffix,
+            linestyle=curvelinestyle,
+            color=curvecolor,
         )
 
     if args.plotthermalisation:
@@ -413,6 +382,11 @@ def plot_artis_lightcurve(
         if average_over_theta:
             lcdataframes = at.average_direction_bins(lcdataframes, overangle="theta")
 
+        if average_over_phi or average_over_theta:
+            # averaging is linear, so it is only valid for the luminosity columns. Rebuild the magnitude from
+            # the averaged luminosity rather than averaging magnitudes, which a single dark bin sends to inf.
+            lcdataframes = {dirbin: lzdf.with_columns(derived_lum_unit_cols()) for dirbin, lzdf in lcdataframes.items()}
+
     if args.dashes[lcindex]:
         plotkwargs["dashes"] = args.dashes[lcindex]
     if args.linewidth[lcindex]:
@@ -571,7 +545,7 @@ def plot_artis_lightcurve(
             print(lcdata)
 
         if args.plotcmf:
-            assert not args.magnitude, "Cannot plot cmf luminosity if magnitude is selected"
+            assert get_plot_lum_unit(args) != "mag", "Cannot plot cmf luminosity if magnitude is selected"
             plotkwargs["linewidth"] = 1
             if not linelabel_is_custom:
                 assert label_with_tags is not None
@@ -586,11 +560,27 @@ def plot_artis_lightcurve(
             )
 
     if args.plotdeposition or args.plotthermalisation:
+        # plotkwargs is whatever the direction bin loop above left behind, so build the deposition style from
+        # the command line instead of inheriting one bin's colour, transparency, z order and line width
+        depositionkwargs: dict[str, t.Any] = {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
         plot_deposition_thermalisation(
-            axis, axistherm, modelpath, label=linelabel, args=args, modelname=linelabel, **plotkwargs
+            axis, axistherm, modelpath, label=linelabel, args=args, modelname=linelabel, **depositionkwargs
         )
 
     return lcdataframes
+
+
+def invert_magnitude_yaxis(ax: mplax.Axes | npt.NDArray[t.Any]) -> None:
+    """Point the magnitude axis downwards, so that a brighter series is drawn higher.
+
+    invert_yaxis() toggles rather than sets and the axes of a subplot grid share one y axis, so calling it once
+    per plotted series flips the axis back and forth instead of inverting it.
+    """
+    firstaxis = ax if isinstance(ax, mplax.Axes) else ax[0]
+    assert isinstance(firstaxis, mplax.Axes)
+    ymin, ymax = firstaxis.get_ylim()
+    if ymin < ymax:
+        firstaxis.invert_yaxis()
 
 
 def set_time_axis_limits(axis: mplax.Axes, args: argparse.Namespace) -> None:
@@ -738,10 +728,12 @@ def make_lightcurve_plot(
 
     lumunit = get_plot_lum_unit(args)
     if lumunit == "mag":
-        # deposition rates are converted onto the same magnitude axis, so say so when they are drawn
-        axis.set_ylabel(
-            r"Absolute Bolometric Magnitude ($L$ or $\dot{E}$)" if showsdeposition else "Absolute Bolometric Magnitude"
-        )
+        # the gamma-ray light curve and the deposition rates are converted onto this same magnitude axis, so
+        # the label must name what is drawn rather than always claiming a bolometric luminosity
+        ylabel = r"Absolute $\gamma$-ray Magnitude" if showgamma and not showuvoir else "Absolute Bolometric Magnitude"
+        if showsdeposition:
+            ylabel += r" ($L$ or $\dot{E}$)"
+        axis.set_ylabel(ylabel)
     else:
         str_units = r" [{}$\mathrm{{L}}_\odot$]" if lumunit == "Lsun" else " [{}erg/s]"
         if args.logscaley:
@@ -781,9 +773,10 @@ def make_lightcurve_plot(
         axis.set_ylim(bottom=args.ymin)
     if args.ymax is not None:
         axis.set_ylim(top=args.ymax)
-    if args.magnitude:
-        # invert last: set_ylim always writes the limits back in ascending order, undoing an earlier inversion
-        axis.invert_yaxis()
+    if lumunit == "mag":
+        # invert last: set_ylim re-sorts the limits into the order of the pair it is given, so an inversion
+        # applied before a one-sided limit is lost
+        invert_magnitude_yaxis(axis)
 
     if args.plotthermalisation:
         assert axistherm is not None
@@ -1121,14 +1114,10 @@ def make_band_lightcurves_plot(
 
     if args.filter and len(band_lightcurve_data) == 1:
         args.outputfile = Path(outputfolder, f"plot{first_band_name}lightcurves.pdf")
+    invert_magnitude_yaxis(ax)
+
     if args.show:
         plt.show()
-
-    firstaxis = ax if isinstance(ax, mplax.Axes) else ax[0]
-    assert isinstance(firstaxis, mplax.Axes)
-    ymin, ymax = firstaxis.get_ylim()
-    if ymin < ymax:
-        firstaxis.invert_yaxis()
 
     save_figure(fig, args.outputfile, format="pdf")
 
@@ -1138,7 +1127,10 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
     if args.labelfontsize is None:
         args.labelfontsize = 24
     angle_counter = 0
-    color_list = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
+    # a direction bin must not repeat the colour that a whole model was given, since both go on the same axes
+    assignedcolors = {mplcolors.to_hex(color) for color in [*args.color, *args.refspeccolors] if color}
+    tab20colors = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
+    color_list = [color for color in tab20colors if mplcolors.to_hex(color) not in assignedcolors] or tab20colors
 
     fig, ax = create_axes(args)
 
@@ -1160,13 +1152,14 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
             else:
                 dirbincolor = args.color[modelnumber]
 
+            # the filter pairs share bands, so integrate the bands of every pair once for this direction bin
+            args.filter = sorted({name for filters in args.colour_evolution for name in filters.split("-")})
+            band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
+                modelpath, args, dirbin=dirbin, modelnumber=modelnumber
+            )
+
             for plotnumber, filters in enumerate(args.colour_evolution):
                 filter_names = filters.split("-")
-                args.filter = filter_names
-                band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-                    modelpath, args, dirbin=dirbin, modelnumber=modelnumber
-                )
-
                 plot_times, colour_delta_mag = at.lightcurve.get_colour_delta_mag(band_lightcurve_data, filter_names)
 
                 plotkwargs["label"] = get_linelabel(modelname, modelnumber, dirbin, dirbin_definition, args)
@@ -1197,7 +1190,6 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 curax.plot(plot_times, colour_delta_mag, linewidth=4 if args.subplots else 3, **plotkwargs)
 
                 assert isinstance(curax, mplax.Axes)
-                curax.invert_yaxis()
                 curax.annotate(
                     f"{filter_names[0]}-{filter_names[1]}",
                     xy=(1.0, 1.0),
@@ -1218,6 +1210,8 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
     fig, ax = set_lightcurve_plot_labels(fig, ax, args, colour_evolution=True)
     ax = at.plottools.set_axis_properties(ax, args)
     set_lightcurveplot_legend(ax, args)
+
+    invert_magnitude_yaxis(ax)
 
     args.outputfile = Path(outputfolder, f"plotcolorevolution{filter_names[0]}-{filter_names[1]}.pdf")
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -178,7 +178,8 @@ def plot_deposition_thermalisation(
     if args.plotthermalisation:
         dfmodel, _ = at.inputmodel.get_modeldata(modelpath, derived_cols=["mass_g", "vel_r_mid", "kinetic_en_erg"])
 
-        model_mass_grams = dfmodel.select("mass_g").sum().collect().item()
+        # one collect for both sums: get_modeldata returns a plan, so a second one re-derives every column
+        model_mass_grams, ejecta_ke_erg = dfmodel.select(pl.sum("mass_g"), pl.sum("kinetic_en_erg")).collect().row(0)
         print(f"  model mass: {model_mass_grams / Msun_to_g:.3f} Msun")
 
     depdata = at.get_deposition(modelpath).collect()
@@ -233,8 +234,6 @@ def plot_deposition_thermalisation(
                 linestyle="solid",
                 color=ratiocolor,
             )
-
-        ejecta_ke_erg: float | int = dfmodel.select("kinetic_en_erg").sum().collect().item()
 
         print(f"  ejecta kinetic energy: {ejecta_ke_erg / 1e7:.2e} [J] = {ejecta_ke_erg:.2e} [erg]")
 
@@ -301,7 +300,6 @@ def plot_artis_lightcurve(
     escape_type: str = "TYPE_RPKT",
     frompackets: bool = False,
     maxpacketfiles: int | None = None,
-    axistherm: mplax.Axes | None = None,
     directionbins: Sequence[int] | None = None,
     average_over_phi: bool = False,
     average_over_theta: bool = False,
@@ -309,14 +307,9 @@ def plot_artis_lightcurve(
     args: argparse.Namespace | None = None,
     pellet_nucname: str | None = None,
     use_pellet_decay_time: bool = False,
-    showdeposition: bool = True,
     **plotkwargs: t.Any,
 ) -> dict[int, pl.DataFrame] | None:
-    """Plot one model's bolometric light curve, and return the plotted data per direction bin.
-
-    The deposition rates belong to the model rather than to one escape type or pellet nuclide, so a caller
-    that plots several series from one model asks for them on one series only, with showdeposition.
-    """
+    """Plot one model's bolometric light curve, and return the plotted data per direction bin."""
     if args is None:
         args = argparse.Namespace()
     if escape_type not in {"TYPE_RPKT", "TYPE_GAMMA"}:
@@ -385,13 +378,14 @@ def plot_artis_lightcurve(
 
         lcdataframes = at.lightcurve.readfile(lcpath)
 
+        # averaging is linear, so the magnitude has to be rebuilt from the averaged luminosity
+        unitcols = derived_lum_unit_cols()
+
         if average_over_phi:
-            lcdataframes = at.average_direction_bins(lcdataframes, overangle="phi", derivedcols=derived_lum_unit_cols())
+            lcdataframes = at.average_direction_bins(lcdataframes, overangle="phi", derivedcols=unitcols)
 
         if average_over_theta:
-            lcdataframes = at.average_direction_bins(
-                lcdataframes, overangle="theta", derivedcols=derived_lum_unit_cols()
-            )
+            lcdataframes = at.average_direction_bins(lcdataframes, overangle="theta", derivedcols=unitcols)
 
     lumunit = get_plot_lum_unit(args)
     ycolumn = get_plot_lum_column(lumunit)
@@ -566,12 +560,6 @@ def plot_artis_lightcurve(
                 **plotkwargs,
             )
 
-    if showdeposition and shows_deposition(args):
-        # plotkwargs is whatever the direction bin loop above left behind, so build the deposition style from
-        # the command line instead of inheriting one bin's colour, transparency, z order and line width
-        depositionkwargs: dict[str, t.Any] = {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
-        plot_deposition_thermalisation(axis, axistherm, modelpath, modelname=linelabel, args=args, **depositionkwargs)
-
     return lcdataframes
 
 
@@ -652,6 +640,7 @@ def make_lightcurve_plot(
             plottedsomething = True
 
         else:
+            plottedthismodel = False
             dirbin = args.plotviewingangle or (args.plotvspecpol or [-1])
             escape_types: list[str] = ["TYPE_RPKT"] if showuvoir else []
             if showgamma:
@@ -694,7 +683,6 @@ def make_lightcurve_plot(
                         escape_type=escape_type,
                         frompackets=frompackets,
                         maxpacketfiles=maxpacketfiles,
-                        axistherm=axistherm,
                         directionbins=dirbin,
                         average_over_phi=args.average_over_phi_angle,
                         average_over_theta=args.average_over_theta_angle,
@@ -702,9 +690,6 @@ def make_lightcurve_plot(
                         args=args,
                         pellet_nucname=pellet_nucname,
                         use_pellet_decay_time=args.use_pellet_decay_time,
-                        # one model can contribute an r-packet series, a gamma series and one series per
-                        # nuclide, but it has a single set of deposition rates to draw
-                        showdeposition=escape_type == escape_types[0] and pellet_nucname is None,
                         linestyle=args.linestyle[lcindex]
                         if (escape_type == "TYPE_RPKT" or len(escape_types) == 1)
                         else ":",
@@ -712,6 +697,22 @@ def make_lightcurve_plot(
                         linelabel=args.label[lcindex],
                     )
                     plottedsomething = plottedsomething or (lcdataframes is not None)
+                    plottedthismodel = plottedthismodel or (lcdataframes is not None)
+
+            if plottedthismodel and shows_deposition(args):
+                # the rates belong to the model, not to one escape type or pellet nuclide, and the style
+                # comes from the command line rather than from whatever a series left in its plot kwargs
+                depositionkwargs: dict[str, t.Any] = (
+                    {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
+                )
+                plot_deposition_thermalisation(
+                    axis,
+                    axistherm,
+                    Path(modelpath).parent if Path(modelpath).is_file() else Path(modelpath),
+                    modelname=get_series_label(args.label, lcindex, at.get_model_name(modelpath)),
+                    args=args,
+                    **depositionkwargs,
+                )
 
         print()
 
@@ -732,20 +733,18 @@ def make_lightcurve_plot(
 
     axis.set_xlabel(r"Time [days]")
 
-    showsdeposition = shows_deposition(args)
-
     if lumunit == "mag":
         # the gamma-ray light curve and the deposition rates are converted onto this same magnitude axis, so
         # the label must name what is drawn rather than always claiming a bolometric luminosity
         ylabel = r"Absolute $\gamma$-ray Magnitude" if showgamma and not showuvoir else "Absolute Bolometric Magnitude"
-        if showsdeposition:
+        if shows_deposition(args):
             ylabel += r" ($L$ or $\dot{E}$)"
         axis.set_ylabel(ylabel)
     else:
         str_units = r" [{}$\mathrm{{L}}_\odot$]" if lumunit == "Lsun" else " [{}erg/s]"
         if args.logscaley:
             str_units = str_units.replace("{}", "")
-        if showsdeposition:
+        if shows_deposition(args):
             yvarname = r"$L$ or $\dot{{E}}$"
         elif showgamma and not showuvoir:
             yvarname = r"$\mathrm{{L}}_\gamma$"
@@ -981,7 +980,7 @@ def make_colorbar_viewingangles(
             cbar = fig.colorbar(scaledmap, orientation="horizontal", location="top", pad=0.10, ax=ax, shrink=0.95)
         else:
             assert ax is not None
-            firstaxis = ax if isinstance(ax, mplax.Axes) else next(iter(ax))
+            firstaxis = iter_axes(ax)[0]
             axisfigure = firstaxis.get_figure()
             assert axisfigure is not None
             cbar = axisfigure.colorbar(scaledmap, ax=ax)
@@ -1029,8 +1028,7 @@ def make_band_lightcurves_plot(
                 plotkwargs["label"] = str(args.plot_hesma_model).split("_")[:3]
 
             for plotnumber, band_name in enumerate(band_lightcurve_data):
-                axis = ax if isinstance(ax, mplax.Axes) else ax[plotnumber]
-                assert isinstance(axis, mplax.Axes)
+                axis = iter_axes(ax)[plotnumber]
                 if first_band_name is None:
                     first_band_name = band_name
                 time, brightness_in_mag = at.lightcurve.get_band_lightcurve(band_lightcurve_data, band_name, args)
@@ -1188,26 +1186,26 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                                 args,
                             )
 
-                curax = ax if isinstance(ax, mplax.Axes) else ax[plotnumber]
+                curax = iter_axes(ax)[plotnumber]
                 curax.plot(plot_times, colour_delta_mag, linewidth=4 if args.subplots else 3, **plotkwargs)
-
-                assert isinstance(curax, mplax.Axes)
-                curax.annotate(
-                    f"{filter_names[0]}-{filter_names[1]}",
-                    xy=(1.0, 1.0),
-                    xycoords="axes fraction",
-                    textcoords="offset points",
-                    xytext=(-30, -30),
-                    horizontalalignment="right",
-                    verticalalignment="top",
-                    fontsize="x-large",
-                )
 
             # UNCOMMENT TO ESTIMATE COLOUR AT TIME B MAX
             # tmax_B = 17.0  # CHANGE TO TIME OF B MAX
             # tmax_B = at.match_closest_time(tmax_B, plot_times)
             # print(f'{filter_names[0]} - {filter_names[1]} at t_Bmax ({tmax_B}) = '
             #       f'{diff[plot_times.index(tmax_B)]}')
+
+    for plotnumber, filters in enumerate(args.colour_evolution):
+        iter_axes(ax)[plotnumber].annotate(
+            filters,
+            xy=(1.0, 1.0),
+            xycoords="axes fraction",
+            textcoords="offset points",
+            xytext=(-30, -30),
+            horizontalalignment="right",
+            verticalalignment="top",
+            fontsize="x-large",
+        )
 
     fig, ax = set_lightcurve_plot_labels(fig, ax, args, colour_evolution=True)
     ax = at.plottools.set_axis_properties(ax, args)
@@ -1255,8 +1253,7 @@ def plot_lightcurve_from_refdata(
 
     filter_data = {}
     for axnumber, filter_name_raw in enumerate(filter_names):
-        axis = ax if isinstance(ax, mplax.Axes) else ax[axnumber]
-        assert isinstance(axis, mplax.Axes)
+        axis = iter_axes(ax)[axnumber]
         if filter_name_raw == "bol":
             continue
         with Path(filterdir / f"{filter_name_raw}.txt").open(encoding="utf-8") as f:
@@ -1355,8 +1352,7 @@ def plot_color_evolution_from_data(
     merge_dataframes = filter_data[0].join(
         filter_data[1], how="inner", on="time", suffix="_second", maintain_order="left"
     )
-    axis = ax if isinstance(ax, mplax.Axes) else ax[plotnumber]
-    assert isinstance(axis, mplax.Axes)
+    axis = iter_axes(ax)[plotnumber]
     axis.plot(
         merge_dataframes["time"],
         merge_dataframes["magnitude"] - merge_dataframes["magnitude_second"],

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1005,6 +1005,10 @@ def make_band_lightcurves_plot(
         args.labelfontsize = 22
     fig, ax = create_axes(args)
 
+    # a model with several direction bins takes its line colours from the cycle, so keep the cycle clear of
+    # the colours that other series were given
+    set_prop_cycle_unusedcolors([ax] if isinstance(ax, mplax.Axes) else ax.tolist(), [*args.color, *args.refspeccolors])
+
     plotkwargs: dict[str, t.Any] = {}
 
     if args.colorbarcostheta or args.colorbarphi:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -48,6 +48,9 @@ from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 from artistools.plottools import set_prop_cycle_unusedcolors
 
+if t.TYPE_CHECKING:
+    import matplotlib.typing as mplt
+
 type LumUnit = t.Literal["mag", "Lsun", "erg/s"]
 
 
@@ -1075,9 +1078,10 @@ def make_band_lightcurves_plot(
                         verticalalignment="top",
                     )
 
-                # a model with several direction bins has only one -color entry to share between them, so let
-                # matplotlib pick a colour per line. plotkwargs is reused, so clear any previous model's colour
-                plotkwargs["color"] = args.color[modelnumber] if len(dirbins) == 1 else None
+                # only the first direction bin can take the model's single -color entry, as on the bolometric
+                # figure; the rest take a colour each from the cycle, which set_prop_cycle_unusedcolors has
+                # kept clear of the assigned colours. plotkwargs is reused, so always assign it
+                plotkwargs["color"] = args.color[modelnumber] if dirbin == dirbins[0] else None
 
                 if args.colorbarcostheta or args.colorbarphi:
                     # Update plotkwargs with viewing angle colour
@@ -1117,14 +1121,24 @@ def make_band_lightcurves_plot(
     save_figure(fig, args.outputfile, format="pdf")
 
 
+def get_dirbin_palette(seriescolors: Sequence[str | None]) -> list["mplt.ColorType"]:
+    """Return the colours to hand out to the direction bins of a colour evolution plot.
+
+    A direction bin must not repeat the colour that a whole model was given, since both go on the same axes.
+    The whole map is the fallback for the case where every one of its colours was assigned to a series: a bin
+    has to be drawn in some colour, and there is none left that no series holds.
+    """
+    tab20colors = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
+
+    return get_unused_colors(tab20colors, seriescolors) or tab20colors
+
+
 def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | Path, args: argparse.Namespace) -> None:
     """Plot the evolution of the colour between each pair of bands for every model, and save the figure."""
     if args.labelfontsize is None:
         args.labelfontsize = 24
     angle_counter = 0
-    # a direction bin must not repeat the colour that a whole model was given, since both go on the same axes
-    tab20colors = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
-    color_list = get_unused_colors(tab20colors, [*args.color, *args.refspeccolors]) or tab20colors
+    color_list = get_dirbin_palette([*args.color, *args.refspeccolors])
 
     fig, ax = create_axes(args)
     axes = iter_axes(ax)
@@ -1411,10 +1425,14 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Plot the entire light curve including partially accumulated parts (light travel time effects)",
     )
 
-    parser.add_argument("--plotdeposition", action="store_true", help="Plot model deposition rates")
+    parser.add_argument(
+        "--plotdeposition", action="store_true", help="Plot the gamma-ray and positron deposition rates"
+    )
 
     parser.add_argument(
-        "--plotalphadeposition", action="store_true", help="Plot alpha decay energy release and deposition rates"
+        "--plotalphadeposition",
+        action="store_true",
+        help="Also plot the alpha decay energy release and deposition rates (implies --plotdeposition)",
     )
 
     parser.add_argument(

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -372,16 +372,12 @@ def plot_artis_lightcurve(
         lcdataframes = at.lightcurve.readfile(lcpath)
 
         if average_over_phi:
-            lcdataframes = at.average_direction_bins(lcdataframes, overangle="phi")
+            lcdataframes = at.average_direction_bins(lcdataframes, overangle="phi", derivedcols=derived_lum_unit_cols())
 
         if average_over_theta:
-            lcdataframes = at.average_direction_bins(lcdataframes, overangle="theta")
-
-        if average_over_phi or average_over_theta:
-            # averaging is linear, so it is only valid for the luminosity columns. Rebuild the magnitude from
-            # the averaged luminosity rather than averaging magnitudes, which a single dark bin sends to inf.
-            unitcols = derived_lum_unit_cols()
-            lcdataframes = {dirbin: lzdf.with_columns(unitcols) for dirbin, lzdf in lcdataframes.items()}
+            lcdataframes = at.average_direction_bins(
+                lcdataframes, overangle="theta", derivedcols=derived_lum_unit_cols()
+            )
 
     ycolumn = get_plot_lum_column(args)
 
@@ -754,19 +750,12 @@ def make_lightcurve_plot(
         scaledmap = make_colorbar_viewingangles_colormap()
         make_colorbar_viewingangles(phi_viewing_angle_bins, scaledmap, args, ax=axis)
 
-    if args.logscalex:
-        axis.set_xscale("log")
-
-    if args.logscaley:
-        axis.set_yscale("log")
-
     # set the limits only now that the data is drawn: on an empty axes matplotlib turns autoscaling off, so a
     # one-sided limit would freeze the other side at the default 0-1 view instead of fitting the light curves
     set_time_axis_limits(axis, args)
-    if args.ymin is not None:
-        axis.set_ylim(bottom=args.ymin)
-    if args.ymax is not None:
-        axis.set_ylim(top=args.ymax)
+    # the y limits, the log scales and the tick style are shared with the band and colour evolution figures.
+    # This parser has no -xmin/-xmax (the time range is -timemin/-timemax), so it leaves the x limits alone
+    at.plottools.set_axis_properties(axis, args)
     if lumunit == "mag":
         # invert last: set_ylim re-sorts the limits into the order of the pair it is given, so an inversion
         # applied before a one-sided limit is lost

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -205,9 +205,12 @@ def plot_deposition_thermalisation(
     at.plottools.get_next_color(axis)  # skip a colour so the deposition curves differ from the light curve
     color_gamma = at.plottools.get_next_color(axis)
     color_beta = at.plottools.get_next_color(axis)
-    color_alpha = at.plottools.get_next_color(axis)
+    # the alpha curves are drawn only on request, so their colour is taken only then: consuming it anyway
+    # would step the next model's deposition curves along the cycle for a curve that is never drawn
+    plotsalpha = args.plotalphadeposition or args.plotthermalisation
+    color_alpha: str | None = at.plottools.get_next_color(axis) if plotsalpha else None
 
-    depositioncurves = [
+    depositioncurves: list[tuple[str, str, str, str | None]] = [
         ("gammadep_Lsun", r" $\dot{E}_{dep,\gamma}$", "dashed", color_gamma),
         ("eps_elec_Lsun", r" $\dot{E}_{rad,\beta^-}$", "dotted", color_beta),
         ("elecdep_Lsun", r" $\dot{E}_{dep,\beta^-}$", "dashed", color_beta),
@@ -861,9 +864,7 @@ def set_lightcurveplot_legend(ax: mplax.Axes | npt.NDArray[t.Any], args: argpars
         return
 
     if args.subplots:
-        assert not isinstance(ax, mplax.Axes)
-        axis = ax[args.legendsubplotnumber]
-        assert isinstance(axis, mplax.Axes)
+        axis = iter_axes(ax)[args.legendsubplotnumber]
         axis.legend(loc=args.legendposition, frameon=args.legendframeon, fontsize="x-small", ncol=args.ncolslegend)
     else:
         assert isinstance(ax, mplax.Axes)
@@ -1011,16 +1012,18 @@ def make_band_lightcurves_plot(
         scaledmap = make_colorbar_viewingangles_colormap()
 
     first_band_name = None
+    bandnames: list[str] = []
     for modelnumber, modelpath in enumerate(Path(m) for m in modelpaths):
         # check if doing viewing angle stuff, and if so define which data to use
         dirbins, dirbin_definition = at.lightcurve.parse_directionbin_args(modelpath, args)
 
-        for index, dirbin in enumerate(dirbins):
+        for dirbin in dirbins:
             modelname = at.get_model_name(modelpath)
             print(f"Reading spectra: {modelname} (angle {dirbin})")
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
                 modelpath, args, dirbin, modelnumber=modelnumber
             )
+            bandnames = list(band_lightcurve_data)
 
             if modelnumber == 0 and args.plot_hesma_model:  # TODO: does this work?
                 hesma_model = at.lightcurve.read_hesma_lightcurve(args)
@@ -1072,21 +1075,6 @@ def make_band_lightcurves_plot(
                         verticalalignment="top",
                     )
 
-                if args.reflightcurves and modelnumber == 0:
-                    if len(dirbins) > 1 and index > 0:
-                        print("already plotted reflightcurve")
-                    else:
-                        assert isinstance(ax, mplax.Axes)
-                        for i, reflightcurve in enumerate(args.reflightcurves):
-                            plot_lightcurve_from_refdata(
-                                list(band_lightcurve_data.keys()),
-                                reflightcurve,
-                                args.refspeccolors[i],
-                                args.refspecmarkers[i],
-                                ax,
-                                plotnumber,
-                            )
-
                 # a model with several direction bins has only one -color entry to share between them, so let
                 # matplotlib pick a colour per line. plotkwargs is reused, so clear any previous model's colour
                 plotkwargs["color"] = args.color[modelnumber] if len(dirbins) == 1 else None
@@ -1101,6 +1089,14 @@ def make_band_lightcurves_plot(
                 plotkwargs["linestyle"] = args.linestyle[modelnumber]
 
                 axis.plot(time, brightness_in_mag, linewidth=4 if args.subplots else 3.5, **plotkwargs)
+
+    # once for the whole figure: the helper draws every band of a reference file onto its own panel, so
+    # calling it per band drew each reference curve once per band and re-read the file each time. It also
+    # asserted a single axes, which a figure with more than one band never has
+    for refindex, reflightcurve in enumerate(args.reflightcurves):
+        plot_lightcurve_from_refdata(
+            bandnames, reflightcurve, args.refspeccolors[refindex], args.refspecmarkers[refindex], ax
+        )
 
     at.set_mpl_style()
 
@@ -1233,14 +1229,13 @@ def plot_lightcurve_from_refdata(
     color: t.Any,
     marker: t.Any,
     ax: npt.NDArray[t.Any] | mplax.Axes,
-    plotnumber: int,
 ) -> str | None:
     """Plot an observed band light curve, dereddened with CCM89, and return its legend label."""
     from extinction import apply
     from extinction import ccm89
 
     lightcurve_data, metadata = at.lightcurve.read_reflightcurve_band_data(lightcurvefilename)
-    linename = metadata["label"] if plotnumber == 0 else None
+    linename = metadata["label"]
     assert linename is None or isinstance(linename, str)
     filterdir = Path(at.get_path("artistools_dir"), "data/filters/")
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -25,10 +25,10 @@ import artistools as at
 from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
-from artistools.constants import Mbol_sun
 from artistools.constants import Msun_to_g
 from artistools.lightcurve.lightcurve import derived_lum_unit_cols
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
+from artistools.lightcurve.lightcurve import lum_lsun_to_mag
 from artistools.lightcurve.lightcurve import path_is_reference_lightcurve
 from artistools.misc import add_axis_limit_args
 from artistools.misc import add_figscale_args
@@ -37,16 +37,15 @@ from artistools.misc import add_maxpacketfiles_arg
 from artistools.misc import add_modelpath_arg
 from artistools.misc import add_outputfile_arg
 from artistools.misc import add_series_style_args
+from artistools.misc import get_series_label
 from artistools.misc import makelist
 from artistools.misc import print_theta_phi_definitions
 from artistools.misc import trim_or_pad
 from artistools.plottools import get_series_colors
+from artistools.plottools import get_unused_colors
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
 from artistools.plottools import set_prop_cycle_unusedcolors
-
-if t.TYPE_CHECKING:
-    from collections.abc import Mapping
 
 type LumUnit = t.Literal["mag", "Lsun", "erg/s"]
 
@@ -65,9 +64,9 @@ def get_plot_lum_unit(args: argparse.Namespace) -> LumUnit:
 
 def get_plot_lum_column(args: argparse.Namespace) -> str:
     """Return the light curve dataframe column holding the luminosity in the y axis units."""
-    # annotated so that a unit added to LumUnit without a column here is a type error, not a plot-time KeyError
-    lumcolumns: Mapping[LumUnit, str] = {"mag": "mag", "Lsun": "luminosity_Lsun", "erg/s": "luminosity_erg/s"}
-    return lumcolumns[get_plot_lum_unit(args)]
+    lumunit = get_plot_lum_unit(args)
+
+    return "mag" if lumunit == "mag" else f"luminosity_{lumunit}"
 
 
 def convert_lum_lsun_to_plotunits(
@@ -76,9 +75,7 @@ def convert_lum_lsun_to_plotunits(
     """Convert a luminosity in solar luminosities to the y axis units: bolometric magnitude, Lsun, or erg/s."""
     lumunit = get_plot_lum_unit(args)
     if lumunit == "mag":
-        # a zero or negative luminosity has no magnitude, so let it become inf/nan instead of warning
-        with np.errstate(divide="ignore", invalid="ignore"):
-            return Mbol_sun - 2.5 * np.log10(lum_lsun)
+        return lum_lsun_to_mag(lum_lsun)
 
     return lum_lsun if lumunit == "Lsun" else lum_lsun * Lsun_to_erg_per_s
 
@@ -161,14 +158,13 @@ def plot_deposition_thermalisation(
     axistherm: mplax.Axes | None,
     modelpath: str | Path,
     modelname: str,
-    label: str,
     args: argparse.Namespace,
     **plotkwargs: t.Any,
 ) -> None:
     """Plot the gamma-ray and positron deposition rates, and the thermalisation efficiencies when axistherm is given.
 
-    Every curve below appends its own suffix to label and picks its own linestyle and colour, so plotkwargs must
-    carry none of those: matplotlib would receive them twice ("dashes" also silently overrides "linestyle").
+    Every curve below appends its own suffix to modelname and picks its own linestyle and colour, so plotkwargs
+    must carry none of those: matplotlib would receive them twice ("dashes" also overrides "linestyle").
     """
     if args.plotthermalisation:
         dfmodel, _ = at.inputmodel.get_modeldata(modelpath, derived_cols=["mass_g", "vel_r_mid", "kinetic_en_erg"])
@@ -204,7 +200,7 @@ def plot_deposition_thermalisation(
             depdata["tmid_days"],
             convert_lum_lsun_to_plotunits(depdata[depcol].to_numpy(), args),
             **plotkwargs,
-            label=label + labelsuffix,
+            label=modelname + labelsuffix,
             linestyle=curvelinestyle,
             color=curvecolor,
         )
@@ -384,7 +380,10 @@ def plot_artis_lightcurve(
         if average_over_phi or average_over_theta:
             # averaging is linear, so it is only valid for the luminosity columns. Rebuild the magnitude from
             # the averaged luminosity rather than averaging magnitudes, which a single dark bin sends to inf.
-            lcdataframes = {dirbin: lzdf.with_columns(derived_lum_unit_cols()) for dirbin, lzdf in lcdataframes.items()}
+            unitcols = derived_lum_unit_cols()
+            lcdataframes = {dirbin: lzdf.with_columns(unitcols) for dirbin, lzdf in lcdataframes.items()}
+
+    ycolumn = get_plot_lum_column(args)
 
     if args.dashes[lcindex]:
         plotkwargs["dashes"] = args.dashes[lcindex]
@@ -477,8 +476,6 @@ def plot_artis_lightcurve(
         if pellet_nucname is not None:
             plotkwargs["color"] = None
 
-        ycolumn = get_plot_lum_column(args)
-
         if (
             args.average_over_phi_angle
             and dirbin % at.get_viewingdirection_costhetabincount() == 0
@@ -562,9 +559,7 @@ def plot_artis_lightcurve(
         # plotkwargs is whatever the direction bin loop above left behind, so build the deposition style from
         # the command line instead of inheriting one bin's colour, transparency, z order and line width
         depositionkwargs: dict[str, t.Any] = {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
-        plot_deposition_thermalisation(
-            axis, axistherm, modelpath, label=linelabel, args=args, modelname=linelabel, **depositionkwargs
-        )
+        plot_deposition_thermalisation(axis, axistherm, modelpath, modelname=linelabel, args=args, **depositionkwargs)
 
     return lcdataframes
 
@@ -846,12 +841,11 @@ def get_linelabel(
     args: argparse.Namespace,
 ) -> str:
     """Return the legend label for one series, from the model name and viewing angle."""
-    # args.label has one entry per model path, each None unless the user gave a -label for it
-    serieslabel = args.label[modelnumber] or modelname
+    serieslabel = get_series_label(args.label, modelnumber, modelname)
     if angle is not None and angle != -1:
         assert angle_definition is not None
         return angle_definition[angle] if args.nomodelname else f"{serieslabel} {angle_definition[angle]}"
-    return str(serieslabel)
+    return serieslabel
 
 
 def set_lightcurveplot_legend(ax: mplax.Axes | npt.NDArray[t.Any], args: argparse.Namespace) -> None:
@@ -1127,13 +1121,15 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
         args.labelfontsize = 24
     angle_counter = 0
     # a direction bin must not repeat the colour that a whole model was given, since both go on the same axes
-    assignedcolors = {mplcolors.to_hex(color) for color in (*args.color, *args.refspeccolors) if color}
     tab20colors = list(plt.get_cmap("tab20")(np.linspace(0, 1.0, 20)))
-    color_list = [color for color in tab20colors if mplcolors.to_hex(color) not in assignedcolors] or tab20colors
+    color_list = get_unused_colors(tab20colors, [*args.color, *args.refspeccolors]) or tab20colors
 
     fig, ax = create_axes(args)
 
     plotkwargs: dict[str, t.Any] = {}
+
+    # the filter pairs share bands, so integrate the bands of every pair once per direction bin
+    args.filter = sorted({name for filters in args.colour_evolution for name in filters.split("-")})
 
     for modelnumber, modelpath in enumerate(modelpaths):
         modelname = at.get_model_name(modelpath)
@@ -1151,8 +1147,6 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
             else:
                 dirbincolor = args.color[modelnumber]
 
-            # the filter pairs share bands, so integrate the bands of every pair once for this direction bin
-            args.filter = sorted({name for filters in args.colour_evolution for name in filters.split("-")})
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
                 modelpath, args, dirbin=dirbin, modelnumber=modelnumber
             )

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -217,8 +217,9 @@ def plot_deposition_thermalisation(
     color_beta = at.plottools.get_next_color(axis)
     # the alpha curves are drawn only on request, so their colour is taken only then: consuming it anyway
     # would step the next model's deposition curves along the cycle for a curve that is never drawn
-    plotsalpha = args.plotalphadeposition or args.plotthermalisation
-    color_alpha: str | None = at.plottools.get_next_color(axis) if plotsalpha else None
+    color_alpha: str | None = (
+        at.plottools.get_next_color(axis) if args.plotalphadeposition or args.plotthermalisation else None
+    )
 
     depositioncurves: list[tuple[str, str, str, str | None]] = [
         ("gammadep_Lsun", r" $\dot{E}_{dep,\gamma}$", "dashed", color_gamma),
@@ -274,53 +275,34 @@ def plot_deposition_thermalisation(
         m5 = model_mass_grams / (5e-3 * Msun_to_g)  # M / (5e-3 Msun)
         v2 = ejecta_v / (0.2 * C_cm_per_s)  # ejecta_v / (0.2c)
 
+        def barnes_f_charged(t_ineff: float) -> list[float]:
+            """Return the Barnes et al (2016) equation 32 thermalisation efficiency of a charged particle."""
+            return [math.log(1 + 2 * (t / t_ineff) ** 2) / (2 * (t / t_ineff) ** 2) for t in depdata["tmid_days"]]
+
         # Barnes et al (2016) scaling form from equation 17, with fiducial t_ineff_gamma of 1.4 days
         t_ineff_gamma = 1.4 * np.sqrt(m5) / v2
-        # Barnes et al (2016) equation 33
-        barnes_f_gamma = [1 - math.exp(-((t / t_ineff_gamma) ** -2)) for t in depdata["tmid_days"]]
-
-        axistherm.plot(
-            depdata["tmid_days"],
-            barnes_f_gamma,
-            linewidth=linewidth,
-            label=r"Barnes+2016 $f_\gamma$",
-            linestyle="dashed",
-            color=color_gamma,
-        )
-
         e0_beta_mev = 0.5
         # Barnes et al (2016) equation 20
         t_ineff_beta = 7.4 * (e0_beta_mev / 0.5) ** -0.5 * m5**0.5 * (v2 ** (-3.0 / 2))
-        # Barnes et al (2016) equation 32
-        barnes_f_beta = [
-            math.log(1 + 2 * (t / t_ineff_beta) ** 2) / (2 * (t / t_ineff_beta) ** 2) for t in depdata["tmid_days"]
-        ]
-
-        axistherm.plot(
-            depdata["tmid_days"],
-            barnes_f_beta,
-            linewidth=linewidth,
-            label=r"Barnes+2016 $f_\beta$",
-            linestyle="dashed",
-            color=color_beta,
-        )
-
         e0_alpha_mev = 6.0
         # Barnes et al (2016) equation 25 times equation 16 for t_peak
         t_ineff_alpha = 4.3 * 1.8 * (e0_alpha_mev / 6.0) ** -0.5 * m5**0.5 * (v2 ** (-3.0 / 2))
-        # Barnes et al (2016) equation 32
-        barnes_f_alpha = [
-            math.log(1 + 2 * (t / t_ineff_alpha) ** 2) / (2 * (t / t_ineff_alpha) ** 2) for t in depdata["tmid_days"]
-        ]
 
-        axistherm.plot(
-            depdata["tmid_days"],
-            barnes_f_alpha,
-            linewidth=linewidth,
-            label=r"Barnes+2016 $f_\alpha$",
-            linestyle="dashed",
-            color=color_alpha,
-        )
+        barnes_curves = [
+            # Barnes et al (2016) equation 33 for the gamma rays, equation 32 for the charged particles
+            ([1 - math.exp(-((t / t_ineff_gamma) ** -2)) for t in depdata["tmid_days"]], r"\gamma", color_gamma),
+            (barnes_f_charged(t_ineff_beta), r"\beta", color_beta),
+            (barnes_f_charged(t_ineff_alpha), r"\alpha", color_alpha),
+        ]
+        for barnes_f, symbol, curvecolor in barnes_curves:
+            axistherm.plot(
+                depdata["tmid_days"],
+                barnes_f,
+                linewidth=linewidth,
+                label=rf"Barnes+2016 $f_{symbol}$",
+                linestyle="dashed",
+                color=curvecolor,
+            )
 
 
 def plot_artis_lightcurve(
@@ -348,8 +330,9 @@ def plot_artis_lightcurve(
         raise ValueError(msg)
 
     # handle e.g. modelpath = 'modelpath/light_curve.out'
-    lcfilename = Path(modelpath).name if Path(modelpath).is_file() else None
-    modelpath = get_model_folder(modelpath)
+    inputpath = Path(modelpath)
+    lcfilename = inputpath.name if inputpath.is_file() else None
+    modelpath = inputpath.parent if lcfilename else inputpath
 
     if not modelpath.is_dir():
         print(f"\nWARNING: Skipping because {modelpath} does not exist\n")
@@ -783,7 +766,7 @@ def make_lightcurve_plot(
 
     # set the limits only now that the data is drawn: on an empty axes matplotlib turns autoscaling off, so a
     # one-sided limit would freeze the other side at the default 0-1 view instead of fitting the light curves
-    at.plottools.set_axis_properties(axis, args)
+    at.plottools.set_axis_properties(axis, args, xlimits=(args.timemin, args.timemax, "-timemin"))
     if lumunit == "mag":
         # invert last: set_ylim re-sorts the limits into the order of the pair it is given, so an inversion
         # applied before a one-sided limit is lost
@@ -1021,8 +1004,9 @@ def make_band_lightcurves_plot(
         )
         scaledmap = make_colorbar_viewingangles_colormap()
 
-    first_band_name = None
-    bandnames: list[str] = []
+    # every model is asked for the same bands, so one list serves the loader, the reference curves, the
+    # y axis label and the output file name. main() dispatches here only when -filter has a value
+    bandnames: list[str] = list(args.filter)
     for modelnumber, modelpath in enumerate(Path(m) for m in modelpaths):
         # check if doing viewing angle stuff, and if so define which data to use
         dirbins, dirbin_definition = at.lightcurve.parse_directionbin_args(modelpath, args)
@@ -1031,9 +1015,8 @@ def make_band_lightcurves_plot(
             modelname = at.get_model_name(modelpath)
             print(f"Reading spectra: {modelname} (angle {dirbin})")
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-                modelpath, args, dirbin, modelnumber=modelnumber
+                modelpath, args, dirbin, modelnumber=modelnumber, filternames=bandnames
             )
-            bandnames = list(band_lightcurve_data)
 
             if modelnumber == 0 and args.plot_hesma_model:  # TODO: does this work?
                 hesma_model = at.lightcurve.read_hesma_lightcurve(args)
@@ -1041,8 +1024,6 @@ def make_band_lightcurves_plot(
 
             for plotnumber, band_name in enumerate(band_lightcurve_data):
                 axis = axes[plotnumber]
-                if first_band_name is None:
-                    first_band_name = band_name
                 time, brightness_in_mag = at.lightcurve.get_band_lightcurve(band_lightcurve_data, band_name, args)
 
                 if args.print_data or args.write_data:
@@ -1111,15 +1092,15 @@ def make_band_lightcurves_plot(
 
     at.set_mpl_style()
 
-    ax = at.plottools.set_axis_properties(ax, args)
-    fig, ax = set_lightcurve_plot_labels(fig, ax, args, band_name=first_band_name)
+    ax = at.plottools.set_axis_properties(ax, args, xlimits=(args.timemin, args.timemax, "-timemin"))
+    fig, ax = set_lightcurve_plot_labels(fig, ax, args, band_name=bandnames[0] if bandnames else None)
     set_lightcurveplot_legend(ax, args)
 
     if args.colorbarcostheta or args.colorbarphi:
         make_colorbar_viewingangles(phi_viewing_angle_bins, scaledmap, args, fig=fig, ax=ax)
 
-    if args.filter and len(band_lightcurve_data) == 1:
-        args.outputfile = Path(outputfolder, f"plot{first_band_name}lightcurves.pdf")
+    if args.filter and len(bandnames) == 1:
+        args.outputfile = Path(outputfolder, f"plot{bandnames[0]}lightcurves.pdf")
     invert_magnitude_yaxis(ax)
 
     if args.show:
@@ -1159,7 +1140,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
 
         dirbins, dirbin_definition = at.lightcurve.parse_directionbin_args(modelpath, args)
 
-        for index, dirbin in enumerate(dirbins):
+        for dirbin in dirbins:
             if len(dirbins) > 1:
                 # -color has one colour per model, which cannot distinguish a model's direction bins, so take a
                 # colour per bin from the colour map instead, wrapping around when it runs out. The colour is
@@ -1181,21 +1162,6 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 if filterfunc is not None:
                     colour_delta_mag = filterfunc(colour_delta_mag)
 
-                if args.reflightcurves and modelnumber == 0:
-                    if len(dirbins) > 1 and index > 0:
-                        print("already plotted reflightcurve")
-                    else:
-                        for i, reflightcurve in enumerate(args.reflightcurves):
-                            plot_color_evolution_from_data(
-                                filter_names,
-                                reflightcurve,
-                                args.refspeccolors[i],
-                                args.refspecmarkers[i],
-                                ax,
-                                plotnumber,
-                                args,
-                            )
-
                 axes[plotnumber].plot(
                     plot_times,
                     colour_delta_mag,
@@ -1204,6 +1170,20 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                     linestyle=args.linestyle[modelnumber],
                     linewidth=4 if args.subplots else 3,
                 )
+
+    # once for the whole figure, as on the band plot: the reference data does not depend on the models or
+    # their direction bins, so drawing it inside those loops re-read each file once per model per pair
+    for refindex, reflightcurve in enumerate(args.reflightcurves):
+        for plotnumber, filters in enumerate(args.colour_evolution):
+            plot_color_evolution_from_data(
+                filters.split("-"),
+                reflightcurve,
+                args.refspeccolors[refindex],
+                args.refspecmarkers[refindex],
+                ax,
+                plotnumber,
+                args,
+            )
 
     for plotnumber, filters in enumerate(args.colour_evolution):
         axes[plotnumber].annotate(
@@ -1218,7 +1198,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
         )
 
     fig, ax = set_lightcurve_plot_labels(fig, ax, args, colour_evolution=True)
-    ax = at.plottools.set_axis_properties(ax, args)
+    ax = at.plottools.set_axis_properties(ax, args, xlimits=(args.timemin, args.timemax, "-timemin"))
     set_lightcurveplot_legend(ax, args)
 
     invert_magnitude_yaxis(ax)
@@ -1657,9 +1637,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     args.color, args.label, args.linestyle, args.dashes, args.linewidth = trim_or_pad(
         len(args.modelpath), args.color, args.label, args.linestyle, args.dashes, args.linewidth
     )
-
-    # the x axis is the time axis, so the shared limit helpers see the time range under the name they read
-    args.xmin, args.xmax = args.timemin, args.timemax
 
     args.reflightcurves = makelist(args.reflightcurves)
     args.refspeccolors, args.refspecmarkers = trim_or_pad(

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -69,10 +69,10 @@ def get_plot_lum_column(lumunit: LumUnit) -> str:
 
 
 def shows_deposition(args: argparse.Namespace) -> bool:
-    """Return whether plot_deposition_thermalisation draws deposition rates on the light curve axis.
+    """Return whether the command-line arguments ask for deposition rates on the light curve axis.
 
-    Every deposition flag puts the gamma and beta curves on that axis, so the y axis label has to agree
-    with the same condition that decides whether to call it.
+    Every deposition flag puts the gamma and beta curves on that axis. Asking is not drawing, though: the y
+    axis label follows whether a model actually contributed curves, not this.
     """
     return bool(args.plotdeposition or args.plotalphadeposition or args.plotthermalisation)
 
@@ -160,18 +160,25 @@ def plot_bol_reflightcurve(
     return plotlabel
 
 
+def get_model_folder(modelpath: str | Path) -> Path:
+    """Return the model folder, whether modelpath names the folder itself or a file inside it."""
+    path = Path(modelpath)
+
+    return path.parent if path.is_file() else path
+
+
 def plot_deposition_thermalisation(
     axis: mplax.Axes,
     axistherm: mplax.Axes | None,
     modelpath: str | Path,
     modelname: str,
     args: argparse.Namespace,
-    **plotkwargs: t.Any,
+    linewidth: float | str | None = None,
 ) -> None:
     """Plot the gamma-ray and positron deposition rates, and the thermalisation efficiencies when axistherm is given.
 
-    Every curve below appends its own suffix to modelname and picks its own linestyle and colour, so plotkwargs
-    must carry none of those: matplotlib would receive them twice ("dashes" also overrides "linestyle").
+    Every curve below appends its own suffix to modelname and picks its own linestyle and colour, so the line
+    width is the only style the caller sets: passing the rest would reach matplotlib twice.
     """
     lumunit = get_plot_lum_unit(args)
 
@@ -209,7 +216,7 @@ def plot_deposition_thermalisation(
         axis.plot(
             depdata["tmid_days"],
             convert_lum_lsun_to_plotunits(depdata[depcol].to_numpy(), lumunit),
-            **plotkwargs,
+            linewidth=linewidth,
             label=modelname + labelsuffix,
             linestyle=curvelinestyle,
             color=curvecolor,
@@ -229,7 +236,7 @@ def plot_deposition_thermalisation(
             axistherm.plot(
                 depdata["tmid_days"],
                 depdata[depcol] / depdata[epscol],
-                **plotkwargs,
+                linewidth=linewidth,
                 label=modelname + rf" $\left({ratiolabel}\right)$",
                 linestyle="solid",
                 color=ratiocolor,
@@ -251,7 +258,7 @@ def plot_deposition_thermalisation(
         axistherm.plot(
             depdata["tmid_days"],
             barnes_f_gamma,
-            **plotkwargs,
+            linewidth=linewidth,
             label=r"Barnes+2016 $f_\gamma$",
             linestyle="dashed",
             color=color_gamma,
@@ -268,7 +275,7 @@ def plot_deposition_thermalisation(
         axistherm.plot(
             depdata["tmid_days"],
             barnes_f_beta,
-            **plotkwargs,
+            linewidth=linewidth,
             label=r"Barnes+2016 $f_\beta$",
             linestyle="dashed",
             color=color_beta,
@@ -285,7 +292,7 @@ def plot_deposition_thermalisation(
         axistherm.plot(
             depdata["tmid_days"],
             barnes_f_alpha,
-            **plotkwargs,
+            linewidth=linewidth,
             label=r"Barnes+2016 $f_\alpha$",
             linestyle="dashed",
             color=color_alpha,
@@ -316,11 +323,9 @@ def plot_artis_lightcurve(
         msg = f"Unknown escape type {escape_type}"
         raise ValueError(msg)
 
-    lcfilename = None
-    modelpath = Path(modelpath)
-    if Path(modelpath).is_file():  # handle e.g. modelpath = 'modelpath/light_curve.out'
-        lcfilename = Path(modelpath).parts[-1]
-        modelpath = Path(modelpath).parent
+    # handle e.g. modelpath = 'modelpath/light_curve.out'
+    lcfilename = Path(modelpath).name if Path(modelpath).is_file() else None
+    modelpath = get_model_folder(modelpath)
 
     if not modelpath.is_dir():
         print(f"\nWARNING: Skipping because {modelpath} does not exist\n")
@@ -566,13 +571,14 @@ def plot_artis_lightcurve(
 def invert_magnitude_yaxis(ax: mplax.Axes | npt.NDArray[t.Any]) -> None:
     """Point the magnitude axis downwards, so that a brighter series is drawn higher.
 
-    invert_yaxis() toggles rather than sets and the axes of a subplot grid share one y axis, so calling it once
-    per plotted series flips the axis back and forth instead of inverting it.
+    invert_yaxis() toggles rather than sets, so calling it once per plotted series flips the axis back and
+    forth instead of inverting it. Inverting a shared y axis already inverts the rest of the grid, which the
+    check per axes skips over rather than undoing, so this does not rely on the subplots sharing one axis.
     """
-    firstaxis = iter_axes(ax)[0]
-    ymin, ymax = firstaxis.get_ylim()
-    if ymin < ymax:
-        firstaxis.invert_yaxis()
+    for axis in iter_axes(ax):
+        ymin, ymax = axis.get_ylim()
+        if ymin < ymax:
+            axis.invert_yaxis()
 
 
 def set_time_axis_limits(axis: mplax.Axes, args: argparse.Namespace) -> None:
@@ -629,6 +635,7 @@ def make_lightcurve_plot(
     set_prop_cycle_unusedcolors([axis], [*args.color, *args.refspeccolors])
 
     plottedsomething = False
+    plotteddeposition = False
     for lcindex, modelpath in enumerate(modelpaths):
         if path_is_reference_lightcurve(modelpath):
             bolreflightcurve = Path(modelpath)
@@ -696,23 +703,22 @@ def make_lightcurve_plot(
                         color=args.color[lcindex],
                         linelabel=args.label[lcindex],
                     )
-                    plottedsomething = plottedsomething or (lcdataframes is not None)
                     plottedthismodel = plottedthismodel or (lcdataframes is not None)
+
+            plottedsomething = plottedsomething or plottedthismodel
 
             if plottedthismodel and shows_deposition(args):
                 # the rates belong to the model, not to one escape type or pellet nuclide, and the style
                 # comes from the command line rather than from whatever a series left in its plot kwargs
-                depositionkwargs: dict[str, t.Any] = (
-                    {"linewidth": args.linewidth[lcindex]} if args.linewidth[lcindex] else {}
-                )
                 plot_deposition_thermalisation(
                     axis,
                     axistherm,
-                    Path(modelpath).parent if Path(modelpath).is_file() else Path(modelpath),
+                    get_model_folder(modelpath),
                     modelname=get_series_label(args.label, lcindex, at.get_model_name(modelpath)),
                     args=args,
-                    **depositionkwargs,
+                    linewidth=args.linewidth[lcindex] or None,
                 )
+                plotteddeposition = True
 
         print()
 
@@ -737,14 +743,14 @@ def make_lightcurve_plot(
         # the gamma-ray light curve and the deposition rates are converted onto this same magnitude axis, so
         # the label must name what is drawn rather than always claiming a bolometric luminosity
         ylabel = r"Absolute $\gamma$-ray Magnitude" if showgamma and not showuvoir else "Absolute Bolometric Magnitude"
-        if shows_deposition(args):
+        if plotteddeposition:
             ylabel += r" ($L$ or $\dot{E}$)"
         axis.set_ylabel(ylabel)
     else:
         str_units = r" [{}$\mathrm{{L}}_\odot$]" if lumunit == "Lsun" else " [{}erg/s]"
         if args.logscaley:
             str_units = str_units.replace("{}", "")
-        if shows_deposition(args):
+        if plotteddeposition:
             yvarname = r"$L$ or $\dot{{E}}$"
         elif showgamma and not showuvoir:
             yvarname = r"$\mathrm{{L}}_\gamma$"
@@ -886,9 +892,8 @@ def set_lightcurve_plot_labels(
 ) -> tuple[mplfig.Figure, mplax.Axes | npt.NDArray[t.Any]]:
     """Set the axis labels and limits for a band magnitude or colour evolution plot.
 
-    The caller states which kind of plot this is rather than it being read back off args: colour_evolution_plot
-    assigns args.filter before it asks for labels, so sniffing args.filter here labels a colour plot as a
-    band plot.
+    The caller states which kind of plot this is rather than it being read back off args, which cannot tell a
+    colour plot from a band plot on its own.
     """
     if colour_evolution:
         ylabel = r"$\Delta$m"
@@ -998,10 +1003,11 @@ def make_band_lightcurves_plot(
     if args.labelfontsize is None:
         args.labelfontsize = 22
     fig, ax = create_axes(args)
+    axes = iter_axes(ax)
 
     # a model with several direction bins takes its line colours from the cycle, so keep the cycle clear of
     # the colours that other series were given
-    set_prop_cycle_unusedcolors(iter_axes(ax), [*args.color, *args.refspeccolors])
+    set_prop_cycle_unusedcolors(axes, [*args.color, *args.refspeccolors])
 
     plotkwargs: dict[str, t.Any] = {}
 
@@ -1028,7 +1034,7 @@ def make_band_lightcurves_plot(
                 plotkwargs["label"] = str(args.plot_hesma_model).split("_")[:3]
 
             for plotnumber, band_name in enumerate(band_lightcurve_data):
-                axis = iter_axes(ax)[plotnumber]
+                axis = axes[plotnumber]
                 if first_band_name is None:
                     first_band_name = band_name
                 time, brightness_in_mag = at.lightcurve.get_band_lightcurve(band_lightcurve_data, band_name, args)
@@ -1132,11 +1138,10 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
     color_list = get_unused_colors(tab20colors, [*args.color, *args.refspeccolors]) or tab20colors
 
     fig, ax = create_axes(args)
-
-    plotkwargs: dict[str, t.Any] = {}
+    axes = iter_axes(ax)
 
     # the filter pairs share bands, so integrate the bands of every pair once per direction bin
-    args.filter = sorted({name for filters in args.colour_evolution for name in filters.split("-")})
+    bandnames = sorted({name for filters in args.colour_evolution for name in filters.split("-")})
 
     for modelnumber, modelpath in enumerate(modelpaths):
         modelname = at.get_model_name(modelpath)
@@ -1155,21 +1160,16 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 dirbincolor = args.color[modelnumber]
 
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-                modelpath, args, dirbin=dirbin, modelnumber=modelnumber
+                modelpath, args, dirbin=dirbin, modelnumber=modelnumber, filternames=bandnames
             )
 
             for plotnumber, filters in enumerate(args.colour_evolution):
                 filter_names = filters.split("-")
                 plot_times, colour_delta_mag = at.lightcurve.get_colour_delta_mag(band_lightcurve_data, filter_names)
 
-                plotkwargs["label"] = get_linelabel(modelname, modelnumber, dirbin, dirbin_definition, args)
-
                 filterfunc = at.get_filterfunc(args)
                 if filterfunc is not None:
                     colour_delta_mag = filterfunc(colour_delta_mag)
-
-                plotkwargs["color"] = dirbincolor
-                plotkwargs["linestyle"] = args.linestyle[modelnumber]
 
                 if args.reflightcurves and modelnumber == 0:
                     if len(dirbins) > 1 and index > 0:
@@ -1186,8 +1186,14 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                                 args,
                             )
 
-                curax = iter_axes(ax)[plotnumber]
-                curax.plot(plot_times, colour_delta_mag, linewidth=4 if args.subplots else 3, **plotkwargs)
+                axes[plotnumber].plot(
+                    plot_times,
+                    colour_delta_mag,
+                    label=get_linelabel(modelname, modelnumber, dirbin, dirbin_definition, args),
+                    color=dirbincolor,
+                    linestyle=args.linestyle[modelnumber],
+                    linewidth=4 if args.subplots else 3,
+                )
 
             # UNCOMMENT TO ESTIMATE COLOUR AT TIME B MAX
             # tmax_B = 17.0  # CHANGE TO TIME OF B MAX
@@ -1196,7 +1202,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
             #       f'{diff[plot_times.index(tmax_B)]}')
 
     for plotnumber, filters in enumerate(args.colour_evolution):
-        iter_axes(ax)[plotnumber].annotate(
+        axes[plotnumber].annotate(
             filters,
             xy=(1.0, 1.0),
             xycoords="axes fraction",
@@ -1252,8 +1258,9 @@ def plot_lightcurve_from_refdata(
     filterdir = Path(at.get_path("artistools_dir"), "data/filters/")
 
     filter_data = {}
+    axes = iter_axes(ax)
     for axnumber, filter_name_raw in enumerate(filter_names):
-        axis = iter_axes(ax)[axnumber]
+        axis = axes[axnumber]
         if filter_name_raw == "bol":
             continue
         with Path(filterdir / f"{filter_name_raw}.txt").open(encoding="utf-8") as f:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -500,6 +500,35 @@ def plot_artis_lightcurve(
     return lcdataframes
 
 
+def plot_bol_reflightcurve(
+    axis: mplax.Axes, lightcurvefilename: str | Path, color: str, label: str | None = None
+) -> str:
+    """Plot an observed bolometric light curve, with error bars if the data file has them.
+
+    Return the label used in the plot legend, which comes from the file metadata unless label is given.
+    """
+    dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(lightcurvefilename)
+    plotlabel = label or str(metadata.get("label", lightcurvefilename))
+
+    if {"luminosity_errminus_erg/s", "luminosity_errplus_erg/s"}.issubset(dflightcurve.columns):
+        axis.errorbar(
+            dflightcurve["time_days"],
+            dflightcurve["luminosity_erg/s"],
+            yerr=[dflightcurve["luminosity_errminus_erg/s"], dflightcurve["luminosity_errplus_erg/s"]],
+            fmt="o",
+            capsize=3,
+            label=plotlabel,
+            color=color,
+            zorder=0,
+        )
+    else:
+        axis.scatter(
+            dflightcurve["time_days"], dflightcurve["luminosity_erg/s"], label=plotlabel, color=color, zorder=0
+        )
+
+    return plotlabel
+
+
 def make_lightcurve_plot(
     modelpaths: Sequence[str | Path],
     filenameout: str | Path,
@@ -564,31 +593,9 @@ def make_lightcurve_plot(
         if path_is_reference_lightcurve(modelpath):
             bolreflightcurve = Path(modelpath)
 
-            dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
-            lightcurvelabel = args.label[lcindex] or metadata.get("label", bolreflightcurve)
-            color = args.color[lcindex]
-            if (
-                "luminosity_errminus_erg/s" in dflightcurve.columns
-                and "luminosity_errplus_erg/s" in dflightcurve.columns
-            ):
-                axis.errorbar(
-                    dflightcurve["time_days"],
-                    dflightcurve["luminosity_erg/s"],
-                    yerr=[dflightcurve["luminosity_errminus_erg/s"], dflightcurve["luminosity_errplus_erg/s"]],
-                    fmt="o",
-                    capsize=3,
-                    label=lightcurvelabel,
-                    color=color,
-                    zorder=0,
-                )
-            else:
-                axis.scatter(
-                    dflightcurve["time_days"],
-                    dflightcurve["luminosity_erg/s"],
-                    label=lightcurvelabel,
-                    color=color,
-                    zorder=0,
-                )
+            lightcurvelabel = plot_bol_reflightcurve(
+                axis, bolreflightcurve, color=args.color[lcindex], label=args.label[lcindex]
+            )
             print(f"====> {lightcurvelabel}")
             plottedsomething = True
 
@@ -658,13 +665,7 @@ def make_lightcurve_plot(
             if args.Lsun:
                 print("Check units - trying to plot ref light curve in erg/s")
                 sys.exit(1)
-            bollightcurve_data, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
-            axis.scatter(
-                bollightcurve_data["time_days"],
-                bollightcurve_data["luminosity_erg/s"],
-                label=metadata.get("label", bolreflightcurve),
-                color=args.refspeccolors[refindex],
-            )
+            plot_bol_reflightcurve(axis, bolreflightcurve, color=args.refspeccolors[refindex])
             plottedsomething = True
 
     assert plottedsomething, "No light curve was plotted"

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -144,7 +144,8 @@ def plot_bol_reflightcurve(
     Return the label used in the plot legend, which comes from the file metadata unless label is given.
     """
     dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(lightcurvefilename)
-    plotlabel = label or str(metadata.get("label", lightcurvefilename))
+    # an empty label is a series deliberately left out of the legend, so only a missing one takes the metadata
+    plotlabel = str(metadata.get("label", lightcurvefilename)) if label is None else label
     lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
     time_days = dflightcurve["time_days"].to_numpy()
     yvalues = convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit)

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -62,18 +62,15 @@ def get_plot_lum_unit(args: argparse.Namespace) -> LumUnit:
     return "Lsun" if args.Lsun else "erg/s"
 
 
-def get_plot_lum_column(args: argparse.Namespace) -> str:
+def get_plot_lum_column(lumunit: LumUnit) -> str:
     """Return the light curve dataframe column holding the luminosity in the y axis units."""
-    lumunit = get_plot_lum_unit(args)
-
     return "mag" if lumunit == "mag" else f"luminosity_{lumunit}"
 
 
 def convert_lum_lsun_to_plotunits(
-    lum_lsun: npt.NDArray[np.floating[t.Any]], args: argparse.Namespace
+    lum_lsun: npt.NDArray[np.floating[t.Any]], lumunit: LumUnit
 ) -> npt.NDArray[np.floating[t.Any]]:
     """Convert a luminosity in solar luminosities to the y axis units: bolometric magnitude, Lsun, or erg/s."""
-    lumunit = get_plot_lum_unit(args)
     if lumunit == "mag":
         return lum_lsun_to_mag(lum_lsun)
 
@@ -81,41 +78,41 @@ def convert_lum_lsun_to_plotunits(
 
 
 def convert_lum_ergs_to_plotunits(
-    lum_erg_per_s: npt.NDArray[np.floating[t.Any]], args: argparse.Namespace
+    lum_erg_per_s: npt.NDArray[np.floating[t.Any]], lumunit: LumUnit
 ) -> npt.NDArray[np.floating[t.Any]]:
     """Convert a luminosity in erg/s to the y axis units: bolometric magnitude, Lsun, or erg/s."""
-    if get_plot_lum_unit(args) == "erg/s":
+    if lumunit == "erg/s":
         return lum_erg_per_s
 
-    return convert_lum_lsun_to_plotunits(lum_erg_per_s / Lsun_to_erg_per_s, args)
+    return convert_lum_lsun_to_plotunits(lum_erg_per_s / Lsun_to_erg_per_s, lumunit)
 
 
 def get_reflightcurve_yerr(
     lum_erg_per_s: npt.NDArray[np.floating[t.Any]],
     errminus_erg_per_s: npt.NDArray[np.floating[t.Any]],
     errplus_erg_per_s: npt.NDArray[np.floating[t.Any]],
-    args: argparse.Namespace,
+    lumunit: LumUnit,
 ) -> list[npt.NDArray[np.floating[t.Any]]]:
     """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in erg/s and its errors."""
-    if get_plot_lum_unit(args) == "mag":
+    if lumunit == "mag":
         # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
-        mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, args)
+        mag = convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit)
         # an error bar reaching zero luminosity has no faintest magnitude, so leave it undefined
         lum_faintest = np.where(lum_erg_per_s > errminus_erg_per_s, lum_erg_per_s - errminus_erg_per_s, np.nan)
         return [
-            mag - convert_lum_ergs_to_plotunits(lum_erg_per_s + errplus_erg_per_s, args),
-            convert_lum_ergs_to_plotunits(lum_faintest, args) - mag,
+            mag - convert_lum_ergs_to_plotunits(lum_erg_per_s + errplus_erg_per_s, lumunit),
+            convert_lum_ergs_to_plotunits(lum_faintest, lumunit) - mag,
         ]
 
     # the conversion is a simple scaling, so it applies to the error sizes directly
     return [
-        convert_lum_ergs_to_plotunits(errminus_erg_per_s, args),
-        convert_lum_ergs_to_plotunits(errplus_erg_per_s, args),
+        convert_lum_ergs_to_plotunits(errminus_erg_per_s, lumunit),
+        convert_lum_ergs_to_plotunits(errplus_erg_per_s, lumunit),
     ]
 
 
 def plot_bol_reflightcurve(
-    axis: mplax.Axes, lightcurvefilename: str | Path, args: argparse.Namespace, color: str, label: str | None = None
+    axis: mplax.Axes, lightcurvefilename: str | Path, lumunit: LumUnit, color: str, label: str | None = None
 ) -> str:
     """Plot an observed bolometric light curve in the y axis units, with error bars if the data file has them.
 
@@ -128,12 +125,12 @@ def plot_bol_reflightcurve(
     if {"luminosity_errminus_erg/s", "luminosity_errplus_erg/s"}.issubset(dflightcurve.columns):
         axis.errorbar(
             dflightcurve["time_days"],
-            convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+            convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit),
             yerr=get_reflightcurve_yerr(
                 lum_erg_per_s,
                 dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
                 dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
-                args,
+                lumunit,
             ),
             fmt="o",
             capsize=3,
@@ -144,7 +141,7 @@ def plot_bol_reflightcurve(
     else:
         axis.scatter(
             dflightcurve["time_days"],
-            convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+            convert_lum_ergs_to_plotunits(lum_erg_per_s, lumunit),
             label=plotlabel,
             color=color,
             zorder=0,
@@ -166,6 +163,8 @@ def plot_deposition_thermalisation(
     Every curve below appends its own suffix to modelname and picks its own linestyle and colour, so plotkwargs
     must carry none of those: matplotlib would receive them twice ("dashes" also overrides "linestyle").
     """
+    lumunit = get_plot_lum_unit(args)
+
     if args.plotthermalisation:
         dfmodel, _ = at.inputmodel.get_modeldata(modelpath, derived_cols=["mass_g", "vel_r_mid", "kinetic_en_erg"])
 
@@ -198,7 +197,7 @@ def plot_deposition_thermalisation(
             continue
         axis.plot(
             depdata["tmid_days"],
-            convert_lum_lsun_to_plotunits(depdata[depcol].to_numpy(), args),
+            convert_lum_lsun_to_plotunits(depdata[depcol].to_numpy(), lumunit),
             **plotkwargs,
             label=modelname + labelsuffix,
             linestyle=curvelinestyle,
@@ -379,7 +378,8 @@ def plot_artis_lightcurve(
                 lcdataframes, overangle="theta", derivedcols=derived_lum_unit_cols()
             )
 
-    ycolumn = get_plot_lum_column(args)
+    lumunit = get_plot_lum_unit(args)
+    ycolumn = get_plot_lum_column(lumunit)
 
     if args.dashes[lcindex]:
         plotkwargs["dashes"] = args.dashes[lcindex]
@@ -537,7 +537,7 @@ def plot_artis_lightcurve(
             print(lcdata)
 
         if args.plotcmf:
-            assert get_plot_lum_unit(args) != "mag", "Cannot plot cmf luminosity if magnitude is selected"
+            assert lumunit != "mag", "Cannot plot cmf luminosity if magnitude is selected"
             plotkwargs["linewidth"] = 1
             if not linelabel_is_custom:
                 assert label_with_tags is not None
@@ -597,6 +597,8 @@ def make_lightcurve_plot(
     if "figwidthscale" not in args:
         args.figwidthscale = 1.0
 
+    lumunit = get_plot_lum_unit(args)
+
     figwidth = args.figscale * 5.0 * args.figwidthscale
     figheight = args.figscale * 5.0 * (0.25 + 0.4)
     fig, axis = plt.subplots(
@@ -630,7 +632,7 @@ def make_lightcurve_plot(
             bolreflightcurve = Path(modelpath)
 
             lightcurvelabel = plot_bol_reflightcurve(
-                axis, bolreflightcurve, args, color=args.color[lcindex], label=args.label[lcindex]
+                axis, bolreflightcurve, lumunit, color=args.color[lcindex], label=args.label[lcindex]
             )
             print(f"====> {lightcurvelabel}")
             plottedsomething = True
@@ -698,7 +700,7 @@ def make_lightcurve_plot(
 
     if args.reflightcurves:
         for refindex, bolreflightcurve in enumerate(args.reflightcurves):
-            plot_bol_reflightcurve(axis, bolreflightcurve, args, color=args.refspeccolors[refindex])
+            plot_bol_reflightcurve(axis, bolreflightcurve, lumunit, color=args.refspeccolors[refindex])
             plottedsomething = True
 
     assert plottedsomething, "No light curve was plotted"
@@ -716,7 +718,6 @@ def make_lightcurve_plot(
     # plot_deposition_thermalisation draws the deposition rates on the main axis for either flag
     showsdeposition = args.plotdeposition or args.plotalphadeposition or args.plotthermalisation
 
-    lumunit = get_plot_lum_unit(args)
     if lumunit == "mag":
         # the gamma-ray light curve and the deposition rates are converted onto this same magnitude axis, so
         # the label must name what is drawn rather than always claiming a bolometric luminosity

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -25,6 +25,7 @@ import artistools as at
 from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import Lsun_to_erg_per_s
+from artistools.constants import Mbol_sun
 from artistools.constants import Msun_to_g
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
 from artistools.misc import add_axis_limit_args
@@ -37,6 +38,37 @@ from artistools.misc import add_series_style_args
 from artistools.misc import print_theta_phi_definitions
 from artistools.plottools import save_figure
 from artistools.plottools import set_axis_labels
+
+
+def convert_lum_lsun_to_plotunits(
+    lum_lsun: npt.NDArray[np.floating[t.Any]], args: argparse.Namespace
+) -> npt.NDArray[np.floating[t.Any]]:
+    """Convert a luminosity in solar luminosities to the y axis units: bolometric magnitude, Lsun, or erg/s."""
+    if args.magnitude:
+        return Mbol_sun - 2.5 * np.log10(lum_lsun)
+
+    return lum_lsun if args.Lsun else lum_lsun * Lsun_to_erg_per_s
+
+
+def get_reflightcurve_yerr(
+    lum_lsun: npt.NDArray[np.floating[t.Any]],
+    errminus_lsun: npt.NDArray[np.floating[t.Any]],
+    errplus_lsun: npt.NDArray[np.floating[t.Any]],
+    args: argparse.Namespace,
+) -> list[npt.NDArray[np.floating[t.Any]]]:
+    """Return the [lower, upper] error bar sizes in the y axis units for a luminosity in Lsun and its errors."""
+    if args.magnitude:
+        # a magnitude gets smaller as the luminosity gets larger, so the error bars swap sides and become asymmetric
+        mag = convert_lum_lsun_to_plotunits(lum_lsun, args)
+        # an error bar reaching zero luminosity has no faintest magnitude, so leave it undefined
+        lum_faintest_lsun = np.where(lum_lsun > errminus_lsun, lum_lsun - errminus_lsun, np.nan)
+        return [
+            mag - convert_lum_lsun_to_plotunits(lum_lsun + errplus_lsun, args),
+            convert_lum_lsun_to_plotunits(lum_faintest_lsun, args) - mag,
+        ]
+
+    # the conversion is a simple scaling, so it applies to the error sizes directly
+    return [convert_lum_lsun_to_plotunits(errminus_lsun, args), convert_lum_lsun_to_plotunits(errplus_lsun, args)]
 
 
 def plot_deposition_thermalisation(
@@ -61,7 +93,7 @@ def plot_deposition_thermalisation(
 
     axis.plot(
         depdata["tmid_days"],
-        depdata["gammadep_Lsun"] * Lsun_to_erg_per_s,
+        convert_lum_lsun_to_plotunits(depdata["gammadep_Lsun"].to_numpy(), args),
         **plotkwargs,
         label=plotkwargs["label"] + r" $\dot{E}_{dep,\gamma}$",
         linestyle="dashed",
@@ -73,7 +105,7 @@ def plot_deposition_thermalisation(
     if "eps_elec_Lsun" in depdata:
         axis.plot(
             depdata["tmid_days"],
-            depdata["eps_elec_Lsun"] * Lsun_to_erg_per_s,
+            convert_lum_lsun_to_plotunits(depdata["eps_elec_Lsun"].to_numpy(), args),
             **plotkwargs,
             label=plotkwargs["label"] + r" $\dot{E}_{rad,\beta^-}$",
             linestyle="dotted",
@@ -83,7 +115,7 @@ def plot_deposition_thermalisation(
     if "elecdep_Lsun" in depdata:
         axis.plot(
             depdata["tmid_days"],
-            depdata["elecdep_Lsun"] * Lsun_to_erg_per_s,
+            convert_lum_lsun_to_plotunits(depdata["elecdep_Lsun"].to_numpy(), args),
             **plotkwargs,
             label=plotkwargs["label"] + r" $\dot{E}_{dep,\beta^-}$",
             linestyle="dashed",
@@ -98,7 +130,7 @@ def plot_deposition_thermalisation(
         if "eps_alpha_ana_Lsun" in depdata:
             axis.plot(
                 depdata["tmid_days"],
-                depdata["eps_alpha_ana_Lsun"] * Lsun_to_erg_per_s,
+                convert_lum_lsun_to_plotunits(depdata["eps_alpha_ana_Lsun"].to_numpy(), args),
                 **plotkwargs,
                 label=plotkwargs["label"] + r" $\dot{E}_{rad,\alpha}$ analytical",
                 linestyle="solid",
@@ -108,7 +140,7 @@ def plot_deposition_thermalisation(
         if "eps_alpha_Lsun" in depdata:
             axis.plot(
                 depdata["tmid_days"],
-                depdata["eps_alpha_Lsun"] * Lsun_to_erg_per_s,
+                convert_lum_lsun_to_plotunits(depdata["eps_alpha_Lsun"].to_numpy(), args),
                 **plotkwargs,
                 label=plotkwargs["label"] + r" $\dot{E}_{rad,\alpha}$",
                 linestyle="dashed",
@@ -117,7 +149,7 @@ def plot_deposition_thermalisation(
 
         axis.plot(
             depdata["tmid_days"],
-            depdata["alphadep_Lsun"] * Lsun_to_erg_per_s,
+            convert_lum_lsun_to_plotunits(depdata["alphadep_Lsun"].to_numpy(), args),
             **plotkwargs,
             label=plotkwargs["label"] + r" $\dot{E}_{dep,\alpha}$",
             linestyle="dotted",
@@ -570,14 +602,20 @@ def make_lightcurve_plot(
             dflightcurve, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
             lightcurvelabel = args.label[lcindex] or metadata.get("label", bolreflightcurve)
             color = args.color[lcindex] or ["0.0", "0.5", "0.7"][reflightcurveindex]
+            lum_lsun = dflightcurve["luminosity_erg/s"].to_numpy() / Lsun_to_erg_per_s
             if (
                 "luminosity_errminus_erg/s" in dflightcurve.columns
                 and "luminosity_errplus_erg/s" in dflightcurve.columns
             ):
                 axis.errorbar(
                     dflightcurve["time_days"],
-                    dflightcurve["luminosity_erg/s"],
-                    yerr=[dflightcurve["luminosity_errminus_erg/s"], dflightcurve["luminosity_errplus_erg/s"]],
+                    convert_lum_lsun_to_plotunits(lum_lsun, args),
+                    yerr=get_reflightcurve_yerr(
+                        lum_lsun,
+                        dflightcurve["luminosity_errminus_erg/s"].to_numpy() / Lsun_to_erg_per_s,
+                        dflightcurve["luminosity_errplus_erg/s"].to_numpy() / Lsun_to_erg_per_s,
+                        args,
+                    ),
                     fmt="o",
                     capsize=3,
                     label=lightcurvelabel,
@@ -587,7 +625,7 @@ def make_lightcurve_plot(
             else:
                 axis.scatter(
                     dflightcurve["time_days"],
-                    dflightcurve["luminosity_erg/s"],
+                    convert_lum_lsun_to_plotunits(lum_lsun, args),
                     label=lightcurvelabel,
                     color=color,
                     zorder=0,
@@ -662,13 +700,12 @@ def make_lightcurve_plot(
 
     if args.reflightcurves:
         for bolreflightcurve in args.reflightcurves:
-            if args.Lsun:
-                print("Check units - trying to plot ref light curve in erg/s")
-                sys.exit(1)
             bollightcurve_data, metadata = at.lightcurve.read_bol_reflightcurve_data(bolreflightcurve)
             axis.scatter(
                 bollightcurve_data["time_days"],
-                bollightcurve_data["luminosity_erg/s"],
+                convert_lum_lsun_to_plotunits(
+                    bollightcurve_data["luminosity_erg/s"].to_numpy() / Lsun_to_erg_per_s, args
+                ),
                 label=metadata.get("label", bolreflightcurve),
                 color="k",
             )

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -854,12 +854,12 @@ def get_linelabel(
     args: argparse.Namespace,
 ) -> str:
     """Return the legend label for one series, from the model name and viewing angle."""
+    # args.label has one entry per model path, each None unless the user gave a -label for it
+    serieslabel = args.label[modelnumber] or modelname
     if angle is not None and angle != -1:
         assert angle_definition is not None
-        return angle_definition[angle] if args.nomodelname else f"{modelname} {angle_definition[angle]}"
-    if args.label:
-        return str(args.label[modelnumber])
-    return modelname
+        return angle_definition[angle] if args.nomodelname else f"{serieslabel} {angle_definition[angle]}"
+    return str(serieslabel)
 
 
 def set_lightcurveplot_legend(ax: mplax.Axes | npt.NDArray[t.Any], args: argparse.Namespace) -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1,3 +1,4 @@
+import argparse
 import typing as t
 from operator import itemgetter
 from pathlib import Path
@@ -5,10 +6,13 @@ from unittest import mock
 
 import matplotlib.axes as mplax
 import numpy as np
+import numpy.typing as npt
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import artistools as at
+from artistools.constants import Lsun_to_erg_per_s
+from artistools.constants import Mbol_sun
 
 modelpath = at.get_path("testdata") / "testmodel"
 outputpath = at.get_path("testoutput")
@@ -418,3 +422,91 @@ def test_read_hesma_lightcurve_file_no_header(tmp_path: Path) -> None:
 
     assert list(dfhesma.columns) == ["time", "bol"]
     assert dfhesma["bol"].to_list() == [2.0, 4.0]
+
+
+REFLIGHTCURVE = "AT2017gfo_smarttetal2017.txt"
+
+
+def get_reflightcurve_errorbar_call(mockerrorbar: t.Any) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    """Return the times and luminosities that the reference light curve was drawn with."""
+    assert mockerrorbar.call_count == 1
+    callargs = mockerrorbar.call_args_list[0]
+
+    return np.array(callargs[0][1]), np.array(callargs[0][2])
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_erg_per_s(mockerrorbar: t.Any) -> None:
+    """A bolometric reference light curve is plotted in erg/s by default."""
+    at.lightcurve.plot(
+        argsraw=[], modelpath=[REFLIGHTCURVE, modelpath], outputfile=outputpath / "lightcurve_reflightcurve_ergpers.pdf"
+    )
+
+    arr_time_d, arr_lum = get_reflightcurve_errorbar_call(mockerrorbar)
+
+    assert np.isclose(arr_time_d[0], 0.638, rtol=1e-4)
+    assert np.isclose(arr_lum[0], 1.1246049739669314e42, rtol=1e-4)
+
+    yerr = mockerrorbar.call_args_list[0][1]["yerr"]
+    assert np.isclose(yerr[0][0], 2.7737755982632654e41, rtol=1e-4)
+    assert np.isclose(yerr[1][0], 3.681894356120629e41, rtol=1e-4)
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_lsun(mockerrorbar: t.Any) -> None:
+    """A bolometric reference light curve must be converted to Lsun when the axis is in Lsun.
+
+    Before the conversion was applied, the reference data stayed in erg/s and was drawn a factor of
+    Lsun_to_erg_per_s above the ARTIS light curves on the same axis.
+    """
+    at.lightcurve.plot(
+        argsraw=[], modelpath=[REFLIGHTCURVE, modelpath], Lsun=True, outputfile=outputpath / "lc_reflc_Lsun.pdf"
+    )
+
+    _arr_time_d, arr_lum = get_reflightcurve_errorbar_call(mockerrorbar)
+
+    assert np.isclose(arr_lum[0], 1.1246049739669314e42 / Lsun_to_erg_per_s, rtol=1e-4)
+    assert np.isclose(arr_lum[0], 2.9393752586e8, rtol=1e-4)
+
+    yerr = mockerrorbar.call_args_list[0][1]["yerr"]
+    assert np.isclose(yerr[0][0], 2.7737755982632654e41 / Lsun_to_erg_per_s, rtol=1e-4)
+    assert np.isclose(yerr[1][0], 3.681894356120629e41 / Lsun_to_erg_per_s, rtol=1e-4)
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_magnitude(mockerrorbar: t.Any) -> None:
+    """A bolometric reference light curve must be converted to magnitudes when the axis is in magnitudes."""
+    at.lightcurve.plot(
+        argsraw=[], modelpath=[REFLIGHTCURVE, modelpath], magnitude=True, outputfile=outputpath / "lc_reflc_mag.pdf"
+    )
+
+    _arr_time_d, arr_mag = get_reflightcurve_errorbar_call(mockerrorbar)
+
+    dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(REFLIGHTCURVE)
+    lum_lsun = dflightcurve["luminosity_erg/s"].to_numpy() / Lsun_to_erg_per_s
+    assert np.allclose(arr_mag, Mbol_sun - 2.5 * np.log10(lum_lsun), rtol=1e-10)
+    assert np.isclose(arr_mag[0], -16.4306375858, rtol=1e-9)
+
+    # the file gives a symmetric error in log10(luminosity), so both magnitude error bars are 2.5 times it
+    yerr = mockerrorbar.call_args_list[0][1]["yerr"]
+    expected_magerr = 2.5 * dflightcurve["log_lbol_err"].to_numpy()
+    assert np.allclose(yerr[0], expected_magerr, rtol=1e-3)
+    assert np.allclose(yerr[1], expected_magerr, rtol=1e-3)
+
+
+def test_convert_lum_lsun_to_plotunits() -> None:
+    """Deposition rates and reference data must use the same unit conversion as the ARTIS light curves."""
+    lum_lsun = np.array([1.0, 1e8])
+
+    args = argparse.Namespace(magnitude=False, Lsun=True)
+    assert np.allclose(at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), lum_lsun)
+
+    args = argparse.Namespace(magnitude=False, Lsun=False)
+    assert np.allclose(
+        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), lum_lsun * Lsun_to_erg_per_s
+    )
+
+    args = argparse.Namespace(magnitude=True, Lsun=False)
+    assert np.allclose(
+        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), [Mbol_sun, Mbol_sun - 20.0]
+    )

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
+import matplotlib.colors as mplcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
@@ -809,12 +810,16 @@ def test_bol_reflightcurve_magnitude_asymmetric(mockerrorbar: t.Any) -> None:
     )
 
     dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(reflightcurve)
-    expected = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(
-        dflightcurve["luminosity_erg/s"].to_numpy(),
-        dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
-        dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
-        argparse.Namespace(magnitude=True, Lsun=False),
-    )
+    lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
+    errminus = dflightcurve["luminosity_errminus_erg/s"].to_numpy()
+    errplus = dflightcurve["luminosity_errplus_erg/s"].to_numpy()
+
+    # computed from the luminosity ratios rather than from the function under test, so that swapping the two
+    # rows of get_reflightcurve_yerr fails here instead of swapping the expectation with it
+    expected = [
+        2.5 * np.log10((lum_erg_per_s + errplus) / lum_erg_per_s),
+        2.5 * np.log10(lum_erg_per_s / (lum_erg_per_s - errminus)),
+    ]
 
     yerr = mockerrorbar.call_args_list[0][1]["yerr"]
     assert np.allclose(yerr[0], expected[0])
@@ -823,7 +828,8 @@ def test_bol_reflightcurve_magnitude_asymmetric(mockerrorbar: t.Any) -> None:
 
 
 @pytest.mark.parametrize("lumunit", ["erg/s", "Lsun", "magnitude"])
-def test_plotdeposition(lumunit: str) -> None:
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_plotdeposition(mockplot: t.Any, lumunit: str) -> None:
     """Deposition curves are drawn in the y axis units, in every unit mode.
 
     plot_deposition_thermalisation() appends a suffix to the caller's label and picks its own linestyle and
@@ -842,6 +848,22 @@ def test_plotdeposition(lumunit: str) -> None:
             outputfile=outputpath / f"lc_deposition_{lumunit.replace('/', '')}.pdf",
             **plotkwargs,
         )
+
+    gammadep_lsun = at.get_deposition(modelpath_classic_3d).collect()["gammadep_Lsun"].to_numpy()
+    with np.errstate(divide="ignore"):
+        expected = {
+            "erg/s": gammadep_lsun * Lsun_to_erg_per_s,
+            "Lsun": gammadep_lsun,
+            "magnitude": Mbol_sun - 2.5 * np.log10(gammadep_lsun),
+        }[lumunit]
+
+    gammacurves = [
+        callargs
+        for callargs in mockplot.call_args_list
+        if str(callargs.kwargs.get("label", "")).endswith(r"$\dot{E}_{dep,\gamma}$")
+    ]
+    assert len(gammacurves) == 1
+    assert np.allclose(np.asarray(gammacurves[0][0][2], dtype=float), expected, equal_nan=True)
 
 
 def test_plotthermalisation() -> None:
@@ -899,3 +921,145 @@ def test_get_plot_lum_unit_and_column() -> None:
         args = argparse.Namespace(magnitude=magnitude, Lsun=lsun)
         assert at.lightcurve.plotlightcurve.get_plot_lum_unit(args) == expected_unit
         assert at.lightcurve.plotlightcurve.get_plot_lum_column(args) == expected_col
+
+
+@pytest.mark.parametrize(
+    ("dirbins", "colour_evolution"),
+    [([0], ["B-V"]), ([0, 1], ["B-V"]), ([0], ["U-B", "B-V"]), ([0, 1], ["U-B", "B-V"])],
+)
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_yaxis_is_inverted(
+    mockplot: t.Any, dirbins: list[int], colour_evolution: list[str]
+) -> None:
+    """The colour axis points downwards however many direction bins and filter pairs are drawn.
+
+    invert_yaxis() toggles rather than sets, and the subplots share one y axis, so inverting once per plotted
+    line left the axis the right way up whenever an even number of lines was drawn.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        colour_evolution=colour_evolution,
+        plotviewingangle=dirbins,
+        timemin=5,
+        timemax=8,
+        outputfile=outputpath / "lc_colourevolution_inverted.pdf",
+    )
+
+    axes = {id(callargs[0][0]): callargs[0][0] for callargs in mockplot.call_args_list}
+    assert axes
+    for axis in axes.values():
+        ymin, ymax = axis.get_ylim()
+        assert ymin > ymax, f"the colour axis is not inverted for {len(dirbins)} bins and {colour_evolution}"
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_dirbin_colours_avoid_the_model_colours(mockplot: t.Any) -> None:
+    """A direction bin must not be given the colour that a whole model was assigned.
+
+    The direction bin palette and the per-model colours are two independent sources drawn on one set of axes,
+    and both used to start at the first colour of the matplotlib cycle.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath, modelpath_classic_3d],
+        colour_evolution=["B-V"],
+        plotviewingangle=[0, 1],
+        timemin=5,
+        timemax=8,
+        outputfile=outputpath / "lc_colourevolution_colours.pdf",
+    )
+
+    colors = [mplcolors.to_hex(callargs.kwargs["color"]) for callargs in mockplot.call_args_list]
+    assert len(colors) == 3
+    assert len(set(colors)) == len(colors), colors
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_plotdeposition_does_not_inherit_the_light_curve_style(mockplot: t.Any) -> None:
+    """The deposition curves take their style from the command line, not from the last direction bin drawn.
+
+    plot_artis_lightcurve mutates its plot kwargs per direction bin, and those used to ride into the
+    deposition curves, drawing them semi-transparent and above the light curves for no stated reason.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotdeposition=True,
+        plotviewingangle=[0, 1],
+        colorbarphi=True,
+        outputfile=outputpath / "lc_deposition_style.pdf",
+    )
+
+    depositionkwargs = [
+        callargs.kwargs for callargs in mockplot.call_args_list if r"\dot{E}" in str(callargs.kwargs.get("label"))
+    ]
+    assert depositionkwargs
+    for kwargs in depositionkwargs:
+        assert "alpha" not in kwargs
+        assert "zorder" not in kwargs
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_lightcurve_plot_one_sided_time_limit_keeps_the_data_in_view(mockplot: t.Any) -> None:
+    """A -timemin with no -timemax leaves the right hand side fitted to the light curve.
+
+    Setting a one-sided limit before anything is drawn turns autoscaling off, freezing the other side at the
+    default 0-1 view instead of the range of the data.
+    """
+    at.lightcurve.plot(argsraw=[], modelpath=modelpath, timemin=250.0, outputfile=outputpath / "lc_timemin_only.pdf")
+
+    axis = mockplot.call_args_list[0][0][0]
+    xmin, xmax = axis.get_xlim()
+    assert np.isclose(xmin, 250.0)
+    assert xmax > 300.0, xmax
+
+
+@mock.patch.object(mplax.Axes, "set_ylabel", side_effect=mplax.Axes.set_ylabel, autospec=True)
+def test_gamma_lightcurve_magnitude_ylabel(mockylabel: t.Any) -> None:
+    """A gamma-ray light curve in magnitudes is not a bolometric magnitude, and must not be labelled as one."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        gamma=True,
+        rpkt=False,
+        magnitude=True,
+        outputfile=outputpath / "lc_gamma_mag.pdf",
+    )
+
+    ylabels = [callargs[0][1] for callargs in mockylabel.call_args_list]
+    assert ylabels == [r"Absolute $\gamma$-ray Magnitude"]
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_averaged_direction_bin_magnitude_is_rebuilt(mockplot: t.Any) -> None:
+    """Averaging direction bins averages the luminosity, so the magnitude must be rebuilt from the result.
+
+    average_direction_bins takes the mean of every column, and a magnitude is logarithmic: the mean of the
+    magnitudes is not the magnitude of the mean luminosity, and one dark bin sends the mean to inf.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        magnitude=True,
+        plotviewingangle=[0],
+        average_over_phi_angle=True,
+        outputfile=outputpath / "lc_averagedphi_mag.pdf",
+    )
+
+    lcpath = at.firstexisting("light_curve_res.out", folder=modelpath_classic_3d, tryzipped=True)
+    averaged = at.average_direction_bins(at.lightcurve.readfile(lcpath), overangle="phi")[0].collect()
+    lum_lsun_by_time = dict(zip(averaged["time_days"], averaged["luminosity_Lsun"], strict=True))
+    meanofmags_by_time = dict(zip(averaged["time_days"], averaged["mag"], strict=True))
+
+    arr_time_d = np.array(mockplot.call_args_list[0][0][1])
+    arr_mag = np.array(mockplot.call_args_list[0][0][2])
+    assert arr_time_d.size > 0
+
+    with np.errstate(divide="ignore"):
+        expected = Mbol_sun - 2.5 * np.log10(np.array([lum_lsun_by_time[t_d] for t_d in arr_time_d]))
+    assert np.allclose(arr_mag, expected, equal_nan=True)
+
+    meanofmags = np.array([meanofmags_by_time[t_d] for t_d in arr_time_d])
+    assert not np.allclose(arr_mag, meanofmags, equal_nan=True), "the stale mean of the magnitudes was plotted"
+    assert np.isfinite(arr_mag).sum() > np.isfinite(meanofmags).sum(), "a dark bin still poisons the average"

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -237,6 +237,41 @@ def test_colour_evolution_plot_ylabel(mockylabel: t.Any) -> None:
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_linelabel_falls_back_to_the_model_name(mockplot: t.Any) -> None:
+    """A series with no -label is named after its model, not after the None that pads the -label list."""
+    at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["B"], outputfile=outputpath)
+
+    assert [callargs.kwargs["label"] for callargs in mockplot.call_args_list] == ["TEST MODEL"]
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_linelabel_uses_the_label_arg(mockplot: t.Any) -> None:
+    """A -label value names its series, in place of the model name."""
+    at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["B"], label=["My model"], outputfile=outputpath)
+
+    assert [callargs.kwargs["label"] for callargs in mockplot.call_args_list] == ["My model"]
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_linelabel_direction_bin_keeps_the_label_arg(mockplot: t.Any) -> None:
+    """A direction bin is named after the -label value of its model, with the bin appended."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        filter=["B"],
+        plotviewingangle=[0],
+        label=["My model"],
+        timemin=5,
+        timemax=8,
+        outputfile=outputpath,
+    )
+
+    labels = [callargs.kwargs["label"] for callargs in mockplot.call_args_list]
+    assert len(labels) == 1
+    assert labels[0].startswith("My model "), labels
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 def test_colour_evolution_plot_color_arg(mockplot: t.Any) -> None:
     """A -color value must reach the plotted line."""
     at.lightcurve.plot(

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -878,6 +878,25 @@ def test_bol_reflightcurve_unbounded_bar_keeps_the_bright_half_and_gets_an_arrow
     assert screen_y_of_fainter < screen_y_of_brighter
 
 
+def test_bol_reflightcurve_empty_label_stays_out_of_the_legend() -> None:
+    """An explicit -label "" keeps a positional reference curve out of the legend.
+
+    Only a missing label takes the file metadata: matplotlib gives no legend entry to a series
+    labelled "", which is how one is suppressed.
+    """
+    _fig, axis = plt.subplots()
+    plotlabel = at.lightcurve.plotlightcurve.plot_bol_reflightcurve(
+        axis, "AT2017gfo_smarttetal2017.txt", "erg/s", color="0.0", label=""
+    )
+    assert not plotlabel
+
+    plotlabel = at.lightcurve.plotlightcurve.plot_bol_reflightcurve(
+        axis, "AT2017gfo_smarttetal2017.txt", "erg/s", color="0.0", label=None
+    )
+    assert plotlabel
+    assert plotlabel != "None"
+
+
 def test_get_reflightcurve_yerr_scaling() -> None:
     """Without magnitudes the error bar sizes are scaled the same way as the luminosities."""
     lum = np.array([1e42, 2e42])

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -247,25 +247,44 @@ def test_colour_evolution_plot_color_arg(mockplot: t.Any) -> None:
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
-def test_colour_evolution_plot_viewingangle_colours(mockplot: t.Any, capsys: pytest.CaptureFixture[str]) -> None:
+def test_colour_evolution_plot_viewingangle_colours(mockplot: t.Any) -> None:
     """Direction bins get one colour each from the tab20 colour map, whatever -color says.
 
     The -color list has one entry per model, so it cannot colour the direction bins. This used to warn about
-    a -color argument that the user never gave, and then leave the colour unset.
+    a -color argument that the user never gave, and then leave the colour unset. More direction bins than the
+    colour map has colours must wrap around rather than run off the end of the list.
     """
+    ndirbins = 21  # one more than the number of colours in the colour map
     at.lightcurve.plot(
         argsraw=[],
-        modelpath=modelpath,
+        modelpath=modelpath_classic_3d,
         colour_evolution=["B-V"],
-        plotviewingangle=[0],
+        plotviewingangle=list(range(ndirbins)),
+        timemin=5,
+        timemax=8,
         color=["magenta"],
         outputfile=outputpath,
     )
 
-    assert "WARNING: -color" not in capsys.readouterr().out
     colors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list]
-    assert colors, "no lines were plotted"
-    assert all(np.allclose(color, plt.get_cmap("tab20")(0.0)) for color in colors), colors
+    assert len(colors) == ndirbins
+    assert np.allclose(colors[0], plt.get_cmap("tab20")(0.0))
+    assert np.allclose(colors[-1], colors[0])
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_single_dirbin_colour(mockplot: t.Any) -> None:
+    """Use the -color value when a model contributes a single line, even if that line is one direction bin."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        colour_evolution=["B-V"],
+        plotviewingangle=[5],
+        color=["magenta"],
+        outputfile=outputpath,
+    )
+
+    assert [callargs.kwargs["color"] for callargs in mockplot.call_args_list] == ["magenta"]
 
 
 def test_colour_evolution_subplots() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1276,7 +1276,8 @@ def run_set_scatterplot_plot_params(
 
     viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
 
-    return axis.get_xlim()[1], *axis.get_ylim()
+    ymin, ymax = axis.get_ylim()
+    return axis.get_xlim()[1], ymin, ymax
 
 
 def test_set_scatterplot_plot_params_without_xmin() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -16,6 +16,7 @@ from pytest_codspeed.plugin import BenchmarkFixture
 import artistools as at
 from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Mbol_sun
+from artistools.lightcurve import viewingangleanalysis
 
 modelpath = at.get_path("testdata") / "testmodel"
 modelpath_classic_3d = at.get_path("testdata") / "test-classicmode_3d"
@@ -214,6 +215,26 @@ def test_band_lightcurve_peakmag_risetime_plot() -> None:
         save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
         outputfile=outputpath,
     )
+
+
+def test_viewing_angle_peakmag_risetime_scatter_plot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The viewing angle scatter plot must not read -xmin/-xmax, which this parser does not define.
+
+    Its time range is named -timemin/-timemax, so args has no xmin and reading it raised AttributeError
+    before any scatter plot could be saved. The plot reads the data file that the first call writes.
+    """
+    monkeypatch.chdir(tmp_path)
+    commonargs: dict[str, t.Any] = {
+        "modelpath": [modelpath],
+        "filter": ["B"],
+        "timemin": 250,
+        "timemax": 300,
+        "outputfile": tmp_path,
+    }
+    at.lightcurve.plot(argsraw=[], save_viewing_angle_peakmag_risetime_delta_m15_to_file=True, **commonargs)
+    at.lightcurve.plot(argsraw=[], make_viewing_angle_peakmag_risetime_scatter_plot=True, **commonargs)
+
+    assert list(tmp_path.glob("*risetime_peakmag.pdf"))
 
 
 def test_band_lightcurve_subplots() -> None:
@@ -1124,3 +1145,53 @@ def test_averaged_direction_bin_magnitude_is_rebuilt(mockplot: t.Any) -> None:
     meanofmags = np.array([meanofmags_by_time[t_d] for t_d in arr_time_d])
     assert not np.allclose(arr_mag, meanofmags, equal_nan=True), "the stale mean of the magnitudes was plotted"
     assert np.isfinite(arr_mag).sum() > np.isfinite(meanofmags).sum(), "a dark bin still poisons the average"
+
+
+def test_colour_evolution_plot_leaves_the_filter_arg_alone() -> None:
+    """The band selection must not be written back onto args.filter, which main() dispatches on.
+
+    A caller that reuses one Namespace would otherwise take the band light curve branch on the second call
+    and silently draw a different plot.
+    """
+    parser = argparse.ArgumentParser()
+    at.lightcurve.addargs(parser)
+    args = parser.parse_args([])
+    args.modelpath = [modelpath]
+    args.colour_evolution = ["U-B", "B-V"]
+    args.outputfile = outputpath
+
+    at.lightcurve.plot(args=args)
+
+    assert not args.filter
+
+
+@mock.patch.object(mplax.Axes, "set_ylabel", side_effect=mplax.Axes.set_ylabel, autospec=True)
+def test_lightcurve_ylabel_names_deposition_only_when_it_is_drawn(mockylabel: t.Any) -> None:
+    """Asking for deposition rates is not drawing them, so a run with no ARTIS model must not claim them."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[REFLIGHTCURVE],
+        plotdeposition=True,
+        outputfile=outputpath / "lc_reflc_only_deposition.pdf",
+    )
+
+    ylabels = [callargs[0][1] for callargs in mockylabel.call_args_list]
+    assert all(r"\dot{E}" not in ylabel for ylabel in ylabels), ylabels
+
+
+def test_set_scatterplot_plot_params_without_xmin() -> None:
+    """The light curve parser names its range -timemin/-timemax, so the scatter setup must not read args.xmin.
+
+    Reading args.xmin raised AttributeError and made every --make_viewing_angle_peakmag_* run fail.
+    """
+    fig, axis = plt.subplots()
+    axis.plot([1.0, 10.0], [15.0, 19.0])
+    args = argparse.Namespace(colouratpeak=False, ymin=None, ymax=None, colorbarcostheta=False, colorbarphi=False)
+
+    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
+
+    ymin, ymax = axis.get_ylim()
+    assert ymin > ymax, "the magnitude axis must point downwards"
+    # neither side falls back to the default 0-1 view when no limit was given
+    assert axis.get_xlim()[1] >= 10.0
+    assert ymin >= 19.0

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -308,6 +308,31 @@ def test_colour_evolution_plot_viewingangle_colours(mockplot: t.Any) -> None:
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_dirbin_colour_is_stable_across_subplots(mockplot: t.Any) -> None:
+    """A direction bin keeps one colour across the subplots of the filter pairs.
+
+    The legend is drawn on one subplot only, so a bin drawn in a different colour in each subplot
+    contradicts the legend everywhere else.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        colour_evolution=["U-B", "B-V"],
+        plotviewingangle=[0, 1],
+        timemin=5,
+        timemax=8,
+        outputfile=outputpath,
+    )
+
+    # one call per (direction bin, filter pair), the filter pairs of a bin together
+    colors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list]
+    assert len(colors) == 4
+    assert np.allclose(colors[0], colors[1]), "bin 0 changed colour between the subplots"
+    assert np.allclose(colors[2], colors[3]), "bin 1 changed colour between the subplots"
+    assert not np.allclose(colors[0], colors[2]), "the two direction bins share a colour"
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 def test_colour_evolution_plot_single_dirbin_colour(mockplot: t.Any) -> None:
     """Use the -color value when a model contributes a single line, even if that line is one direction bin."""
     at.lightcurve.plot(

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -975,6 +975,24 @@ def test_colour_evolution_plot_dirbin_colours_avoid_the_model_colours(mockplot: 
     assert len(set(colors)) == len(colors), colors
 
 
+@pytest.mark.parametrize("plotalpha", [False, True])
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_plotalphadeposition_draws_the_alpha_curves(mockplot: t.Any, plotalpha: bool) -> None:
+    """The alpha decay curves are drawn only when -plotalphadeposition asks for them."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotdeposition=not plotalpha,
+        plotalphadeposition=plotalpha,
+        outputfile=outputpath / "lc_alphadep.pdf",
+    )
+
+    labels = [str(callargs.kwargs.get("label")) for callargs in mockplot.call_args_list]
+    assert any(r"\alpha" in label for label in labels) == plotalpha, labels
+    # the gamma and beta curves are drawn either way, so the alpha rates can be compared against them
+    assert any(r"\gamma" in label for label in labels), labels
+
+
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 def test_plotdeposition_does_not_inherit_the_light_curve_style(mockplot: t.Any) -> None:
     """The deposition curves take their style from the command line, not from the last direction bin drawn.

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -312,22 +312,36 @@ def test_colour_evolution_plot_viewingangle_colours(mockplot: t.Any) -> None:
     a -color argument that the user never gave, and then leave the colour unset. More direction bins than the
     colour map has colours must wrap around rather than run off the end of the list.
     """
-    ndirbins = 21  # one more than the number of colours in the colour map
-    at.lightcurve.plot(
-        argsraw=[],
-        modelpath=modelpath_classic_3d,
-        colour_evolution=["B-V"],
-        plotviewingangle=list(range(ndirbins)),
-        timemin=5,
-        timemax=8,
-        color=["magenta"],
-        outputfile=outputpath,
-    )
+    palette = ["#111111", "#222222"]
+    ndirbins = len(palette) + 1  # one more than the palette holds, so the last bin wraps to the first colour
+
+    # a short palette exercises the wrap with three direction bins rather than the twenty-one the tab20 map
+    # would need, and the palette itself is covered by test_colour_evolution_plot_dirbin_colours_*
+    with mock.patch.object(at.lightcurve.plotlightcurve, "get_dirbin_palette", return_value=palette):
+        at.lightcurve.plot(
+            argsraw=[],
+            modelpath=modelpath_classic_3d,
+            colour_evolution=["B-V"],
+            plotviewingangle=list(range(ndirbins)),
+            timemin=5,
+            timemax=8,
+            color=["magenta"],
+            outputfile=outputpath,
+        )
 
     colors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list]
-    assert len(colors) == ndirbins
-    assert np.allclose(colors[0], plt.get_cmap("tab20")(0.0))
-    assert np.allclose(colors[-1], colors[0])
+    assert colors == [*palette, palette[0]]
+
+
+def test_dirbin_palette_avoids_the_assigned_colours() -> None:
+    """The direction bin palette holds tab20 colours, minus any that a whole series was given."""
+    tab20colors = [mplcolors.to_hex(color) for color in plt.get_cmap("tab20")(np.linspace(0, 1.0, 20))]
+
+    palette = [mplcolors.to_hex(color) for color in at.lightcurve.plotlightcurve.get_dirbin_palette([tab20colors[0]])]
+    assert palette == tab20colors[1:]
+
+    # every colour of the map assigned leaves none free, and a bin still has to be drawn in something
+    assert len(at.lightcurve.plotlightcurve.get_dirbin_palette(tab20colors)) == len(tab20colors)
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
@@ -1391,3 +1405,41 @@ def test_alpha_deposition_colour_is_taken_only_when_it_is_drawn(mockcolor: t.Any
     )
 
     assert mockcolor.call_count == withoutalpha + 1
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_band_plot_first_dirbin_takes_the_color_arg(mockplot: t.Any) -> None:
+    """A -color value is removed from the cycle for the model, so one of its lines has to use it.
+
+    The band figure gave every line of a multi-bin model a cycle colour, so the requested colour was
+    reserved and then drawn nowhere. The bolometric figure has always given it to the first bin.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        filter=["B"],
+        plotviewingangle=[0, 1],
+        color=["magenta"],
+        timemin=5,
+        timemax=8,
+        outputfile=outputpath / "lc_band_dirbin_color.pdf",
+    )
+
+    colors = [
+        mplcolors.to_hex(callargs[1]["color"]) for callargs in mockplot.call_args_list if callargs[1].get("color")
+    ]
+    assert mplcolors.to_hex("magenta") in colors, colors
+
+
+def test_scatterplot_magnitude_axis_stays_inverted_with_limits() -> None:
+    """set_ylim re-sorts the pair it is given, so an inversion applied before it is lost."""
+    fig, axis = plt.subplots()
+    axis.plot([1.0, 10.0], [-19.0, -15.0])
+    args = argparse.Namespace(colouratpeak=False, ymin=-20.0, ymax=-14.0, colorbarcostheta=False, colorbarphi=False)
+
+    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
+
+    ymin, ymax = axis.get_ylim()
+    assert ymin > ymax, "the magnitude axis must point downwards even when -ymin/-ymax are given"
+    assert np.isclose(ymin, -14.0)
+    assert np.isclose(ymax, -20.0)

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -10,6 +10,7 @@ import matplotlib.colors as mplcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
+import polars as pl
 import pytest
 from pytest_codspeed.plugin import BenchmarkFixture
 
@@ -1336,3 +1337,57 @@ def test_viewing_angle_scatter_needs_the_angle_averaged_step(monkeypatch: pytest
             save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
             make_viewing_angle_peakmag_risetime_scatter_plot=True,
         )
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_band_reflightcurve_is_drawn_once_per_panel(mockplot: t.Any) -> None:
+    """A band reference file is read and drawn once for the whole figure, not once per band.
+
+    plot_lightcurve_from_refdata already draws every band of the file onto its own panel, so calling it
+    from inside the band loop drew each reference curve once per band. It also asserted a single axes,
+    which a figure with more than one band never has, so -filter B V -reflightcurves raised AssertionError.
+    """
+    refdata = pl.DataFrame({
+        "band": ["B", "B", "V", "V"],
+        "time": [260.0, 280.0, 260.0, 280.0],
+        "magnitude": [-13.0, -12.5, -13.2, -12.7],
+    })
+
+    with mock.patch.object(
+        at.lightcurve, "read_reflightcurve_band_data", return_value=(refdata, {"label": "refband"})
+    ) as mockread:
+        at.lightcurve.plot(
+            argsraw=[],
+            modelpath=[modelpath],
+            filter=["B", "V"],
+            reflightcurves=["fakeref.dat"],
+            outputfile=outputpath / "lc_band_ref_once.pdf",
+        )
+
+    assert mockread.call_count == 1, "the reference file must be read once, not once per band"
+
+    reflines = [callargs for callargs in mockplot.call_args_list if callargs[1].get("label") == "refband"]
+    assert len(reflines) == 2, "one reference curve per band panel"
+    assert {tuple(np.asarray(callargs[0][1])) for callargs in reflines} == {(260.0, 280.0)}
+
+
+@mock.patch.object(at.plottools, "get_next_color", side_effect=at.plottools.get_next_color, autospec=True)
+def test_alpha_deposition_colour_is_taken_only_when_it_is_drawn(mockcolor: t.Any) -> None:
+    """A colour taken but not drawn steps every later series along the cycle for nothing."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotdeposition=True,
+        outputfile=outputpath / "lc_dep_colourcount.pdf",
+    )
+    withoutalpha = mockcolor.call_count
+
+    mockcolor.reset_mock()
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotalphadeposition=True,
+        outputfile=outputpath / "lc_alphadep_colourcount.pdf",
+    )
+
+    assert mockcolor.call_count == withoutalpha + 1

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import pytest
@@ -233,6 +234,38 @@ def test_colour_evolution_plot_ylabel(mockylabel: t.Any) -> None:
 
     ylabels = [callargs[0][1] for callargs in mockylabel.call_args_list]
     assert r"$\Delta$m" in ylabels, ylabels
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_color_arg(mockplot: t.Any) -> None:
+    """A -color value must reach the plotted line."""
+    at.lightcurve.plot(
+        argsraw=[], modelpath=modelpath, colour_evolution=["B-V"], color=["magenta"], outputfile=outputpath
+    )
+
+    assert [callargs.kwargs["color"] for callargs in mockplot.call_args_list] == ["magenta"]
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_colour_evolution_plot_viewingangle_colours(mockplot: t.Any, capsys: pytest.CaptureFixture[str]) -> None:
+    """Direction bins get one colour each from the tab20 colour map, whatever -color says.
+
+    The -color list has one entry per model, so it cannot colour the direction bins. This used to warn about
+    a -color argument that the user never gave, and then leave the colour unset.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        colour_evolution=["B-V"],
+        plotviewingangle=[0],
+        color=["magenta"],
+        outputfile=outputpath,
+    )
+
+    assert "WARNING: -color" not in capsys.readouterr().out
+    colors = [callargs.kwargs["color"] for callargs in mockplot.call_args_list]
+    assert colors, "no lines were plotted"
+    assert all(np.allclose(color, plt.get_cmap("tab20")(0.0)) for color in colors), colors
 
 
 def test_colour_evolution_subplots() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1,5 +1,6 @@
 import argparse
 import typing as t
+import warnings
 from operator import itemgetter
 from pathlib import Path
 from unittest import mock
@@ -15,6 +16,7 @@ from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Mbol_sun
 
 modelpath = at.get_path("testdata") / "testmodel"
+modelpath_classic_3d = at.get_path("testdata") / "test-classicmode_3d"
 outputpath = at.get_path("testoutput")
 
 
@@ -510,3 +512,193 @@ def test_convert_lum_lsun_to_plotunits() -> None:
     assert np.allclose(
         at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), [Mbol_sun, Mbol_sun - 20.0]
     )
+
+
+def test_convert_lum_ergs_to_plotunits() -> None:
+    """The erg/s axis must pass the reference data through untouched, with no round trip through Lsun."""
+    lum_erg_per_s = np.array([1.1246049739669314e42, 3.0e41])
+
+    args = argparse.Namespace(magnitude=False, Lsun=False)
+    assert (at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, args) == lum_erg_per_s).all()
+
+    args = argparse.Namespace(magnitude=False, Lsun=True)
+    assert np.allclose(
+        at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+        lum_erg_per_s / Lsun_to_erg_per_s,
+    )
+
+
+def test_convert_lum_to_plotunits_nonpositive() -> None:
+    """A zero or negative luminosity has no magnitude, and must not raise a numpy warning."""
+    args = argparse.Namespace(magnitude=True, Lsun=False)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(np.array([0.0, -1.0, 1.0]), args)
+
+    assert np.isinf(result[0])
+    assert np.isnan(result[1])
+    assert np.isclose(result[2], Mbol_sun)
+
+
+def test_get_reflightcurve_yerr_magnitude() -> None:
+    """Magnitude error bars must reach the magnitudes of the brightest and faintest luminosity bounds.
+
+    matplotlib draws the bar from y - yerr[0] to y + yerr[1], and a brighter (larger) luminosity is a smaller
+    magnitude, so the two rows are asymmetric and must not be swapped.
+    """
+    args = argparse.Namespace(magnitude=True, Lsun=False)
+    lum = np.array([1e42, 1e42, 1e42])
+    errplus = np.array([1e42, 0.0, 1e42])
+    errminus = np.array([0.9e42, 0.0, 2e42])  # the last error bar reaches past zero luminosity
+
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
+    mag = at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum, args)
+
+    assert np.isclose(yerr[0][0], 2.5 * np.log10(2.0))  # brighter by a factor of two
+    assert np.isclose(yerr[1][0], 2.5)  # fainter by a factor of ten
+    assert yerr[1][0] > yerr[0][0], "the fainter (upper) row must not be swapped with the brighter (lower) row"
+
+    assert np.isclose(mag[0] - yerr[0][0], Mbol_sun - 2.5 * np.log10(2e42 / Lsun_to_erg_per_s))
+    assert np.isclose(mag[0] + yerr[1][0], Mbol_sun - 2.5 * np.log10(0.1e42 / Lsun_to_erg_per_s))
+
+    assert yerr[0][1] == 0.0  # a zero error stays zero on both sides
+    assert yerr[1][1] == 0.0
+
+    # an error bar reaching zero luminosity has no faintest magnitude, but the brighter side is still defined
+    assert np.isnan(yerr[1][2])
+    assert not np.isnan(yerr[0][2])
+
+
+def test_get_reflightcurve_yerr_scaling() -> None:
+    """Without magnitudes the error bar sizes are scaled the same way as the luminosities."""
+    lum = np.array([1e42, 2e42])
+    errminus = np.array([1e41, 3e41])
+    errplus = np.array([2e41, 4e41])
+
+    args = argparse.Namespace(magnitude=False, Lsun=False)
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
+    assert np.allclose(yerr[0], errminus)
+    assert np.allclose(yerr[1], errplus)
+
+    args = argparse.Namespace(magnitude=False, Lsun=True)
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
+    assert np.allclose(yerr[0], errminus / Lsun_to_erg_per_s)
+    assert np.allclose(yerr[1], errplus / Lsun_to_erg_per_s)
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_magnitude_asymmetric(mockerrorbar: t.Any) -> None:
+    """A reference curve with asymmetric luminosity errors gets asymmetric magnitude error bars.
+
+    AT2017gfo_smarttetal2017.txt has errors that are symmetric in log10(luminosity), so its two magnitude
+    error bar rows are equal and cannot catch a swapped or symmetric-only implementation.
+    """
+    reflightcurve = "AT2017gfo_waxmanetal2018.txt"
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[reflightcurve, modelpath],
+        magnitude=True,
+        outputfile=outputpath / "lc_reflc_mag_asym.pdf",
+    )
+
+    dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(reflightcurve)
+    expected = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(
+        dflightcurve["luminosity_erg/s"].to_numpy(),
+        dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
+        dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
+        argparse.Namespace(magnitude=True, Lsun=False),
+    )
+
+    yerr = mockerrorbar.call_args_list[0][1]["yerr"]
+    assert np.allclose(yerr[0], expected[0])
+    assert np.allclose(yerr[1], expected[1])
+    assert not np.allclose(yerr[0], yerr[1], rtol=1e-2), "this file must exercise the asymmetric branch"
+
+
+@pytest.mark.parametrize("lumunit", ["erg/s", "Lsun", "magnitude"])
+def test_plotdeposition(lumunit: str) -> None:
+    """Deposition curves are drawn in the y axis units, in every unit mode.
+
+    plot_deposition_thermalisation() appends a suffix to the caller's label and picks its own linestyle and
+    colour, so those keys must not also arrive in the **plotkwargs splat, which used to raise
+    "got multiple values for keyword argument".
+    """
+    plotkwargs: dict[str, t.Any] = {} if lumunit == "erg/s" else {lumunit: True}
+
+    with warnings.catch_warnings():
+        # a zero deposition rate has no magnitude, but it must not warn
+        warnings.simplefilter("error", RuntimeWarning)
+        at.lightcurve.plot(
+            argsraw=[],
+            modelpath=[modelpath_classic_3d],
+            plotdeposition=True,
+            outputfile=outputpath / f"lc_deposition_{lumunit.replace('/', '')}.pdf",
+            **plotkwargs,
+        )
+
+
+def test_plotthermalisation() -> None:
+    """The thermalisation curves share plot_deposition_thermalisation's kwargs handling."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotthermalisation=True,
+        outputfile=outputpath / "lc_thermalisation.pdf",
+    )
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
+    """-reflightcurves must draw the same curve as a positional reference file, error bars included.
+
+    This branch used to scatter the points with no uncertainties while the positional branch drew error bars
+    from the same file, and it kept its own copy of the unit conversion.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath],
+        reflightcurves=[REFLIGHTCURVE],
+        magnitude=True,
+        outputfile=outputpath / "lc_reflightcurves_arg.pdf",
+    )
+
+    dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(REFLIGHTCURVE)
+    lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
+    args = argparse.Namespace(magnitude=True, Lsun=False)
+
+    assert mockerrorbar.call_count == 1
+    arr_mag = np.array(mockerrorbar.call_args_list[0][0][2])
+    assert np.allclose(arr_mag, Mbol_sun - 2.5 * np.log10(lum_erg_per_s / Lsun_to_erg_per_s))
+
+    yerr = mockerrorbar.call_args_list[0][1]["yerr"]
+    expected = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(
+        lum_erg_per_s,
+        dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
+        dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
+        args,
+    )
+    assert np.allclose(yerr[0], expected[0])
+    assert np.allclose(yerr[1], expected[1])
+
+
+def test_reflightcurve_colors_cycle() -> None:
+    """More reference light curves than default colours must cycle rather than run off the end of the list."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[REFLIGHTCURVE, "AT2017gfo_waxmanetal2018.txt", REFLIGHTCURVE, "AT2017gfo_waxmanetal2018.txt"],
+        outputfile=outputpath / "lc_reflightcurves_four.pdf",
+    )
+
+
+def test_get_plot_lum_unit_and_column() -> None:
+    """The unit choice and the light curve column to plot come from one place."""
+    for magnitude, lsun, expected_unit, expected_col in [
+        (True, False, "mag", "mag"),
+        (True, True, "mag", "mag"),  # magnitude wins over Lsun
+        (False, True, "Lsun", "luminosity_Lsun"),
+        (False, False, "erg/s", "luminosity_erg/s"),
+    ]:
+        args = argparse.Namespace(magnitude=magnitude, Lsun=lsun)
+        assert at.lightcurve.plotlightcurve.get_plot_lum_unit(args) == expected_unit
+        assert at.lightcurve.plotlightcurve.get_plot_lum_column(args) == expected_col

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -774,7 +774,7 @@ def test_get_reflightcurve_yerr_magnitude() -> None:
     errplus = np.array([1e42, 0.0, 1e42])
     errminus = np.array([0.9e42, 0.0, 2e42])  # the last error bar reaches past zero luminosity
 
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "mag")
+    yerr, unbounded = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "mag")
     mag = at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum, "mag")
 
     assert np.isclose(yerr[0][0], 2.5 * np.log10(2.0))  # brighter by a factor of two
@@ -784,12 +784,65 @@ def test_get_reflightcurve_yerr_magnitude() -> None:
     assert np.isclose(mag[0] - yerr[0][0], Mbol_sun - 2.5 * np.log10(2e42 / Lsun_to_erg_per_s))
     assert np.isclose(mag[0] + yerr[1][0], Mbol_sun - 2.5 * np.log10(0.1e42 / Lsun_to_erg_per_s))
 
-    assert yerr[0][1] == 0.0  # a zero error stays zero on both sides
-    assert yerr[1][1] == 0.0
+    assert np.isclose(yerr[0][1], 0.0)  # a zero error stays zero on both sides
+    assert np.isclose(yerr[1][1], 0.0)
 
-    # an error bar reaching zero luminosity has no faintest magnitude, but the brighter side is still defined
-    assert np.isnan(yerr[1][2])
-    assert not np.isnan(yerr[0][2])
+    # a bar reaching zero luminosity has no faintest magnitude. A NaN there makes matplotlib drop the whole
+    # bar, so the faint side has no length and the point is flagged for an arrow instead
+    assert np.allclose(unbounded, [False, False, True])
+    assert np.isfinite(yerr[1][2])
+    assert np.isclose(yerr[1][2], 0.0)
+    assert np.isclose(yerr[0][2], 2.5 * np.log10(2.0))
+
+
+def test_get_reflightcurve_yerr_nonpositive_luminosity_draws_no_bar() -> None:
+    """A luminosity at or below zero has no magnitude, so it must not reach matplotlib as an infinite bar.
+
+    matplotlib adds the error to the value, and inf + -inf warns and yields NaN.
+    """
+    lum = np.array([0.0, -1e42, 1e42])
+    errminus = np.array([1e41, 1e41, 1e41])
+    errplus = np.array([1e41, 1e41, 1e41])
+
+    yerr, unbounded = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "mag")
+
+    assert np.all(np.isfinite(yerr[0])), yerr[0]
+    assert np.all(np.isfinite(yerr[1])), yerr[1]
+    assert np.allclose(yerr[0][:2], 0.0)
+    assert np.allclose(yerr[1][:2], 0.0)
+    # a point with no magnitude is not an open faint side, it is not drawn at all
+    assert not unbounded[:2].any()
+    assert yerr[0][2] > 0.0
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_unbounded_faint_side_keeps_the_bright_half(mockerrorbar: t.Any, tmp_path: Path) -> None:
+    """An error bar reaching zero luminosity keeps its bright half and gains an arrow on the faint side.
+
+    Putting NaN in the faint row instead makes matplotlib collapse the segment to a single vertex, so the
+    finite bright half disappears with it.
+    """
+    reffile = tmp_path / "unbounded_reflightcurve.txt"
+    reffile.write_text(
+        "#time_days luminosity_erg/s luminosity_errminus_erg/s luminosity_errplus_erg/s\n"
+        "2.0 1e42 5e41 5e41\n"
+        "3.0 1e42 2e42 5e41\n",
+        encoding="utf-8",
+    )
+
+    at.lightcurve.plot(
+        argsraw=[], modelpath=[reffile], magnitude=True, outputfile=outputpath / "lc_reflc_unbounded.pdf"
+    )
+
+    barcall, arrowcall = mockerrorbar.call_args_list
+    yerr = barcall[1]["yerr"]
+    assert np.all(np.isfinite(yerr[0]))
+    assert np.all(np.isfinite(yerr[1]))
+    assert yerr[0][1] > 0.0, "the bright half of the unbounded bar must still be drawn"
+    assert np.isclose(yerr[1][1], 0.0), "the faint half has no length, so matplotlib keeps the bright one"
+
+    assert arrowcall[1]["lolims"] is True
+    assert np.allclose(arrowcall[0][1], [3.0]), "only the unbounded point gets an arrow"
 
 
 def test_get_reflightcurve_yerr_scaling() -> None:
@@ -798,11 +851,12 @@ def test_get_reflightcurve_yerr_scaling() -> None:
     errminus = np.array([1e41, 3e41])
     errplus = np.array([2e41, 4e41])
 
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "erg/s")
+    yerr, unbounded = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "erg/s")
     assert np.allclose(yerr[0], errminus)
     assert np.allclose(yerr[1], errplus)
+    assert not unbounded.any(), "a luminosity axis reaches zero, so no bar is open-ended"
 
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "Lsun")
+    yerr, _unbounded = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "Lsun")
     assert np.allclose(yerr[0], errminus / Lsun_to_erg_per_s)
     assert np.allclose(yerr[1], errplus / Lsun_to_erg_per_s)
 
@@ -911,7 +965,7 @@ def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
     assert np.allclose(arr_mag, Mbol_sun - 2.5 * np.log10(lum_erg_per_s / Lsun_to_erg_per_s))
 
     yerr = mockerrorbar.call_args_list[0][1]["yerr"]
-    expected = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(
+    expected, _unbounded = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(
         lum_erg_per_s,
         dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
         dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
@@ -1195,3 +1249,90 @@ def test_set_scatterplot_plot_params_without_xmin() -> None:
     # neither side falls back to the default 0-1 view when no limit was given
     assert axis.get_xlim()[1] >= 10.0
     assert ymin >= 19.0
+
+
+def test_readfile_rebuilds_the_magnitude_after_averaging() -> None:
+    """The loader owns the averaging, so the magnitude cannot be left as the mean of the magnitudes.
+
+    Averaging is linear and a magnitude is logarithmic, so a single dark bin sends the arithmetic mean of
+    the magnitudes to inf while the magnitude of the averaged luminosity stays finite.
+    """
+    lcpath = at.firstexisting("light_curve_res.out", folder=modelpath_classic_3d, tryzipped=True)
+
+    averaged = at.lightcurve.readfile(lcpath, average_over_phi=True)[0].collect()
+    stalemean = at.average_direction_bins(at.lightcurve.readfile(lcpath), overangle="phi")[0].collect()
+
+    with np.errstate(divide="ignore"):
+        magofmeanlum = Mbol_sun - 2.5 * np.log10(averaged["luminosity_Lsun"].to_numpy())
+
+    assert np.allclose(averaged["mag"].to_numpy(), magofmeanlum, equal_nan=True)
+    assert not np.allclose(averaged["mag"].to_numpy(), stalemean["mag"].to_numpy(), equal_nan=True)
+
+
+def test_color_arg_rejects_a_colour_matplotlib_cannot_parse() -> None:
+    """A mistyped colour must be named by the argument that took it, not by a colour cycle helper."""
+    parser = argparse.ArgumentParser()
+    at.lightcurve.addargs(parser)
+
+    assert parser.parse_args(["-color", "tab:blue", "#1F77B4"]).color == ["tab:blue", "#1F77B4"]
+
+    for argname in ("-color", "-refspeccolors"):
+        with pytest.raises(SystemExit):
+            parser.parse_args([argname, "notacolour"])
+
+
+def test_transparent_series_colour_leaves_the_cycle_alone() -> None:
+    """A series drawn in "none" holds no colour, so it must not remove black from the palette."""
+    assert not at.plottools.get_assigned_colors(["none"])
+    assert mplcolors.to_hex("#000000") in {
+        mplcolors.to_hex(color) for color in at.plottools.get_unused_colors(["#000000", "#ffffff"], ["none"])
+    }
+
+
+@pytest.mark.parametrize("plottype", ["bolometric", "band", "colour_evolution"])
+@mock.patch.object(mplax.Axes, "set_xlim", side_effect=mplax.Axes.set_xlim, autospec=True)
+def test_time_limits_reach_every_figure(mockxlim: t.Any, plottype: str) -> None:
+    """-timemin/-timemax are this command's x limits, so every figure it draws must honour them."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath],
+        timemin=260,
+        timemax=300,
+        outputfile=outputpath,
+        filter=["B"] if plottype == "band" else [],
+        colour_evolution=["B-V"] if plottype == "colour_evolution" else [],
+    )
+
+    limits = [callargs[0][1:3] for callargs in mockxlim.call_args_list if len(callargs[0]) > 2]
+    assert (260, 300) in limits, limits
+
+
+def test_nonpositive_limit_on_a_log_axis_is_dropped(capsys: pytest.CaptureFixture[str]) -> None:
+    """A log axis cannot show a limit at or below zero, so it is dropped with a message naming the argument."""
+    _fig, axis = plt.subplots()
+    axis.plot([1.0, 10.0], [1e40, 1e44])
+    args = argparse.Namespace(logscaley=True, ymin=0.0, ymax=1e45, xmin=None, xmax=None)
+
+    at.plottools.set_axis_properties(axis, args)
+
+    assert "-ymin" in capsys.readouterr().out
+    ymin, ymax = axis.get_ylim()
+    assert ymin > 0.0, "the data must stay in view rather than the axis freezing at a rejected limit"
+    assert np.isclose(ymax, 1e45)
+
+
+def test_viewing_angle_scatter_needs_the_angle_averaged_step(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Writing the per-direction-bin data and plotting it are two runs, so asking for both must say so."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="angle-averaged"):
+        at.lightcurve.plot(
+            argsraw=[],
+            modelpath=[modelpath],
+            filter=["B"],
+            timemin=250,
+            timemax=300,
+            outputfile=tmp_path,
+            save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
+            make_viewing_angle_peakmag_risetime_scatter_plot=True,
+        )

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -62,6 +62,39 @@ def test_lightcurve_plot_frompackets(mockplot: t.Any, benchmark: BenchmarkFixtur
     assert np.isclose(arr_lum.std(), 3.614004402353378e38, rtol=1e-4)
 
 
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_lightcurve_plot_reflightcurves_keep_their_errorbars(mockerrorbar: t.Any) -> None:
+    """Reference light curves keep their error bars by either route, the model path list or -reflightcurves."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=["AT2017gfo_waxmanetal2018.txt"],
+        reflightcurves=["AT2017gfo_smarttetal2017.txt"],
+        outputfile=Path(outputpath, "lightcurve_reflightcurves.pdf"),
+    )
+
+    # one call for the reference light curve given as a model path, one for the -reflightcurves file
+    assert mockerrorbar.call_count == 2
+
+    labels = [callitem[1]["label"] for callitem in mockerrorbar.call_args_list]
+    assert labels == ["AT2017gfo (Waxman+2018)", "AT2017gfo (Smartt+2017)"]
+
+    # the -reflightcurves file continues the grey sequence rather than starting it again
+    assert [callitem[1]["color"] for callitem in mockerrorbar.call_args_list] == ["0.0", "0.4"]
+
+    assert all(callitem[1]["zorder"] == 0 for callitem in mockerrorbar.call_args_list)
+
+    for callitem, expected_time_d_min in zip(mockerrorbar.call_args_list, (0.5, 0.638), strict=True):
+        arr_time_d = np.array(callitem[0][1])
+        arr_lum = np.array(callitem[0][2])
+        arr_errminus, arr_errplus = (np.array(err) for err in callitem[1]["yerr"])
+
+        assert np.isclose(arr_time_d.min(), expected_time_d_min, rtol=1e-4)
+        assert arr_errminus.shape == arr_lum.shape
+        assert arr_errplus.shape == arr_lum.shape
+        assert (arr_errminus > 0.0).all()
+        assert (arr_errplus > 0.0).all()
+
+
 def test_band_lightcurve_plot() -> None:
     at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["B"], outputfile=outputpath)
 
@@ -447,8 +480,10 @@ def test_lightcurve_plot_reflightcurves_continue_the_greys(mockerrorbar: t.Any, 
         outputfile=outputpath,
     )
 
-    assert [callargs.kwargs["color"] for callargs in mockerrorbar.call_args_list] == ["0.0"]
-    assert [callargs.kwargs["color"] for callargs in mockscatter.call_args_list] == ["0.4"]
+    assert [callargs.kwargs["color"] for callargs in mockerrorbar.call_args_list] == ["0.0", "0.4"]
+
+    # both files have error columns, so neither route falls back to a plain scatter
+    assert mockscatter.call_args_list == []
 
 
 @mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -709,17 +709,14 @@ def test_convert_lum_lsun_to_plotunits() -> None:
     """Deposition rates and reference data must use the same unit conversion as the ARTIS light curves."""
     lum_lsun = np.array([1.0, 1e8])
 
-    args = argparse.Namespace(magnitude=False, Lsun=True)
-    assert np.allclose(at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), lum_lsun)
+    assert np.allclose(at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, "Lsun"), lum_lsun)
 
-    args = argparse.Namespace(magnitude=False, Lsun=False)
     assert np.allclose(
-        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), lum_lsun * Lsun_to_erg_per_s
+        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, "erg/s"), lum_lsun * Lsun_to_erg_per_s
     )
 
-    args = argparse.Namespace(magnitude=True, Lsun=False)
     assert np.allclose(
-        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, args), [Mbol_sun, Mbol_sun - 20.0]
+        at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(lum_lsun, "mag"), [Mbol_sun, Mbol_sun - 20.0]
     )
 
 
@@ -727,23 +724,19 @@ def test_convert_lum_ergs_to_plotunits() -> None:
     """The erg/s axis must pass the reference data through untouched, with no round trip through Lsun."""
     lum_erg_per_s = np.array([1.1246049739669314e42, 3.0e41])
 
-    args = argparse.Namespace(magnitude=False, Lsun=False)
-    assert (at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, args) == lum_erg_per_s).all()
+    assert (at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, "erg/s") == lum_erg_per_s).all()
 
-    args = argparse.Namespace(magnitude=False, Lsun=True)
     assert np.allclose(
-        at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, args),
+        at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum_erg_per_s, "Lsun"),
         lum_erg_per_s / Lsun_to_erg_per_s,
     )
 
 
 def test_convert_lum_to_plotunits_nonpositive() -> None:
     """A zero or negative luminosity has no magnitude, and must not raise a numpy warning."""
-    args = argparse.Namespace(magnitude=True, Lsun=False)
-
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        result = at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(np.array([0.0, -1.0, 1.0]), args)
+        result = at.lightcurve.plotlightcurve.convert_lum_lsun_to_plotunits(np.array([0.0, -1.0, 1.0]), "mag")
 
     assert np.isinf(result[0])
     assert np.isnan(result[1])
@@ -756,13 +749,12 @@ def test_get_reflightcurve_yerr_magnitude() -> None:
     matplotlib draws the bar from y - yerr[0] to y + yerr[1], and a brighter (larger) luminosity is a smaller
     magnitude, so the two rows are asymmetric and must not be swapped.
     """
-    args = argparse.Namespace(magnitude=True, Lsun=False)
     lum = np.array([1e42, 1e42, 1e42])
     errplus = np.array([1e42, 0.0, 1e42])
     errminus = np.array([0.9e42, 0.0, 2e42])  # the last error bar reaches past zero luminosity
 
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
-    mag = at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum, args)
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "mag")
+    mag = at.lightcurve.plotlightcurve.convert_lum_ergs_to_plotunits(lum, "mag")
 
     assert np.isclose(yerr[0][0], 2.5 * np.log10(2.0))  # brighter by a factor of two
     assert np.isclose(yerr[1][0], 2.5)  # fainter by a factor of ten
@@ -785,13 +777,11 @@ def test_get_reflightcurve_yerr_scaling() -> None:
     errminus = np.array([1e41, 3e41])
     errplus = np.array([2e41, 4e41])
 
-    args = argparse.Namespace(magnitude=False, Lsun=False)
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "erg/s")
     assert np.allclose(yerr[0], errminus)
     assert np.allclose(yerr[1], errplus)
 
-    args = argparse.Namespace(magnitude=False, Lsun=True)
-    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, args)
+    yerr = at.lightcurve.plotlightcurve.get_reflightcurve_yerr(lum, errminus, errplus, "Lsun")
     assert np.allclose(yerr[0], errminus / Lsun_to_erg_per_s)
     assert np.allclose(yerr[1], errplus / Lsun_to_erg_per_s)
 
@@ -895,7 +885,6 @@ def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
 
     dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(REFLIGHTCURVE)
     lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
-    args = argparse.Namespace(magnitude=True, Lsun=False)
 
     assert mockerrorbar.call_count == 1
     arr_mag = np.array(mockerrorbar.call_args_list[0][0][2])
@@ -906,7 +895,7 @@ def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
         lum_erg_per_s,
         dflightcurve["luminosity_errminus_erg/s"].to_numpy(),
         dflightcurve["luminosity_errplus_erg/s"].to_numpy(),
-        args,
+        "mag",
     )
     assert np.allclose(yerr[0], expected[0])
     assert np.allclose(yerr[1], expected[1])
@@ -921,8 +910,9 @@ def test_get_plot_lum_unit_and_column() -> None:
         (False, False, "erg/s", "luminosity_erg/s"),
     ):
         args = argparse.Namespace(magnitude=magnitude, Lsun=lsun)
-        assert at.lightcurve.plotlightcurve.get_plot_lum_unit(args) == expected_unit
-        assert at.lightcurve.plotlightcurve.get_plot_lum_column(args) == expected_col
+        lumunit = at.lightcurve.plotlightcurve.get_plot_lum_unit(args)
+        assert lumunit == expected_unit
+        assert at.lightcurve.plotlightcurve.get_plot_lum_column(lumunit) == expected_col
 
 
 @pytest.mark.parametrize(

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1,6 +1,7 @@
 import argparse
 import typing as t
 import warnings
+from collections.abc import Sequence
 from operator import itemgetter
 from pathlib import Path
 from unittest import mock
@@ -13,6 +14,7 @@ import numpy as np
 import numpy.typing as npt
 import polars as pl
 import pytest
+from matplotlib.container import ErrorbarContainer
 from pytest_codspeed.plugin import BenchmarkFixture
 
 import artistools as at
@@ -832,11 +834,14 @@ def test_get_reflightcurve_yerr_nonpositive_luminosity_draws_no_bar() -> None:
 
 
 @mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
-def test_bol_reflightcurve_unbounded_faint_side_keeps_the_bright_half(mockerrorbar: t.Any, tmp_path: Path) -> None:
-    """An error bar reaching zero luminosity keeps its bright half and gains an arrow on the faint side.
+def test_bol_reflightcurve_unbounded_bar_keeps_the_bright_half_and_gets_an_arrow(
+    mockerrorbar: t.Any, tmp_path: Path
+) -> None:
+    """An error bar reaching zero luminosity keeps its bright half, plus an arrow pointing at the faint side.
 
     Putting NaN in the faint row instead makes matplotlib collapse the segment to a single vertex, so the
-    finite bright half disappears with it.
+    finite bright half disappears with it. The arrow direction is fixed at the errorbar call, and a
+    magnitude axis is inverted only after every series is drawn, so the default direction is the wrong one.
     """
     reffile = tmp_path / "unbounded_reflightcurve.txt"
     reffile.write_text(
@@ -846,9 +851,9 @@ def test_bol_reflightcurve_unbounded_faint_side_keeps_the_bright_half(mockerrorb
         encoding="utf-8",
     )
 
-    at.lightcurve.plot(
-        argsraw=[], modelpath=[reffile], magnitude=True, outputfile=outputpath / "lc_reflc_unbounded.pdf"
-    )
+    _fig, axis = plt.subplots()
+    at.lightcurve.plotlightcurve.plot_bol_reflightcurve(axis, reffile, "mag", color="0.0")
+    at.lightcurve.plotlightcurve.invert_magnitude_yaxis(axis)
 
     barcall, arrowcall = mockerrorbar.call_args_list
     yerr = barcall[1]["yerr"]
@@ -860,31 +865,11 @@ def test_bol_reflightcurve_unbounded_faint_side_keeps_the_bright_half(mockerrorb
     assert arrowcall[1]["lolims"] is True
     assert np.allclose(arrowcall[0][1], [3.0]), "only the unbounded point gets an arrow"
 
-
-@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
-def test_bol_reflightcurve_unbounded_arrow_points_at_the_faint_side(mockerrorbar: t.Any, tmp_path: Path) -> None:
-    """The arrow of an open-ended magnitude bar must point away from the brighter magnitudes.
-
-    matplotlib picks the direction from the orientation of the axis at the time of the errorbar call, and
-    a magnitude axis is inverted only after every series is drawn, so the default direction is the wrong one.
-    """
-    reffile = tmp_path / "unbounded_arrow_reflightcurve.txt"
-    reffile.write_text(
-        "#time_days luminosity_erg/s luminosity_errminus_erg/s luminosity_errplus_erg/s\n"
-        "2.0 1e42 5e41 5e41\n"
-        "3.0 1e42 2e42 5e41\n",
-        encoding="utf-8",
-    )
-
-    at.lightcurve.plot(
-        argsraw=[], modelpath=[reffile], magnitude=True, outputfile=outputpath / "lc_reflc_unbounded_arrow.pdf"
-    )
-
-    axis = mockerrorbar.call_args_list[-1][0][0]
     ymin, ymax = axis.get_ylim()
     assert ymin > ymax, "this test only means anything on an inverted magnitude axis"
-
-    carets = [line.get_marker() for line in axis.containers[-1].lines[1]]
+    arrowcontainer = axis.containers[-1]
+    assert isinstance(arrowcontainer, ErrorbarContainer)
+    carets = [line.get_marker() for line in arrowcontainer.lines[1]]
     assert carets == [mplmarkers.CARETDOWNBASE], carets
     # a downward caret is drawn towards the lower screen positions, which on this axis are the fainter
     # (larger) magnitudes, so the arrow marks the side of the bar that has no end
@@ -1281,21 +1266,29 @@ def test_lightcurve_ylabel_names_deposition_only_when_it_is_drawn(mockylabel: t.
     assert all(r"\dot{E}" not in ylabel for ylabel in ylabels), ylabels
 
 
+def run_set_scatterplot_plot_params(
+    magnitudes: Sequence[float], ymin: float | None, ymax: float | None
+) -> tuple[float, float, float]:
+    """Plot the magnitudes, apply the shared scatter plot setup, and return xmax, ymin, ymax."""
+    fig, axis = plt.subplots()
+    axis.plot([1.0, 10.0], list(magnitudes))
+    args = argparse.Namespace(colouratpeak=False, ymin=ymin, ymax=ymax, colorbarcostheta=False, colorbarphi=False)
+
+    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
+
+    return axis.get_xlim()[1], *axis.get_ylim()
+
+
 def test_set_scatterplot_plot_params_without_xmin() -> None:
     """The light curve parser names its range -timemin/-timemax, so the scatter setup must not read args.xmin.
 
     Reading args.xmin raised AttributeError and made every --make_viewing_angle_peakmag_* run fail.
     """
-    fig, axis = plt.subplots()
-    axis.plot([1.0, 10.0], [15.0, 19.0])
-    args = argparse.Namespace(colouratpeak=False, ymin=None, ymax=None, colorbarcostheta=False, colorbarphi=False)
+    xmax, ymin, ymax = run_set_scatterplot_plot_params([15.0, 19.0], ymin=None, ymax=None)
 
-    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
-
-    ymin, ymax = axis.get_ylim()
     assert ymin > ymax, "the magnitude axis must point downwards"
     # neither side falls back to the default 0-1 view when no limit was given
-    assert axis.get_xlim()[1] >= 10.0
+    assert xmax >= 10.0
     assert ymin >= 19.0
 
 
@@ -1421,23 +1414,18 @@ def test_band_reflightcurve_is_drawn_once_per_panel(mockplot: t.Any) -> None:
 @mock.patch.object(at.plottools, "get_next_color", side_effect=at.plottools.get_next_color, autospec=True)
 def test_alpha_deposition_colour_is_taken_only_when_it_is_drawn(mockcolor: t.Any) -> None:
     """A colour taken but not drawn steps every later series along the cycle for nothing."""
-    at.lightcurve.plot(
-        argsraw=[],
-        modelpath=[modelpath_classic_3d],
-        plotdeposition=True,
-        outputfile=outputpath / "lc_dep_colourcount.pdf",
-    )
-    withoutalpha = mockcolor.call_count
+    for plotalphadeposition, expected_extra in ((False, 0), (True, 1)):
+        _fig, axis = plt.subplots()
+        args = argparse.Namespace(
+            plotdeposition=True, plotalphadeposition=plotalphadeposition, plotthermalisation=False,
+            magnitude=False, Lsun=False,
+        )  # fmt: skip
 
-    mockcolor.reset_mock()
-    at.lightcurve.plot(
-        argsraw=[],
-        modelpath=[modelpath_classic_3d],
-        plotalphadeposition=True,
-        outputfile=outputpath / "lc_alphadep_colourcount.pdf",
-    )
+        mockcolor.reset_mock()
+        at.lightcurve.plotlightcurve.plot_deposition_thermalisation(axis, None, modelpath_classic_3d, "modelname", args)
 
-    assert mockcolor.call_count == withoutalpha + 1
+        # one colour skipped plus gamma and beta, and the alpha colour only when its curves are drawn
+        assert mockcolor.call_count == 3 + expected_extra
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
@@ -1466,13 +1454,8 @@ def test_band_plot_first_dirbin_takes_the_color_arg(mockplot: t.Any) -> None:
 
 def test_scatterplot_magnitude_axis_stays_inverted_with_limits() -> None:
     """set_ylim re-sorts the pair it is given, so an inversion applied before it is lost."""
-    fig, axis = plt.subplots()
-    axis.plot([1.0, 10.0], [-19.0, -15.0])
-    args = argparse.Namespace(colouratpeak=False, ymin=-20.0, ymax=-14.0, colorbarcostheta=False, colorbarphi=False)
+    _xmax, ymin, ymax = run_set_scatterplot_plot_params([-19.0, -15.0], ymin=-20.0, ymax=-14.0)
 
-    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
-
-    ymin, ymax = axis.get_ylim()
     assert ymin > ymax, "the magnitude axis must point downwards even when -ymin/-ymax are given"
     assert np.isclose(ymin, -14.0)
     assert np.isclose(ymax, -20.0)

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import matplotlib.axes as mplax
 import matplotlib.colors as mplcolors
+import matplotlib.markers as mplmarkers
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
@@ -858,6 +859,38 @@ def test_bol_reflightcurve_unbounded_faint_side_keeps_the_bright_half(mockerrorb
 
     assert arrowcall[1]["lolims"] is True
     assert np.allclose(arrowcall[0][1], [3.0]), "only the unbounded point gets an arrow"
+
+
+@mock.patch.object(mplax.Axes, "errorbar", side_effect=mplax.Axes.errorbar, autospec=True)
+def test_bol_reflightcurve_unbounded_arrow_points_at_the_faint_side(mockerrorbar: t.Any, tmp_path: Path) -> None:
+    """The arrow of an open-ended magnitude bar must point away from the brighter magnitudes.
+
+    matplotlib picks the direction from the orientation of the axis at the time of the errorbar call, and
+    a magnitude axis is inverted only after every series is drawn, so the default direction is the wrong one.
+    """
+    reffile = tmp_path / "unbounded_arrow_reflightcurve.txt"
+    reffile.write_text(
+        "#time_days luminosity_erg/s luminosity_errminus_erg/s luminosity_errplus_erg/s\n"
+        "2.0 1e42 5e41 5e41\n"
+        "3.0 1e42 2e42 5e41\n",
+        encoding="utf-8",
+    )
+
+    at.lightcurve.plot(
+        argsraw=[], modelpath=[reffile], magnitude=True, outputfile=outputpath / "lc_reflc_unbounded_arrow.pdf"
+    )
+
+    axis = mockerrorbar.call_args_list[-1][0][0]
+    ymin, ymax = axis.get_ylim()
+    assert ymin > ymax, "this test only means anything on an inverted magnitude axis"
+
+    carets = [line.get_marker() for line in axis.containers[-1].lines[1]]
+    assert carets == [mplmarkers.CARETDOWNBASE], carets
+    # a downward caret is drawn towards the lower screen positions, which on this axis are the fainter
+    # (larger) magnitudes, so the arrow marks the side of the bar that has no end
+    screen_y_of_fainter = axis.transData.transform((0.0, max(ymin, ymax)))[1]
+    screen_y_of_brighter = axis.transData.transform((0.0, min(ymin, ymax)))[1]
+    assert screen_y_of_fainter < screen_y_of_brighter
 
 
 def test_get_reflightcurve_yerr_scaling() -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -986,6 +986,30 @@ def test_plotalphadeposition_draws_the_alpha_curves(mockplot: t.Any, plotalpha: 
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_deposition_curves_do_not_reuse_a_model_colour(mockplot: t.Any) -> None:
+    """The deposition curves take their colours from the axis cycle, which the model colours were removed from.
+
+    A hardcoded colour would collide with whichever model get_series_colors happened to give that colour to.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d, modelpath_classic_3d],
+        plotalphadeposition=True,
+        timemin=3,
+        timemax=8,
+        outputfile=outputpath / "lc_deposition_colours.pdf",
+    )
+
+    lines = [(str(callargs.kwargs.get("label")), callargs.kwargs.get("color")) for callargs in mockplot.call_args_list]
+    modelcolors = {mplcolors.to_hex(color) for label, color in lines if "dot" not in label}
+    depositioncolors = {mplcolors.to_hex(color) for label, color in lines if "dot" in label}
+
+    assert modelcolors
+    assert depositioncolors
+    assert not modelcolors & depositioncolors, f"{modelcolors} and {depositioncolors} share a colour"
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 def test_plotdeposition_does_not_inherit_the_light_curve_style(mockplot: t.Any) -> None:
     """The deposition curves take their style from the command line, not from the last direction bin drawn.
 
@@ -1008,6 +1032,34 @@ def test_plotdeposition_does_not_inherit_the_light_curve_style(mockplot: t.Any) 
     for kwargs in depositionkwargs:
         assert "alpha" not in kwargs
         assert "zorder" not in kwargs
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_plotdeposition_is_drawn_once_per_model(mockplot: t.Any) -> None:
+    """A model draws its deposition rates once, however many light curve series it contributes.
+
+    plot_artis_lightcurve runs once per escape type and once per top nuclide, and the deposition rates were
+    drawn on every run: the gamma-ray series repeated all three curves in new colours, labelled with the
+    gamma-ray series name even though the deposition rates have nothing to do with the escape type.
+    """
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        gamma=True,
+        rpkt=True,
+        plotdeposition=True,
+        outputfile=outputpath / "lc_deposition_gamma_and_rpkt.pdf",
+    )
+
+    depositionlabels = [
+        str(callargs.kwargs.get("label"))
+        for callargs in mockplot.call_args_list
+        if r"\dot{E}" in str(callargs.kwargs.get("label"))
+    ]
+    assert depositionlabels
+    assert len(depositionlabels) == len(set(depositionlabels)), depositionlabels
+    # the deposition rates are a model property, so they keep the model name rather than the gamma series name
+    assert not any(r"$\gamma$ $\dot{E}" in label for label in depositionlabels), depositionlabels
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -778,12 +778,12 @@ def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
 
 def test_get_plot_lum_unit_and_column() -> None:
     """The unit choice and the light curve column to plot come from one place."""
-    for magnitude, lsun, expected_unit, expected_col in [
+    for magnitude, lsun, expected_unit, expected_col in (
         (True, False, "mag", "mag"),
         (True, True, "mag", "mag"),  # magnitude wins over Lsun
         (False, True, "Lsun", "luminosity_Lsun"),
         (False, False, "erg/s", "luminosity_erg/s"),
-    ]:
+    ):
         args = argparse.Namespace(magnitude=magnitude, Lsun=lsun)
         assert at.lightcurve.plotlightcurve.get_plot_lum_unit(args) == expected_unit
         assert at.lightcurve.plotlightcurve.get_plot_lum_column(args) == expected_col

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -342,6 +342,8 @@ def test_colour_evolution_plot_single_dirbin_colour(mockplot: t.Any) -> None:
         colour_evolution=["B-V"],
         plotviewingangle=[5],
         color=["magenta"],
+        timemin=5,
+        timemax=8,
         outputfile=outputpath,
     )
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -886,8 +886,7 @@ def test_reflightcurves_arg_draws_error_bars(mockerrorbar: t.Any) -> None:
     dflightcurve, _metadata = at.lightcurve.read_bol_reflightcurve_data(REFLIGHTCURVE)
     lum_erg_per_s = dflightcurve["luminosity_erg/s"].to_numpy()
 
-    assert mockerrorbar.call_count == 1
-    arr_mag = np.array(mockerrorbar.call_args_list[0][0][2])
+    _arr_time_d, arr_mag = get_reflightcurve_errorbar_call(mockerrorbar)
     assert np.allclose(arr_mag, Mbol_sun - 2.5 * np.log10(lum_erg_per_s / Lsun_to_erg_per_s))
 
     yerr = mockerrorbar.call_args_list[0][1]["yerr"]

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -414,11 +414,8 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
                 capsize=2,
             )
 
-    # args.label has one entry per model path, each None unless the user gave a -label for it, so the list
-    # is always truthy and a whole-list fallback would never fire
-    linelabels = [
-        (args.label[ii] if ii < len(args.label) else None) or modelname for ii, modelname in enumerate(modelnames)
-    ]
+    # modelnames has one entry per (model, direction bin), so it can outrun the per-model -label list
+    linelabels = [at.get_series_label(args.label, ii, modelname) for ii, modelname in enumerate(modelnames)]
 
     # a0, datalabel = at.lightcurve.get_sn_sample_bol()
     # a0, datalabel = at.lightcurve.plot_phillips_relation_data()

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -387,19 +387,17 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
 
         plotkwargsviewingangles, plotkwargsangleaveraged = set_scatterplot_plotkwargs(ii, args)
 
+        # the error bars below use the angle-averaged x value whether or not its point is drawn
         if args.make_viewing_angle_peakmag_delta_m15_scatter_plot:
             xvalues_viewingangles = band_delta_m15_viewing_angles
+            xvalues_angleaveraged = args.band_delta_m15_angle_averaged_polyfit[ii]
         if args.make_viewing_angle_peakmag_risetime_scatter_plot:
             xvalues_viewingangles = band_risetime_viewing_angles
+            xvalues_angleaveraged = args.band_risetime_angle_averaged_polyfit[ii]
 
         a0 = ax.scatter(xvalues_viewingangles, band_peak_mag_viewing_angles, **plotkwargsviewingangles)
 
         if not args.noangleaveraged:
-            if args.make_viewing_angle_peakmag_delta_m15_scatter_plot:
-                xvalues_angleaveraged = args.band_delta_m15_angle_averaged_polyfit[ii]
-            if args.make_viewing_angle_peakmag_risetime_scatter_plot:
-                xvalues_angleaveraged = args.band_risetime_angle_averaged_polyfit[ii]
-
             p0 = ax.scatter(
                 xvalues_angleaveraged, args.band_peakmag_angle_averaged_polyfit[ii], **plotkwargsangleaveraged
             )
@@ -416,7 +414,11 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
                 capsize=2,
             )
 
-    linelabels = args.label or modelnames
+    # args.label has one entry per model path, each None unless the user gave a -label for it, so the list
+    # is always truthy and a whole-list fallback would never fire
+    linelabels = [
+        (args.label[ii] if ii < len(args.label) else None) or modelname for ii, modelname in enumerate(modelnames)
+    ]
 
     # a0, datalabel = at.lightcurve.get_sn_sample_bol()
     # a0, datalabel = at.lightcurve.plot_phillips_relation_data()

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -65,6 +65,15 @@ def parse_directionbin_args(modelpath: Path | str, args: argparse.Namespace) -> 
     return dirbins, dirbin_definition
 
 
+def wants_angle_averaged_data(args: argparse.Namespace) -> bool:
+    """Return whether the command-line arguments ask for the angle-averaged peak magnitude data."""
+    return bool(
+        args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
+        or args.make_viewing_angle_peakmag_risetime_scatter_plot
+        or args.make_viewing_angle_peakmag_delta_m15_scatter_plot
+    )
+
+
 def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: argparse.Namespace) -> None:
     """Write one model's per-direction-bin peak magnitude, rise time, and decline rate to a text file."""
     if args.save_viewing_angle_peakmag_risetime_delta_m15_to_file:
@@ -91,11 +100,7 @@ def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: a
                 comments="",
             )
 
-    elif (
-        args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
-        or args.make_viewing_angle_peakmag_risetime_scatter_plot
-        or args.make_viewing_angle_peakmag_delta_m15_scatter_plot
-    ):
+    elif wants_angle_averaged_data(args):
         args.band_risetime_angle_averaged_polyfit.append(args.band_risetime_polyfit)
         args.band_peakmag_angle_averaged_polyfit.append(args.band_peakmag_polyfit)
         args.band_delta_m15_angle_averaged_polyfit.append(args.band_deltam15_polyfit)
@@ -116,11 +121,7 @@ def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: a
 
 def write_viewing_angle_data(band_name: str, modelnames: list[str], args: argparse.Namespace) -> None:
     """Write the angle-averaged peak magnitude, rise time, and decline rate of every model to a text file."""
-    if (
-        args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
-        or args.make_viewing_angle_peakmag_risetime_scatter_plot
-        or args.make_viewing_angle_peakmag_delta_m15_scatter_plot
-    ):
+    if wants_angle_averaged_data(args):
         np.savetxt(
             f"{band_name}band_{modelnames[0]}_angle_averaged_all_models_data.txt",
             np.c_[
@@ -552,6 +553,16 @@ def peakmag_risetime_declinerate_init(
     modelpaths: list[str | Path] | list[Path] | list[str], args: argparse.Namespace
 ) -> None:
     """Fit every model's band light curves and store the peak magnitudes, rise times, and decline rates on args."""
+    if args.save_viewing_angle_peakmag_risetime_delta_m15_to_file and wants_angle_averaged_data(args):
+        # writing the per-direction-bin files takes the branch that never measures the angle-averaged
+        # values, so the two steps of the workflow cannot run at once. Say so before reading any spectra
+        msg = (
+            "The angle-averaged peak magnitudes are not measured while"
+            " --save_viewing_angle_peakmag_risetime_delta_m15_to_file writes the per-direction-bin data."
+            " Write the data in one run, then plot it in another."
+        )
+        raise ValueError(msg)
+
     args.plotvalues = []  # a0 and p0 values for viewing angle scatter plots
 
     args.band_risetime_polyfit = []
@@ -619,20 +630,6 @@ def peakmag_risetime_declinerate_init(
         # Saving viewing angle data so it can be read in and plotted later on without re-running the script
         #    as it is quite time consuming
         save_viewing_angle_data_for_plotting(plottinglist[0], modelname, args)
-
-    wantsangleaveraged = (
-        args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
-        or args.make_viewing_angle_peakmag_risetime_scatter_plot
-        or args.make_viewing_angle_peakmag_delta_m15_scatter_plot
-    )
-    if wantsangleaveraged and len(args.band_peakmag_angle_averaged_polyfit) != len(modelnames):
-        # save_viewing_angle_data_for_plotting fills these only when the run is not writing the
-        # per-direction-bin files, so the two steps of the workflow cannot be asked for at once
-        msg = (
-            "The angle-averaged peak magnitudes were not measured. Write the per-direction-bin data with"
-            " --save_viewing_angle_peakmag_risetime_delta_m15_to_file in one run, then plot it in another."
-        )
-        raise ValueError(msg)
 
     # Saving all this viewing angle info for each model to a file so that it is available to plot if required again
     # as it takes relatively long to run this for all viewing angles

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -358,11 +358,8 @@ def set_scatterplot_plot_params(fig: mplfig.Figure, axis: mplax.Axes, args: argp
     """Set the axis limits, labels, and legend shared by the viewing angle scatter plots."""
     if not args.colouratpeak:
         axis.invert_yaxis()
-    # this parser names its time range -timemin/-timemax and declares no xmin/xmax, so reading them raised
-    # AttributeError. A limit of None on both sides would only turn autoscaling off, so apply what was given
-    xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
-    if xmin is not None or xmax is not None:
-        axis.set_xlim(xmin, xmax)
+    # the x axis here is a rise time or a decline rate, not a time since explosion, so it takes no limit
+    # from the command line: this parser spells -xmin/-xmax as aliases of the -timemin/-timemax time range
     if args.ymin is not None or args.ymax is not None:
         axis.set_ylim(args.ymin, args.ymax)
     axis.minorticks_on()
@@ -420,7 +417,6 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
                 capsize=2,
             )
 
-    # modelnames has one entry per (model, direction bin), so it can outrun the per-model -label list
     linelabels = [get_series_label(args.label, ii, modelname) for ii, modelname in enumerate(modelnames)]
 
     # a0, datalabel = at.lightcurve.get_sn_sample_bol()
@@ -570,6 +566,9 @@ def peakmag_risetime_declinerate_init(
     modelnames = []  # save names of models
 
     for modelnumber, modelpath in enumerate(modelpaths):
+        modelname = at.get_model_name(modelpath)
+        # one entry per model, matching the per-model style lists and the one data file written per model
+        modelnames.append(modelname)
         lcdataframes: dict[int, pl.LazyFrame] = {}
 
         if not args.filter:
@@ -583,8 +582,6 @@ def peakmag_risetime_declinerate_init(
             dirbins = [-1]
 
         for dirbin in dirbins:
-            modelname = at.get_model_name(modelpath)
-            modelnames.append(modelname)  # save for later
             print(f"Reading spectra: {modelname}")
             if args.filter:
                 lightcurve_data_filters = at.lightcurve.generate_band_lightcurve_data(
@@ -621,6 +618,20 @@ def peakmag_risetime_declinerate_init(
         # Saving viewing angle data so it can be read in and plotted later on without re-running the script
         #    as it is quite time consuming
         save_viewing_angle_data_for_plotting(plottinglist[0], modelname, args)
+
+    wantsangleaveraged = (
+        args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
+        or args.make_viewing_angle_peakmag_risetime_scatter_plot
+        or args.make_viewing_angle_peakmag_delta_m15_scatter_plot
+    )
+    if wantsangleaveraged and len(args.band_peakmag_angle_averaged_polyfit) != len(modelnames):
+        # save_viewing_angle_data_for_plotting fills these only when the run is not writing the
+        # per-direction-bin files, so the two steps of the workflow cannot be asked for at once
+        msg = (
+            "The angle-averaged peak magnitudes were not measured. Write the per-direction-bin data with"
+            " --save_viewing_angle_peakmag_risetime_delta_m15_to_file in one run, then plot it in another."
+        )
+        raise ValueError(msg)
 
     # Saving all this viewing angle info for each model to a file so that it is available to plot if required again
     # as it takes relatively long to run this for all viewing angles

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -356,12 +356,13 @@ def update_plotkwargs_for_viewingangle_colorbar(
 
 def set_scatterplot_plot_params(fig: mplfig.Figure, axis: mplax.Axes, args: argparse.Namespace) -> None:
     """Set the axis limits, labels, and legend shared by the viewing angle scatter plots."""
-    if not args.colouratpeak:
-        axis.invert_yaxis()
     # the x axis here is a rise time or a decline rate, not a time since explosion, so it takes no limit
     # from the command line: this parser spells -xmin/-xmax as aliases of the -timemin/-timemax time range
     if args.ymin is not None or args.ymax is not None:
         axis.set_ylim(args.ymin, args.ymax)
+    if not args.colouratpeak:
+        # after the limits: set_ylim re-sorts the pair it is given, so an inversion applied first is lost
+        at.lightcurve.plotlightcurve.invert_magnitude_yaxis(axis)
     axis.minorticks_on()
     axis.tick_params(axis="both", which="minor", top=False, right=False, length=5, width=2, labelsize=12)
     axis.tick_params(axis="both", which="major", top=False, right=False, length=8, width=2, labelsize=12)

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -18,53 +18,6 @@ import artistools as at
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
 from artistools.plottools import save_figure
 
-_base_colours = [
-    "k",
-    "tab:blue",
-    "tab:red",
-    "tab:green",
-    "purple",
-    "tab:orange",
-    "tab:pink",
-    "tab:gray",
-    "gold",
-    "tab:cyan",
-    "darkblue",
-    "bisque",
-    "yellow",
-]
-
-# the first cycle inserts five extra unique colours before bisque, then the 13-colour base repeats
-define_colours_list = [
-    *_base_colours[:11],
-    "darkgreen",
-    "maroon",
-    "mediumvioletred",
-    "saddlebrown",
-    "darkslategrey",
-    *_base_colours[11:],
-    *(_base_colours * 7),
-]
-
-define_colours_list2 = [
-    "gray",
-    "lightblue",
-    "pink",
-    "yellowgreen",
-    "mediumorchid",
-    "sandybrown",
-    "plum",
-    "lightgray",
-    "wheat",
-    "paleturquoise",
-    "royalblue",
-    "springgreen",
-    "r",
-    "deeppink",
-    "sandybrown",
-    "teal",
-]
-
 
 def parse_directionbin_args(modelpath: Path | str, args: argparse.Namespace) -> tuple[Sequence[int], dict[int, str]]:
     """Return the direction bins selected by args, and a label for each of them."""
@@ -367,20 +320,16 @@ def set_scatterplot_plotkwargs(modelnumber: int, args: argparse.Namespace) -> tu
     plotkwargsviewingangles = {"marker": "x", "zorder": 0, "alpha": 0.8}
     if args.colorbarcostheta or args.colorbarphi:
         update_plotkwargs_for_viewingangle_colorbar(plotkwargsviewingangles, args)
-    elif args.color:
-        plotkwargsviewingangles["color"] = args.color[modelnumber]
     else:
-        plotkwargsviewingangles["color"] = define_colours_list2[modelnumber]
+        plotkwargsviewingangles["color"] = args.color[modelnumber]
 
     plotkwargsangleaveraged = {
         "marker": "o",
         "zorder": 10,
         "edgecolor": "k",
         "s": 120,
-        "color": args.color[modelnumber] if args.color else define_colours_list[modelnumber],
+        "color": args.color[modelnumber],
     }
-    if args.colorbarcostheta or args.colorbarphi:
-        update_plotkwargs_for_viewingangle_colorbar(plotkwargsviewingangles, args)
 
     return plotkwargsviewingangles, plotkwargsangleaveraged
 
@@ -458,14 +407,12 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
         else:
             args.plotvalues.append((a0, a0))
         if not args.noerrorbars:
-            ecolor = args.color or define_colours_list
-
             ax.errorbar(
                 xvalues_angleaveraged,
                 args.band_peakmag_angle_averaged_polyfit[ii],
                 xerr=np.std(xvalues_viewingangles),
                 yerr=np.std(band_peak_mag_viewing_angles),
-                ecolor=ecolor[ii],
+                ecolor=args.color[ii],
                 capsize=2,
             )
 

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -16,6 +16,7 @@ from matplotlib.legend_handler import HandlerTuple
 
 import artistools as at
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
+from artistools.misc import get_series_label
 from artistools.plottools import save_figure
 
 
@@ -357,8 +358,13 @@ def set_scatterplot_plot_params(fig: mplfig.Figure, axis: mplax.Axes, args: argp
     """Set the axis limits, labels, and legend shared by the viewing angle scatter plots."""
     if not args.colouratpeak:
         axis.invert_yaxis()
-    axis.set_xlim(args.xmin, args.xmax)
-    axis.set_ylim(args.ymin, args.ymax)
+    # this parser names its time range -timemin/-timemax and declares no xmin/xmax, so reading them raised
+    # AttributeError. A limit of None on both sides would only turn autoscaling off, so apply what was given
+    xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
+    if xmin is not None or xmax is not None:
+        axis.set_xlim(xmin, xmax)
+    if args.ymin is not None or args.ymax is not None:
+        axis.set_ylim(args.ymin, args.ymax)
     axis.minorticks_on()
     axis.tick_params(axis="both", which="minor", top=False, right=False, length=5, width=2, labelsize=12)
     axis.tick_params(axis="both", which="major", top=False, right=False, length=8, width=2, labelsize=12)
@@ -415,7 +421,7 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
             )
 
     # modelnames has one entry per (model, direction bin), so it can outrun the per-model -label list
-    linelabels = [at.get_series_label(args.label, ii, modelname) for ii, modelname in enumerate(modelnames)]
+    linelabels = [get_series_label(args.label, ii, modelname) for ii, modelname in enumerate(modelnames)]
 
     # a0, datalabel = at.lightcurve.get_sn_sample_bol()
     # a0, datalabel = at.lightcurve.plot_phillips_relation_data()

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -670,8 +670,8 @@ def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Names
             angle, costheta_viewing_angle_bins, phi_viewing_angle_bins, scaledmap, plotkwargs, args
         )
 
-        lumattime = lcdata.filter(pl.col("time_days") == timetoplot).select("luminosity_Lsun").collect().item(0, 0)
-        brightness = lumattime * at.constants.Lsun_to_erg_per_s
+        # readfile derives the erg/s column, so it does not have to be converted here again
+        brightness = lcdata.filter(pl.col("time_days") == timetoplot).select("luminosity_erg/s").collect().item(0, 0)
         if args.colorbarphi:
             xvalues = int(angleindex / 10)
             xlabels = costheta_viewing_angle_bins

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -909,8 +909,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.timebins_tend = list(at.get_timestep_times(args.modelpath[0], loc="end"))
 
     args.label = [
-        label if label is not None else at.get_model_name(modelpath)
-        for label, modelpath in zip(args.label, args.modelpath, strict=True)
+        at.get_series_label(args.label, index, at.get_model_name(modelpath))
+        for index, modelpath in enumerate(args.modelpath)
     ]
 
     at.plottools.set_mpl_style()

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -12,6 +12,7 @@ from artistools.misc.cliutils import add_timedays_arg as add_timedays_arg
 from artistools.misc.cliutils import add_timeminmax_args as add_timeminmax_args
 from artistools.misc.cliutils import add_timestep_arg as add_timestep_arg
 from artistools.misc.cliutils import add_viewingangle_args as add_viewingangle_args
+from artistools.misc.cliutils import color_arg as color_arg
 from artistools.misc.cliutils import flatten_list as flatten_list
 from artistools.misc.cliutils import get_filterfunc as get_filterfunc
 from artistools.misc.cliutils import get_series_label as get_series_label

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -14,6 +14,7 @@ from artistools.misc.cliutils import add_timestep_arg as add_timestep_arg
 from artistools.misc.cliutils import add_viewingangle_args as add_viewingangle_args
 from artistools.misc.cliutils import flatten_list as flatten_list
 from artistools.misc.cliutils import get_filterfunc as get_filterfunc
+from artistools.misc.cliutils import get_series_label as get_series_label
 from artistools.misc.cliutils import makelist as makelist
 from artistools.misc.cliutils import normalize_path_list as normalize_path_list
 from artistools.misc.cliutils import parse_cli_args as parse_cli_args

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -41,6 +41,7 @@ from artistools.misc.dirbins import split_multitable_dataframe as split_multitab
 from artistools.misc.fileio import drop_trailing_null_column as drop_trailing_null_column
 from artistools.misc.fileio import firstexisting as firstexisting
 from artistools.misc.fileio import firstexisting_or_none as firstexisting_or_none
+from artistools.misc.fileio import get_file_identity as get_file_identity
 from artistools.misc.fileio import get_file_metadata as get_file_metadata
 from artistools.misc.fileio import merge_pdf_files as merge_pdf_files
 from artistools.misc.fileio import path_is_artis_model as path_is_artis_model

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -350,7 +350,7 @@ def get_series_label(labels: Sequence[str | None], index: int, fallback: str) ->
     trim_or_pad pads the list with None, so an entry can be missing either as a None or, when the series
     count is not the model path count, by running off the end.
     """
-    label = labels[index] if index < len(labels) else None
+    label = labels[index] if 0 <= index < len(labels) else None
 
     return label or fallback
 

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -364,11 +364,12 @@ def get_series_label(labels: Sequence[str | None], index: int, fallback: str) ->
     """Return the -label value for one series, or fallback when the user gave none for it.
 
     trim_or_pad pads the list with None, so an entry can be missing either as a None or, when the series
-    count is not the model path count, by running off the end.
+    count is not the model path count, by running off the end. An empty label is not a missing one:
+    matplotlib gives no legend entry to a series labelled "", which is how one is left out of the legend.
     """
     label = labels[index] if 0 <= index < len(labels) else None
 
-    return label or fallback
+    return fallback if label is None else label
 
 
 def flatten_list(listin: list[t.Any]) -> list[t.Any]:

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -177,6 +177,21 @@ def add_axis_limit_args(
         parser.add_argument("-ymax", type=float, default=None, help="Plot range: y-axis maximum")
 
 
+def color_arg(value: str) -> str:
+    """Return a colour the user asked for, rejecting one matplotlib cannot parse.
+
+    The colours are compared and resolved long before anything is drawn, so a typo caught here names the
+    argument that caused it instead of surfacing from inside a plotting helper.
+    """
+    import matplotlib.colors as mplcolors
+
+    if not mplcolors.is_color_like(value):
+        msg = f"not a matplotlib color: {value}"
+        raise argparse.ArgumentTypeError(msg)
+
+    return value
+
+
 def add_series_style_args(
     parser: argparse.ArgumentParser,
     *,
@@ -191,6 +206,7 @@ def add_series_style_args(
         "-color",
         "-colors",
         dest="color",
+        type=color_arg,
         default=list(colordefault) if colordefault else [],
         nargs="*",
         help="List of line colors",

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -344,6 +344,17 @@ def trim_or_pad(requiredlength: int, *listoflistin: t.Any) -> Sequence[Sequence[
     return list_sequence
 
 
+def get_series_label(labels: Sequence[str | None], index: int, fallback: str) -> str:
+    """Return the -label value for one series, or fallback when the user gave none for it.
+
+    trim_or_pad pads the list with None, so an entry can be missing either as a None or, when the series
+    count is not the model path count, by running off the end.
+    """
+    label = labels[index] if index < len(labels) else None
+
+    return label or fallback
+
+
 def flatten_list(listin: list[t.Any]) -> list[t.Any]:
     """Flatten a list of lists."""
     listout = []

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -88,10 +88,7 @@ def average_direction_bins(
 
         print(f"bin number {start_bin:2d} = the average of bins {contribbins}")
 
-    if derivedcols:
-        return {dirbin: lzdf.with_columns(derivedcols) for dirbin, lzdf in dirbindataframesout.items()}
-
-    return dirbindataframesout
+    return {dirbin: lzdf.with_columns(derivedcols) for dirbin, lzdf in dirbindataframesout.items()}
 
 
 def get_viewingdirectionbincount() -> int:

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -28,9 +28,17 @@ def split_multitable_dataframe(res_df: pl.DataFrame | pl.LazyFrame) -> dict[int,
 
 
 def average_direction_bins(
-    dirbindataframes: dict[int, pl.DataFrame] | dict[int, pl.LazyFrame], overangle: t.Literal["phi", "theta"]
+    dirbindataframes: dict[int, pl.DataFrame] | dict[int, pl.LazyFrame],
+    overangle: t.Literal["phi", "theta"],
+    derivedcols: Sequence[pl.Expr] = (),
 ) -> dict[int, pl.LazyFrame]:
-    """Average dict of direction-binned polars DataFrames according to the phi or theta angle."""
+    """Average dict of direction-binned polars DataFrames according to the phi or theta angle.
+
+    Every column is averaged, which is only valid for a column that is linear in the bin contributions. A
+    column derived non-linearly from the others, such as a magnitude, is not the average of its bins: a
+    single dark bin sends the mean to infinity. Pass the expressions that build any such column as
+    derivedcols and they are rebuilt from the averaged values.
+    """
     dirbincount = get_viewingdirectionbincount()
     nphibins = get_viewingdirection_phibincount()
 
@@ -79,6 +87,9 @@ def average_direction_bins(
         )
 
         print(f"bin number {start_bin:2d} = the average of bins {contribbins}")
+
+    if derivedcols:
+        return {dirbin: lzdf.with_columns(derivedcols) for dirbin, lzdf in dirbindataframesout.items()}
 
     return dirbindataframesout
 

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -88,6 +88,9 @@ def average_direction_bins(
 
         print(f"bin number {start_bin:2d} = the average of bins {contribbins}")
 
+    if not derivedcols:
+        return dirbindataframesout
+
     return {dirbin: lzdf.with_columns(derivedcols) for dirbin, lzdf in dirbindataframesout.items()}
 
 

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -28,16 +28,13 @@ def split_multitable_dataframe(res_df: pl.DataFrame | pl.LazyFrame) -> dict[int,
 
 
 def average_direction_bins(
-    dirbindataframes: dict[int, pl.DataFrame] | dict[int, pl.LazyFrame],
-    overangle: t.Literal["phi", "theta"],
-    derivedcols: Sequence[pl.Expr] = (),
+    dirbindataframes: dict[int, pl.DataFrame] | dict[int, pl.LazyFrame], overangle: t.Literal["phi", "theta"]
 ) -> dict[int, pl.LazyFrame]:
     """Average dict of direction-binned polars DataFrames according to the phi or theta angle.
 
     Every column is averaged, which is only valid for a column that is linear in the bin contributions. A
     column derived non-linearly from the others, such as a magnitude, is not the average of its bins: a
-    single dark bin sends the mean to infinity. Pass the expressions that build any such column as
-    derivedcols and they are rebuilt from the averaged values.
+    single dark bin sends the mean to infinity. Derive such a column after averaging, not before.
     """
     dirbincount = get_viewingdirectionbincount()
     nphibins = get_viewingdirection_phibincount()
@@ -88,10 +85,7 @@ def average_direction_bins(
 
         print(f"bin number {start_bin:2d} = the average of bins {contribbins}")
 
-    if not derivedcols:
-        return dirbindataframesout
-
-    return {dirbin: lzdf.with_columns(derivedcols) for dirbin, lzdf in dirbindataframesout.items()}
+    return dirbindataframesout
 
 
 def get_viewingdirectionbincount() -> int:

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -437,9 +437,16 @@ def write_parquet_atomic(
     import os
     import tempfile
 
+    # one snapshot of the destination serves the mode and the identity below: the function's whole premise
+    # is that the path can change while it works, so two stats could describe two different files
+    try:
+        deststat: os.stat_result | None = parquetfilepath.stat()
+    except FileNotFoundError:
+        deststat = None
+
     # the file this call was asked to replace, if any. A different one at the end of the write belongs to
     # another process, which read the same inputs and thus wrote the same data
-    outdatedfile = get_file_identity(parquetfilepath)
+    outdatedfile = (deststat.st_dev, deststat.st_ino) if deststat else None
 
     fd, partialfilename = tempfile.mkstemp(
         dir=parquetfilepath.parent, prefix=f".{parquetfilepath.name}.partial", suffix=".partial"
@@ -450,9 +457,7 @@ def write_parquet_atomic(
     # cache written into a group-shared model directory would be unreadable to everyone but its author.
     # Reuse the mode the destination already has, or else the read/write bits of the directory holding it —
     # reading the process umask would need a get-and-restore that is not safe against other threads.
-    destmode = (
-        parquetfilepath.stat().st_mode if parquetfilepath.is_file() else parquetfilepath.parent.stat().st_mode & 0o666
-    )
+    destmode = deststat.st_mode if deststat else parquetfilepath.parent.stat().st_mode & 0o666
     partialfilepath.chmod(destmode & 0o777)
     try:
         pldf.lazy().sink_parquet(

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -422,26 +422,24 @@ def get_file_identity(file: Path | os.stat_result) -> tuple[int, int] | None:
 
 
 def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple[int, int] | None) -> None:
-    """Replace destpath with newfilepath, but only if it still holds the file the caller found out of date.
+    """Install newfilepath at destpath, unless a file other than the given out-of-date one is there.
 
-    The identity check and the rename happen under an exclusive lock file. Without it, two writers that
-    both found the same out-of-date file could both pass the check, and the second rename would replace the
-    first writer's fresh file while a reader scans it. A writer that finds the lock taken waits: the holder
-    is installing an equally valid replacement built from the same inputs, and returning at once would let
-    this writer's caller read the out-of-date file in the moment before the holder's rename lands.
+    An empty destination takes the new file, the file whose identity is outdatedfile is replaced, and any
+    other file is kept: it is a rival's fresh replacement, built from the same inputs. The identity check
+    and the rename happen under an exclusive lock file. Without it, two writers that both found the same
+    out-of-date file could both pass the check, and the second rename would replace the first writer's
+    fresh file while a reader scans it. A writer that finds the lock taken waits: returning at once would
+    let this writer's caller read the out-of-date file in the moment before the holder's rename lands.
     """
     import time
-
-    if outdatedfile is None:
-        # this write does not replace anything, so a file that appeared at the destination is kept
-        return
 
     # the dot prefix keeps the lock out of the globs that find the parquet files, like the .partial file
     lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
 
     while True:
-        if get_file_identity(destpath) != outdatedfile:
-            # another writer has replaced the out-of-date file with the same fresh data
+        identity = get_file_identity(destpath)
+        if identity is not None and identity != outdatedfile:
+            # another writer has put the same fresh data in place
             return
 
         try:
@@ -456,7 +454,8 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
             continue
 
         try:
-            if get_file_identity(destpath) == outdatedfile:
+            identity = get_file_identity(destpath)
+            if identity is None or identity == outdatedfile:
                 newfilepath.replace(destpath)
         finally:
             os.close(lockfd)
@@ -516,8 +515,8 @@ def write_parquet_atomic(
         except FileExistsError:
             replace_outdated_file(partialfilepath, parquetfilepath, replaces)
         except OSError:
-            # a file system without hard links cannot make the destination in one step, thus accept the
-            # rename and the scans that it can break
-            partialfilepath.replace(parquetfilepath)
+            # a file system without hard links cannot make the destination appear in one step, but the
+            # locked identity rule still applies: install, replace the out-of-date file, or keep a rival's
+            replace_outdated_file(partialfilepath, parquetfilepath, replaces)
     finally:
         partialfilepath.unlink(missing_ok=True)

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -402,15 +402,33 @@ def write_gif(giffile: Path | str, imagefiles: Sequence[Path | str], duration: f
     print(f"Created gif: {giffile}")
 
 
+def get_file_identity(filepath: Path) -> tuple[int, int] | None:
+    """Return the device and inode numbers of a file, or None if it does not exist.
+
+    Two stats of one path give the same pair only if it is still the same file. A rename onto the path
+    gives a different pair, which no comparison of names or modification times can detect reliably.
+    """
+    try:
+        filestat = filepath.stat()
+    except FileNotFoundError:
+        return None
+
+    return (filestat.st_dev, filestat.st_ino)
+
+
 def write_parquet_atomic(
     pldf: pl.DataFrame | pl.LazyFrame,
     parquetfilepath: Path,
     metadata: dict[str, str] | None = None,
     compression_level: int = 10,
 ) -> None:
-    """Write a zstd-compressed parquet file via a temporary file and an atomic replace, so a partial write is never mistaken for a complete file.
+    """Write a zstd-compressed parquet file through a temporary file, so a partial write is never mistaken for a complete file.
 
-    If a concurrent process wrote the destination first, it is atomically overwritten by this equally-valid replacement.
+    A parquet file that another process wrote while this one worked is kept, and this copy of the same data
+    is discarded. polars opens a parquet file again by its path between reading the metadata and reading the
+    row groups, so a rename onto a path that already holds a complete file corrupts every scan in progress:
+    the second file gets read with the offsets of the first. A file the caller asked to replace, because the
+    data it holds is out of date, is still replaced.
 
     The temporary name is prefixed with a dot so that it does not start with the destination's name. A glob
     keyed on that name (get_runfolder_timesteps() looks for "estimbatch*.out.parquet*") would otherwise match
@@ -419,15 +437,19 @@ def write_parquet_atomic(
     import os
     import tempfile
 
+    # the file this call was asked to replace, if any. A different one at the end of the write belongs to
+    # another process, which read the same inputs and thus wrote the same data
+    outdatedfile = get_file_identity(parquetfilepath)
+
     fd, partialfilename = tempfile.mkstemp(
         dir=parquetfilepath.parent, prefix=f".{parquetfilepath.name}.partial", suffix=".partial"
     )
     os.close(fd)
     partialfilepath = Path(partialfilename)
-    # mkstemp creates the file 0600, and replace() carries that mode onto the destination, so a cache written
-    # into a group-shared model directory would be unreadable to everyone but its author. Reuse the mode the
-    # destination already has, or else the read/write bits of the directory holding it — reading the process
-    # umask would need a get-and-restore that is not safe against other threads.
+    # mkstemp creates the file 0600, and the destination takes the mode of the file that lands on it, so a
+    # cache written into a group-shared model directory would be unreadable to everyone but its author.
+    # Reuse the mode the destination already has, or else the read/write bits of the directory holding it —
+    # reading the process umask would need a get-and-restore that is not safe against other threads.
     destmode = (
         parquetfilepath.stat().st_mode if parquetfilepath.is_file() else parquetfilepath.parent.stat().st_mode & 0o666
     )
@@ -436,6 +458,16 @@ def write_parquet_atomic(
         pldf.lazy().sink_parquet(
             partialfilepath, compression="zstd", compression_level=compression_level, metadata=metadata
         )
-        partialfilepath.replace(parquetfilepath)
+        try:
+            # gives the file a second name, and fails if that name is taken, thus the destination appears
+            # complete in one step and no reader of it ever sees a different file at the same path
+            os.link(partialfilepath, parquetfilepath)
+        except FileExistsError:
+            if get_file_identity(parquetfilepath) == outdatedfile:
+                partialfilepath.replace(parquetfilepath)
+        except OSError:
+            # a file system without hard links cannot make the destination in one step, thus accept the
+            # rename and the scans that it can break
+            partialfilepath.replace(parquetfilepath)
     finally:
         partialfilepath.unlink(missing_ok=True)

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import io
+import os
 import shlex
 import sys
 import typing as t
@@ -402,14 +403,18 @@ def write_gif(giffile: Path | str, imagefiles: Sequence[Path | str], duration: f
     print(f"Created gif: {giffile}")
 
 
-def get_file_identity(filepath: Path) -> tuple[int, int] | None:
+def get_file_identity(file: Path | os.stat_result) -> tuple[int, int] | None:
     """Return the device and inode numbers of a file, or None if it does not exist.
 
     Two stats of one path give the same pair only if it is still the same file. A rename onto the path
-    gives a different pair, which no comparison of names or modification times can detect reliably.
+    gives a different pair, which no comparison of names or modification times can detect reliably. A
+    caller that already holds a stat result passes it, so the identity describes that same snapshot.
     """
+    if isinstance(file, os.stat_result):
+        return (file.st_dev, file.st_ino)
+
     try:
-        filestat = filepath.stat()
+        filestat = file.stat()
     except FileNotFoundError:
         return None
 
@@ -425,8 +430,11 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
     is installing an equally valid replacement built from the same inputs, and returning at once would let
     this writer's caller read the out-of-date file in the moment before the holder's rename lands.
     """
-    import os
     import time
+
+    if outdatedfile is None:
+        # this write does not replace anything, so a file that appeared at the destination is kept
+        return
 
     # the dot prefix keeps the lock out of the globs that find the parquet files, like the .partial file
     lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
@@ -461,32 +469,30 @@ def write_parquet_atomic(
     parquetfilepath: Path,
     metadata: dict[str, str] | None = None,
     compression_level: int = 10,
+    replaces: tuple[int, int] | None = None,
 ) -> None:
     """Write a zstd-compressed parquet file through a temporary file, so a partial write is never mistaken for a complete file.
 
     A parquet file that another process wrote while this one worked is kept, and this copy of the same data
     is discarded. polars opens a parquet file again by its path between reading the metadata and reading the
     row groups, so a rename onto a path that already holds a complete file corrupts every scan in progress:
-    the second file gets read with the offsets of the first. A file the caller asked to replace, because the
-    data it holds is out of date, is still replaced.
+    the second file gets read with the offsets of the first.
+
+    replaces is the get_file_identity() of the file this write replaces, taken from the same stat snapshot
+    that showed the caller its data was out of date. Only that exact file is replaced. The moment the write
+    started is too late to take it: a rival that finished its own replacement first would be snapshotted as
+    the file to replace, and its fresh file would be renamed over while a reader scans it.
 
     The temporary name is prefixed with a dot so that it does not start with the destination's name. A glob
     keyed on that name (get_runfolder_timesteps() looks for "estimbatch*.out.parquet*") would otherwise match
     the in-flight temporary and read a file that is empty, half-written, or already renamed away.
     """
-    import os
     import tempfile
 
-    # one snapshot of the destination serves the mode and the identity below: the function's whole premise
-    # is that the path can change while it works, so two stats could describe two different files
     try:
         deststat: os.stat_result | None = parquetfilepath.stat()
     except FileNotFoundError:
         deststat = None
-
-    # the file this call was asked to replace, if any. A different one at the end of the write belongs to
-    # another process, which read the same inputs and thus wrote the same data
-    outdatedfile = (deststat.st_dev, deststat.st_ino) if deststat else None
 
     fd, partialfilename = tempfile.mkstemp(
         dir=parquetfilepath.parent, prefix=f".{parquetfilepath.name}.partial", suffix=".partial"
@@ -508,7 +514,7 @@ def write_parquet_atomic(
             # complete in one step and no reader of it ever sees a different file at the same path
             os.link(partialfilepath, parquetfilepath)
         except FileExistsError:
-            replace_outdated_file(partialfilepath, parquetfilepath, outdatedfile)
+            replace_outdated_file(partialfilepath, parquetfilepath, replaces)
         except OSError:
             # a file system without hard links cannot make the destination in one step, thus accept the
             # rename and the scans that it can break

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -416,6 +416,40 @@ def get_file_identity(filepath: Path) -> tuple[int, int] | None:
     return (filestat.st_dev, filestat.st_ino)
 
 
+def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple[int, int] | None) -> None:
+    """Replace destpath with newfilepath, but only if it still holds the file the caller found out of date.
+
+    The identity check and the rename happen under an exclusive lock file. Without it, two writers that
+    both found the same out-of-date file could both pass the check, and the second rename would replace the
+    first writer's fresh file while a reader scans it. A writer that finds the lock taken leaves the
+    destination alone: the holder is installing an equally valid replacement built from the same inputs.
+    """
+    import os
+    import time
+
+    if get_file_identity(destpath) != outdatedfile:
+        return
+
+    # the dot prefix keeps the lock out of the globs that find the parquet files, like the .partial file
+    lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
+    try:
+        lockfd = os.open(lockpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        # the lock is held for the duration of one rename, so an old lock belongs to a process that died
+        # while it held it: remove it, and a later call replaces the out-of-date file
+        with contextlib.suppress(FileNotFoundError):
+            if time.time() - lockpath.stat().st_mtime > 60.0:
+                lockpath.unlink(missing_ok=True)
+        return
+
+    try:
+        if get_file_identity(destpath) == outdatedfile:
+            newfilepath.replace(destpath)
+    finally:
+        os.close(lockfd)
+        lockpath.unlink(missing_ok=True)
+
+
 def write_parquet_atomic(
     pldf: pl.DataFrame | pl.LazyFrame,
     parquetfilepath: Path,
@@ -468,8 +502,7 @@ def write_parquet_atomic(
             # complete in one step and no reader of it ever sees a different file at the same path
             os.link(partialfilepath, parquetfilepath)
         except FileExistsError:
-            if get_file_identity(parquetfilepath) == outdatedfile:
-                partialfilepath.replace(parquetfilepath)
+            replace_outdated_file(partialfilepath, parquetfilepath, outdatedfile)
         except OSError:
             # a file system without hard links cannot make the destination in one step, thus accept the
             # rename and the scans that it can break

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -426,41 +426,34 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
 
     An empty destination takes the new file, the file whose identity is outdatedfile is replaced, and any
     other file is kept: it is a rival's fresh replacement, built from the same inputs. The identity check
-    and the rename happen under an exclusive lock file. Without it, two writers that both found the same
+    and the rename happen under an exclusive flock. Without it, two writers that both found the same
     out-of-date file could both pass the check, and the second rename would replace the first writer's
-    fresh file while a reader scans it. A writer that finds the lock taken waits: returning at once would
-    let this writer's caller read the out-of-date file in the moment before the holder's rename lands.
+    fresh file while a reader scans it. A writer that finds the lock taken waits for the holder, and the
+    operating system releases the lock of a holder that dies, so the lock needs no age heuristic that
+    could steal it from a paused but live writer.
+
+    The lock file stays in place once created. Removing it while a rival waits on it would hand out a
+    second lock on a new inode, and two writers would hold the lock at once. The dot prefix keeps it out
+    of the globs that find the parquet files, like the .partial file.
     """
-    import time
-
-    # the dot prefix keeps the lock out of the globs that find the parquet files, like the .partial file
-    lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
-
-    while True:
-        identity = get_file_identity(destpath)
-        if identity is not None and identity != outdatedfile:
-            # another writer has put the same fresh data in place
-            return
-
-        try:
-            lockfd = os.open(lockpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-        except FileExistsError:
-            # the lock is held for the duration of one rename, so an old lock belongs to a process that
-            # died while it held it: remove it, and take over the replacement on the next pass
-            with contextlib.suppress(FileNotFoundError):
-                if time.time() - lockpath.stat().st_mtime > 10.0:
-                    lockpath.unlink(missing_ok=True)
-            time.sleep(0.010)
-            continue
-
-        try:
-            identity = get_file_identity(destpath)
-            if identity is None or identity == outdatedfile:
-                newfilepath.replace(destpath)
-        finally:
-            os.close(lockfd)
-            lockpath.unlink(missing_ok=True)
+    try:
+        import fcntl
+    except ImportError:
+        # a platform without flock gets the unlocked check. Two simultaneous replacements of one
+        # out-of-date file can then race, which the identity check narrows but cannot close
+        if get_file_identity(destpath) in {None, outdatedfile}:
+            newfilepath.replace(destpath)
         return
+
+    lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
+    lockfd = os.open(lockpath, os.O_CREAT | os.O_WRONLY, 0o666)
+    try:
+        fcntl.flock(lockfd, fcntl.LOCK_EX)
+        identity = get_file_identity(destpath)
+        if identity is None or identity == outdatedfile:
+            newfilepath.replace(destpath)
+    finally:
+        os.close(lockfd)
 
 
 def write_parquet_atomic(

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -421,33 +421,39 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
 
     The identity check and the rename happen under an exclusive lock file. Without it, two writers that
     both found the same out-of-date file could both pass the check, and the second rename would replace the
-    first writer's fresh file while a reader scans it. A writer that finds the lock taken leaves the
-    destination alone: the holder is installing an equally valid replacement built from the same inputs.
+    first writer's fresh file while a reader scans it. A writer that finds the lock taken waits: the holder
+    is installing an equally valid replacement built from the same inputs, and returning at once would let
+    this writer's caller read the out-of-date file in the moment before the holder's rename lands.
     """
     import os
     import time
 
-    if get_file_identity(destpath) != outdatedfile:
-        return
-
     # the dot prefix keeps the lock out of the globs that find the parquet files, like the .partial file
     lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
-    try:
-        lockfd = os.open(lockpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-    except FileExistsError:
-        # the lock is held for the duration of one rename, so an old lock belongs to a process that died
-        # while it held it: remove it, and a later call replaces the out-of-date file
-        with contextlib.suppress(FileNotFoundError):
-            if time.time() - lockpath.stat().st_mtime > 60.0:
-                lockpath.unlink(missing_ok=True)
-        return
 
-    try:
-        if get_file_identity(destpath) == outdatedfile:
-            newfilepath.replace(destpath)
-    finally:
-        os.close(lockfd)
-        lockpath.unlink(missing_ok=True)
+    while True:
+        if get_file_identity(destpath) != outdatedfile:
+            # another writer has replaced the out-of-date file with the same fresh data
+            return
+
+        try:
+            lockfd = os.open(lockpath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            # the lock is held for the duration of one rename, so an old lock belongs to a process that
+            # died while it held it: remove it, and take over the replacement on the next pass
+            with contextlib.suppress(FileNotFoundError):
+                if time.time() - lockpath.stat().st_mtime > 10.0:
+                    lockpath.unlink(missing_ok=True)
+            time.sleep(0.010)
+            continue
+
+        try:
+            if get_file_identity(destpath) == outdatedfile:
+                newfilepath.replace(destpath)
+        finally:
+            os.close(lockfd)
+            lockpath.unlink(missing_ok=True)
+        return
 
 
 def write_parquet_atomic(

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -446,7 +446,12 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
         return
 
     lockpath = destpath.with_name(f".{destpath.name}.replace-lock")
-    lockfd = os.open(lockpath, os.O_CREAT | os.O_WRONLY, 0o666)
+    # flock locks a read-only descriptor, so a different user regenerating a cache in a shared model
+    # directory needs only read access to the lock file. The chmod grants that under a restrictive umask,
+    # and fails harmlessly for a user who does not own the lock
+    lockfd = os.open(lockpath, os.O_CREAT | os.O_RDONLY, 0o666)
+    with contextlib.suppress(OSError):
+        lockpath.chmod(0o666)
     try:
         fcntl.flock(lockfd, fcntl.LOCK_EX)
         identity = get_file_identity(destpath)

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -823,3 +823,15 @@ def test_drop_trailing_null_column() -> None:
     assert at.drop_trailing_null_column(
         pl.LazyFrame({"a": [], "b": []}, schema=emptyschema)
     ).collect_schema().names() == ["a", "b"]
+
+
+def test_get_series_label() -> None:
+    """A series is named by its -label entry, or by the fallback when the user gave none for it."""
+    assert at.get_series_label(["A", "B"], 1, "modelname") == "B"
+    assert at.get_series_label([None, "B"], 0, "modelname") == "modelname"
+
+    # trim_or_pad sizes the list to the model paths, so a per-series index can run off the end
+    assert at.get_series_label(["A"], 3, "modelname") == "modelname"
+
+    # a sentinel index such as the -1 this codebase uses for a direction bin must not wrap to the last label
+    assert at.get_series_label(["A", "B"], -1, "modelname") == "modelname"

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -731,8 +731,12 @@ def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatc
         assert averaged_phi[start_bin].collect()["value"].to_list() == pytest.approx([expected, expected])
 
 
-def test_average_direction_bins_rebuilds_derived_cols(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A column derived non-linearly is rebuilt from the averaged values, not averaged itself."""
+def test_average_direction_bins_averages_every_column(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every column is averaged, so a column that is not linear in the bins must be derived afterwards.
+
+    This is why readfile() derives the magnitude only once the bins are averaged: the mean of the
+    magnitudes of the bins is not the magnitude of their mean luminosity.
+    """
     nphibins = 4
     ncosthetabins = 3
 
@@ -746,17 +750,18 @@ def test_average_direction_bins_rebuilds_derived_cols(monkeypatch: pytest.Monkey
         for dirbin in range(nphibins * ncosthetabins)
     }
 
-    averaged = dirbins.average_direction_bins(dirbindataframes, overangle="phi", derivedcols=[logcol])
+    averaged = dirbins.average_direction_bins(dirbindataframes, overangle="phi")
 
     meanvalue = sum(range(nphibins)) / nphibins
     for start_bin in (0, 4, 8):
         row = averaged[start_bin].collect()
         assert row["value"].item() == pytest.approx(meanvalue)
-        assert row["logvalue"].item() == pytest.approx(math.log10(meanvalue))
-
-    # without the expressions the magnitude-like column is averaged, which the dark bin sends to -inf
-    averaged_nodeclare = dirbins.average_direction_bins(dirbindataframes, overangle="phi")
-    assert averaged_nodeclare[0].collect()["logvalue"].item() == -math.inf
+        # the column carried through the averaging holds the mean of the logs, which the dark bin sends to -inf
+        assert row["logvalue"].item() == -math.inf
+        # deriving it from the averaged value instead gives the finite answer that a caller wants
+        assert averaged[start_bin].with_columns(logcol).collect()["logvalue"].item() == pytest.approx(
+            math.log10(meanvalue)
+        )
 
 
 def test_average_direction_bins_rejects_missing_bins(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -835,3 +835,7 @@ def test_get_series_label() -> None:
 
     # a sentinel index such as the -1 this codebase uses for a direction bin must not wrap to the last label
     assert at.get_series_label(["A", "B"], -1, "modelname") == "modelname"
+
+    # an empty label is a series deliberately left out of the legend, not a missing one
+    # the return type is str, so falsy is the empty string rather than the model name
+    assert not at.get_series_label([""], 0, "modelname")

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -436,7 +436,7 @@ def test_write_parquet_atomic_is_readable_in_a_shared_directory(tmp_path: Path) 
     assert privatepath.stat().st_mode & 0o777 == 0o600
 
     privatepath.chmod(0o640)
-    at.write_parquet_atomic(pl.DataFrame({"a": [2]}), privatepath)
+    at.write_parquet_atomic(pl.DataFrame({"a": [2]}), privatepath, replaces=at.get_file_identity(privatepath))
     assert privatepath.stat().st_mode & 0o777 == 0o640
     assert pl.read_parquet(privatepath)["a"].item() == 2
 
@@ -467,13 +467,38 @@ def test_write_parquet_atomic_keeps_a_concurrently_written_file(tmp_path: Path) 
 
 
 def test_write_parquet_atomic_replaces_an_outdated_file(tmp_path: Path) -> None:
-    """A file the caller asked to replace still gets replaced, since its data is out of date."""
+    """The file whose identity the caller passes as replaces gets replaced, since its data is out of date."""
     parquetpath = tmp_path / "batch.out.parquet.tmp"
     pl.DataFrame({"a": [1, 2, 3]}).write_parquet(parquetpath)
 
-    at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath)
+    at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath, replaces=at.get_file_identity(parquetpath))
 
     assert pl.read_parquet(parquetpath)["a"].to_list() == [4, 5, 6]
+    assert list(tmp_path.glob("*.partial*")) == []
+
+    # without replaces, an existing file is kept: this write does not claim to supersede anything
+    at.write_parquet_atomic(pl.DataFrame({"a": [7, 8, 9]}), parquetpath)
+    assert pl.read_parquet(parquetpath)["a"].to_list() == [4, 5, 6]
+
+
+def test_write_parquet_atomic_replaces_only_the_file_found_outdated(tmp_path: Path) -> None:
+    """A rival that already replaced the out-of-date file is kept, whenever this writer started.
+
+    The identity comes from the stat that showed the caller its cache was out of date. Taking it at the
+    start of the write instead would snapshot the rival's fresh file as the one to replace, and rename over
+    it while a reader scans it.
+    """
+    parquetpath = tmp_path / "batch.out.parquet.tmp"
+    pl.DataFrame({"a": [1, 2, 3]}).write_parquet(parquetpath)
+    outdated = at.get_file_identity(parquetpath)
+
+    # the rival reads the same inputs and finishes its replacement first
+    pl.DataFrame({"a": [4, 5, 6]}).write_parquet(tmp_path / "rival")
+    (tmp_path / "rival").replace(parquetpath)
+
+    at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath, replaces=outdated)
+
+    assert at.get_file_identity(parquetpath) != outdated, "the rival's file must still be in place"
     assert list(tmp_path.glob("*.partial*")) == []
 
 

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -525,54 +525,28 @@ def test_replace_outdated_file_keeps_a_rivals_fresh_replacement(tmp_path: Path) 
     assert destpath.read_text(encoding="utf-8") == "first replacement"
 
 
-def test_replace_outdated_file_rechecks_under_the_lock(tmp_path: Path) -> None:
-    """The identity is checked again under the lock, where a rival's rename can no longer interleave.
-
-    The first check alone is the race: both writers can pass it before either renames. Here it is forced to
-    pass, as it does for a writer that checked just before the rival's rename landed.
-    """
-    destpath = tmp_path / "cache"
-    destpath.write_text("outdated", encoding="utf-8")
-    outdated = at.misc.get_file_identity(destpath)
-
-    first = tmp_path / "first"
-    first.write_text("first replacement", encoding="utf-8")
-    fileio.replace_outdated_file(first, destpath, outdated)
-
-    second = tmp_path / "second"
-    second.write_text("second replacement", encoding="utf-8")
-    real_get_file_identity = fileio.get_file_identity
-    with mock.patch.object(fileio, "get_file_identity", side_effect=[outdated, real_get_file_identity(destpath)]):
-        fileio.replace_outdated_file(second, destpath, outdated)
-
-    assert destpath.read_text(encoding="utf-8") == "first replacement"
-
-
 def test_replace_outdated_file_waits_for_the_lock_holder(tmp_path: Path) -> None:
     """A writer that finds the replacement lock taken waits, so its caller reads the holder's fresh file.
 
     Returning at once would let the caller open the out-of-date file in the moment before the holder's
-    rename lands.
+    rename lands. The wait is the blocking flock call, so the holder's rename is simulated inside it.
     """
     destpath = tmp_path / "cache"
     destpath.write_text("outdated", encoding="utf-8")
     outdated = at.misc.get_file_identity(destpath)
-    lockpath = tmp_path / ".cache.replace-lock"
-    lockpath.touch()
 
     holders_file = tmp_path / "holders_replacement"
     holders_file.write_text("holders replacement", encoding="utf-8")
 
-    def holder_finishes(_seconds: float) -> None:
+    def holder_finishes_first(_fd: int, _operation: int) -> None:
         holders_file.replace(destpath)
-        lockpath.unlink()
 
     replacement = tmp_path / "replacement"
     replacement.write_text("replacement", encoding="utf-8")
-    with mock.patch("time.sleep", side_effect=holder_finishes) as mocksleep:
+    with mock.patch("fcntl.flock", side_effect=holder_finishes_first) as mockflock:
         fileio.replace_outdated_file(replacement, destpath, outdated)
 
-    assert mocksleep.call_count == 1, "the writer must wait while the lock is held"
+    assert mockflock.call_count == 1
     assert destpath.read_text(encoding="utf-8") == "holders replacement"
 
 
@@ -618,21 +592,25 @@ def test_write_parquet_atomic_applies_the_identity_rule_without_hard_links(tmp_p
     assert pl.read_parquet(parquetpath)["a"].to_list() == [7, 8, 9]
 
 
-def test_replace_outdated_file_takes_over_from_a_dead_lock_holder(tmp_path: Path) -> None:
-    """A lock older than the moment its holder could hold it belongs to a dead process and is removed."""
+def test_replace_outdated_file_ignores_a_leftover_lock_file(tmp_path: Path) -> None:
+    """A lock file that no process holds does not block: the flock, not the file, is the lock.
+
+    The operating system releases the flock of a holder that dies, so a leftover file from an earlier
+    replacement carries no lock. The file stays in place: removing it while a rival waits on it would
+    hand out a second lock on a new inode.
+    """
     destpath = tmp_path / "cache"
     destpath.write_text("outdated", encoding="utf-8")
     outdated = at.misc.get_file_identity(destpath)
     lockpath = tmp_path / ".cache.replace-lock"
     lockpath.touch()
-    os.utime(lockpath, (0.0, 0.0))
 
     replacement = tmp_path / "replacement"
     replacement.write_text("replacement", encoding="utf-8")
     fileio.replace_outdated_file(replacement, destpath, outdated)
 
     assert destpath.read_text(encoding="utf-8") == "replacement"
-    assert not lockpath.exists()
+    assert lockpath.exists()
 
 
 def test_get_file_identity(tmp_path: Path) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -440,6 +440,61 @@ def test_write_parquet_atomic_is_readable_in_a_shared_directory(tmp_path: Path) 
     assert pl.read_parquet(privatepath)["a"].item() == 2
 
 
+def test_write_parquet_atomic_keeps_a_concurrently_written_file(tmp_path: Path) -> None:
+    """A cache another process finished first is kept, because a reader may already be streaming it.
+
+    polars opens a parquet file again by its path between reading the metadata and reading the row groups,
+    so renaming a second copy of the same data onto the path makes every scan in progress read the new file
+    with the offsets of the old one.
+    """
+    parquetpath = tmp_path / "batch.out.parquet.tmp"
+    theirs = pl.DataFrame({"a": [1, 2, 3]})
+    real_sink_parquet = pl.LazyFrame.sink_parquet
+
+    def sink_parquet_after_another_process_finished(self: pl.LazyFrame, path: t.Any, **kwargs: t.Any) -> t.Any:
+        result = real_sink_parquet(self, path, **kwargs)
+        # the other process finishes while this one writes, so the destination appears from nowhere.
+        # DataFrame.write_parquet() would re-enter the patched method
+        real_sink_parquet(theirs.lazy(), parquetpath)
+        return result
+
+    with mock.patch.object(pl.LazyFrame, "sink_parquet", sink_parquet_after_another_process_finished):
+        at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath)
+
+    assert pl.read_parquet(parquetpath)["a"].to_list() == [1, 2, 3], "the file a reader may hold was replaced"
+    assert list(tmp_path.glob("*.partial*")) == []
+
+
+def test_write_parquet_atomic_replaces_an_outdated_file(tmp_path: Path) -> None:
+    """A file the caller asked to replace still gets replaced, since its data is out of date."""
+    parquetpath = tmp_path / "batch.out.parquet.tmp"
+    pl.DataFrame({"a": [1, 2, 3]}).write_parquet(parquetpath)
+
+    at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath)
+
+    assert pl.read_parquet(parquetpath)["a"].to_list() == [4, 5, 6]
+    assert list(tmp_path.glob("*.partial*")) == []
+
+
+def test_get_file_identity(tmp_path: Path) -> None:
+    """A file is the same file only while its device and inode are unchanged."""
+    filepath = tmp_path / "cache"
+    assert at.misc.get_file_identity(filepath) is None
+
+    filepath.write_text("first", encoding="utf-8")
+    identity = at.misc.get_file_identity(filepath)
+    assert at.misc.get_file_identity(filepath) == identity
+
+    # rewriting in place keeps the file, but a rename onto the path makes it a different one
+    filepath.write_text("second", encoding="utf-8")
+    assert at.misc.get_file_identity(filepath) == identity
+
+    replacement = tmp_path / "replacement"
+    replacement.write_text("third", encoding="utf-8")
+    replacement.replace(filepath)
+    assert at.misc.get_file_identity(filepath) != identity
+
+
 # --- general.py --------------------------------------------------------------------------------
 
 

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -24,6 +24,7 @@ import yaml
 
 import artistools as at
 from artistools.misc import dirbins
+from artistools.misc import fileio
 
 
 def _write_timesteps_out(modeldir: Path) -> None:
@@ -474,6 +475,75 @@ def test_write_parquet_atomic_replaces_an_outdated_file(tmp_path: Path) -> None:
 
     assert pl.read_parquet(parquetpath)["a"].to_list() == [4, 5, 6]
     assert list(tmp_path.glob("*.partial*")) == []
+
+
+def test_replace_outdated_file_keeps_a_rivals_fresh_replacement(tmp_path: Path) -> None:
+    """The second of two writers that found the same out-of-date file must not replace the first's file.
+
+    Both writers pass the identity check taken before their own write, so only the re-check under the lock
+    separates "still the out-of-date file" from "already the other writer's fresh replacement".
+    """
+    destpath = tmp_path / "cache"
+    destpath.write_text("outdated", encoding="utf-8")
+    outdated = at.misc.get_file_identity(destpath)
+
+    # the first writer replaces the out-of-date file, changing its identity
+    first = tmp_path / "first"
+    first.write_text("first replacement", encoding="utf-8")
+    fileio.replace_outdated_file(first, destpath, outdated)
+    assert destpath.read_text(encoding="utf-8") == "first replacement"
+
+    # the second writer still holds the identity of the file both of them found out of date
+    second = tmp_path / "second"
+    second.write_text("second replacement", encoding="utf-8")
+    fileio.replace_outdated_file(second, destpath, outdated)
+    assert destpath.read_text(encoding="utf-8") == "first replacement"
+
+
+def test_replace_outdated_file_rechecks_under_the_lock(tmp_path: Path) -> None:
+    """The identity is checked again under the lock, where a rival's rename can no longer interleave.
+
+    The first check alone is the race: both writers can pass it before either renames. Here it is forced to
+    pass, as it does for a writer that checked just before the rival's rename landed.
+    """
+    destpath = tmp_path / "cache"
+    destpath.write_text("outdated", encoding="utf-8")
+    outdated = at.misc.get_file_identity(destpath)
+
+    first = tmp_path / "first"
+    first.write_text("first replacement", encoding="utf-8")
+    fileio.replace_outdated_file(first, destpath, outdated)
+
+    second = tmp_path / "second"
+    second.write_text("second replacement", encoding="utf-8")
+    real_get_file_identity = fileio.get_file_identity
+    with mock.patch.object(fileio, "get_file_identity", side_effect=[outdated, real_get_file_identity(destpath)]):
+        fileio.replace_outdated_file(second, destpath, outdated)
+
+    assert destpath.read_text(encoding="utf-8") == "first replacement"
+
+
+def test_replace_outdated_file_defers_to_the_lock_holder(tmp_path: Path) -> None:
+    """A writer that finds the replacement lock taken leaves the destination to the holder."""
+    destpath = tmp_path / "cache"
+    destpath.write_text("outdated", encoding="utf-8")
+    outdated = at.misc.get_file_identity(destpath)
+    lockpath = tmp_path / ".cache.replace-lock"
+    lockpath.touch()
+
+    replacement = tmp_path / "replacement"
+    replacement.write_text("replacement", encoding="utf-8")
+    fileio.replace_outdated_file(replacement, destpath, outdated)
+
+    assert destpath.read_text(encoding="utf-8") == "outdated"
+    assert lockpath.exists(), "a fresh lock belongs to a live writer and must be left in place"
+
+    # a lock older than the holder could possibly hold it belongs to a dead process and is removed
+    os.utime(lockpath, (0.0, 0.0))
+    fileio.replace_outdated_file(replacement, destpath, outdated)
+    assert not lockpath.exists()
+    fileio.replace_outdated_file(replacement, destpath, outdated)
+    assert destpath.read_text(encoding="utf-8") == "replacement"
 
 
 def test_get_file_identity(tmp_path: Path) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -8,6 +8,7 @@ import argparse
 import gzip
 import io
 import lzma
+import math
 import os
 import subprocess
 import sys
@@ -673,6 +674,34 @@ def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatc
     for start_bin in (0, 4, 8):
         expected = sum(start_bin + n for n in range(nphibins)) / nphibins
         assert averaged_phi[start_bin].collect()["value"].to_list() == pytest.approx([expected, expected])
+
+
+def test_average_direction_bins_rebuilds_derived_cols(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A column derived non-linearly is rebuilt from the averaged values, not averaged itself."""
+    nphibins = 4
+    ncosthetabins = 3
+
+    monkeypatch.setattr(dirbins, "get_viewingdirection_phibincount", lambda: nphibins)
+    monkeypatch.setattr(dirbins, "get_viewingdirection_costhetabincount", lambda: ncosthetabins)
+
+    # one bin of every group is dark, so the mean of the logs is -inf while the log of the mean is finite
+    logcol = (pl.col("value").log10()).alias("logvalue")
+    dirbindataframes = {
+        dirbin: pl.DataFrame({"timestep": [0], "value": [float(dirbin % nphibins)]}).with_columns(logcol)
+        for dirbin in range(nphibins * ncosthetabins)
+    }
+
+    averaged = dirbins.average_direction_bins(dirbindataframes, overangle="phi", derivedcols=[logcol])
+
+    meanvalue = sum(range(nphibins)) / nphibins
+    for start_bin in (0, 4, 8):
+        row = averaged[start_bin].collect()
+        assert row["value"].item() == pytest.approx(meanvalue)
+        assert row["logvalue"].item() == pytest.approx(math.log10(meanvalue))
+
+    # without the expressions the magnitude-like column is averaged, which the dark bin sends to -inf
+    averaged_nodeclare = dirbins.average_direction_bins(dirbindataframes, overangle="phi")
+    assert averaged_nodeclare[0].collect()["logvalue"].item() == -math.inf
 
 
 def test_average_direction_bins_rejects_missing_bins(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -523,27 +523,49 @@ def test_replace_outdated_file_rechecks_under_the_lock(tmp_path: Path) -> None:
     assert destpath.read_text(encoding="utf-8") == "first replacement"
 
 
-def test_replace_outdated_file_defers_to_the_lock_holder(tmp_path: Path) -> None:
-    """A writer that finds the replacement lock taken leaves the destination to the holder."""
+def test_replace_outdated_file_waits_for_the_lock_holder(tmp_path: Path) -> None:
+    """A writer that finds the replacement lock taken waits, so its caller reads the holder's fresh file.
+
+    Returning at once would let the caller open the out-of-date file in the moment before the holder's
+    rename lands.
+    """
     destpath = tmp_path / "cache"
     destpath.write_text("outdated", encoding="utf-8")
     outdated = at.misc.get_file_identity(destpath)
     lockpath = tmp_path / ".cache.replace-lock"
     lockpath.touch()
 
+    holders_file = tmp_path / "holders_replacement"
+    holders_file.write_text("holders replacement", encoding="utf-8")
+
+    def holder_finishes(_seconds: float) -> None:
+        holders_file.replace(destpath)
+        lockpath.unlink()
+
+    replacement = tmp_path / "replacement"
+    replacement.write_text("replacement", encoding="utf-8")
+    with mock.patch("time.sleep", side_effect=holder_finishes) as mocksleep:
+        fileio.replace_outdated_file(replacement, destpath, outdated)
+
+    assert mocksleep.call_count == 1, "the writer must wait while the lock is held"
+    assert destpath.read_text(encoding="utf-8") == "holders replacement"
+
+
+def test_replace_outdated_file_takes_over_from_a_dead_lock_holder(tmp_path: Path) -> None:
+    """A lock older than the moment its holder could hold it belongs to a dead process and is removed."""
+    destpath = tmp_path / "cache"
+    destpath.write_text("outdated", encoding="utf-8")
+    outdated = at.misc.get_file_identity(destpath)
+    lockpath = tmp_path / ".cache.replace-lock"
+    lockpath.touch()
+    os.utime(lockpath, (0.0, 0.0))
+
     replacement = tmp_path / "replacement"
     replacement.write_text("replacement", encoding="utf-8")
     fileio.replace_outdated_file(replacement, destpath, outdated)
 
-    assert destpath.read_text(encoding="utf-8") == "outdated"
-    assert lockpath.exists(), "a fresh lock belongs to a live writer and must be left in place"
-
-    # a lock older than the holder could possibly hold it belongs to a dead process and is removed
-    os.utime(lockpath, (0.0, 0.0))
-    fileio.replace_outdated_file(replacement, destpath, outdated)
-    assert not lockpath.exists()
-    fileio.replace_outdated_file(replacement, destpath, outdated)
     assert destpath.read_text(encoding="utf-8") == "replacement"
+    assert not lockpath.exists()
 
 
 def test_get_file_identity(tmp_path: Path) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -576,6 +576,48 @@ def test_replace_outdated_file_waits_for_the_lock_holder(tmp_path: Path) -> None
     assert destpath.read_text(encoding="utf-8") == "holders replacement"
 
 
+def test_replace_outdated_file_installs_at_an_empty_destination(tmp_path: Path) -> None:
+    """An empty destination takes the new file, so a file system without hard links can still create it."""
+    destpath = tmp_path / "cache"
+    replacement = tmp_path / "replacement"
+    replacement.write_text("replacement", encoding="utf-8")
+
+    fileio.replace_outdated_file(replacement, destpath, None)
+
+    assert destpath.read_text(encoding="utf-8") == "replacement"
+
+    # a file that is already there is kept when this write does not claim to replace anything
+    another = tmp_path / "another"
+    another.write_text("another", encoding="utf-8")
+    fileio.replace_outdated_file(another, destpath, None)
+    assert destpath.read_text(encoding="utf-8") == "replacement"
+
+
+def test_write_parquet_atomic_applies_the_identity_rule_without_hard_links(tmp_path: Path) -> None:
+    """A file system that rejects hard links gets the same locked identity rule, not a bare rename."""
+    parquetpath = tmp_path / "batch.out.parquet.tmp"
+    theirs = pl.DataFrame({"a": [1, 2, 3]})
+    real_sink_parquet = pl.LazyFrame.sink_parquet
+
+    def sink_parquet_after_another_process_finished(self: pl.LazyFrame, path: t.Any, **kwargs: t.Any) -> t.Any:
+        result = real_sink_parquet(self, path, **kwargs)
+        real_sink_parquet(theirs.lazy(), parquetpath)
+        return result
+
+    with (
+        mock.patch.object(fileio.os, "link", side_effect=OSError),
+        mock.patch.object(pl.LazyFrame, "sink_parquet", sink_parquet_after_another_process_finished),
+    ):
+        at.write_parquet_atomic(pl.DataFrame({"a": [4, 5, 6]}), parquetpath)
+
+    assert pl.read_parquet(parquetpath)["a"].to_list() == [1, 2, 3], "the file a reader may hold was replaced"
+
+    # the fallback still replaces the file the caller found out of date
+    with mock.patch.object(fileio.os, "link", side_effect=OSError):
+        at.write_parquet_atomic(pl.DataFrame({"a": [7, 8, 9]}), parquetpath, replaces=at.get_file_identity(parquetpath))
+    assert pl.read_parquet(parquetpath)["a"].to_list() == [7, 8, 9]
+
+
 def test_replace_outdated_file_takes_over_from_a_dead_lock_holder(tmp_path: Path) -> None:
     """A lock older than the moment its holder could hold it belongs to a dead process and is removed."""
     destpath = tmp_path / "cache"

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -611,6 +611,9 @@ def test_replace_outdated_file_ignores_a_leftover_lock_file(tmp_path: Path) -> N
 
     assert destpath.read_text(encoding="utf-8") == "replacement"
     assert lockpath.exists()
+    # a different user in a shared model directory needs to open and flock the lock, which takes only read
+    # access: the lock is opened read-only and made world-readable whatever the umask
+    assert lockpath.stat().st_mode & 0o444 == 0o444
 
 
 def test_get_file_identity(tmp_path: Path) -> None:

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -27,8 +27,14 @@ def match_closest_time(reftime: float, searchtimes: Iterable[t.Any]) -> float:
     return min((float(x) for x in searchtimes), key=offset_from_reftime)
 
 
+@lru_cache(maxsize=16)
 def get_deposition(modelpath: Path | str = ".") -> pl.LazyFrame:
-    """Return a polars LazyFrame containing the deposition data."""
+    """Return a polars LazyFrame containing the deposition data.
+
+    The file is read and its times checked against the timesteps on every call, and a light curve plot asks
+    for it once per model and again per escape type, so the parsed frame is cached. A LazyFrame has no
+    in-place operations, so a caller cannot alter what the next one gets.
+    """
     if Path(modelpath).is_file():
         depfilepath = Path(modelpath)
         modelpath = Path(modelpath).parent

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -478,8 +478,7 @@ def make_plot_populations_with_time_or_velocity(modelpaths: Sequence[Path | str]
             title += f", mgi = {args.modelgridindex[0]}"
         elif args.x == "velocity":
             title += f", {timedayslist} days"
-        titleaxis = ax if isinstance(ax, mplax.Axes) else ax[-1]
-        titleaxis.set_title(title)
+        at.plottools.iter_axes(ax)[-1].set_title(title)
 
     at.plottools.set_axis_properties(ax, args)
 

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -415,9 +415,10 @@ def get_packets_rankbatch_parquetfile(
             if parquet_mtime > last_textfile_mtime and parquet_mtime > t_lastschemachange:
                 conversion_needed = False
             else:
-                # leave the stale file in place: write_parquet_atomic() swaps the new one in with a rename, so
-                # the path always resolves to a complete parquet. Deleting it first opens a window in which a
-                # concurrent reader (another rank, or another pytest-xdist worker) finds it missing or half-swapped
+                # leave the outdated file in place: write_parquet_atomic() puts the new one at the path in
+                # one step, so the path always resolves to a complete parquet. Deleting it first opens a
+                # window in which a concurrent reader (another rank, or another pytest-xdist worker) finds
+                # it missing or half-swapped
                 reasons = []
                 if parquet_mtime <= last_textfile_mtime:
                     reasons.append(

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -403,8 +403,10 @@ def get_packets_rankbatch_parquetfile(
     ]
 
     conversion_needed = True
+    outdatedparquet: tuple[int, int] | None = None
     if parquetfilepath.is_file():
-        parquet_mtime = parquetfilepath.stat().st_mtime
+        parquetstat = parquetfilepath.stat()
+        parquet_mtime = parquetstat.st_mtime
         # only the last rank's file is checked, on the assumption that a run writes all of its ranks together. An
         # individually-updated earlier file will not invalidate the cached parquet
         if text_filepath := at.firstexisting_or_none(
@@ -415,6 +417,9 @@ def get_packets_rankbatch_parquetfile(
             if parquet_mtime > last_textfile_mtime and parquet_mtime > t_lastschemachange:
                 conversion_needed = False
             else:
+                # the identity comes from the stat that showed the file is outdated, so only that exact
+                # file can be replaced by this rank's rewrite
+                outdatedparquet = at.get_file_identity(parquetstat)
                 # leave the outdated file in place: write_parquet_atomic() puts the new one at the path in
                 # one step, so the path always resolves to a complete parquet. Deleting it first opens a
                 # window in which a concurrent reader (another rank, or another pytest-xdist worker) finds
@@ -490,7 +495,7 @@ def get_packets_rankbatch_parquetfile(
             f"   took {time.perf_counter() - time_start_load:.1f} seconds. Writing parquet file...", end="", flush=True
         )
         time_start_write = time.perf_counter()
-        at.write_parquet_atomic(pldf_batch, parquetfilepath, compression_level=12)
+        at.write_parquet_atomic(pldf_batch, parquetfilepath, compression_level=12, replaces=outdatedparquet)
         print(f"took {time.perf_counter() - time_start_write:.1f} seconds")
 
     return parquetfilepath

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -19,6 +19,8 @@ from artistools.misc import print_saved
 if t.TYPE_CHECKING:
     from pathlib import Path
 
+    import matplotlib.typing as mplt
+
 # colorcet.glasbey_category20
 glasbey_category20 = [
     (0.121569, 0.466667, 0.705882),
@@ -287,6 +289,15 @@ glasbey_category20_nogreys = [
 refseries_colors = ("0.0", "0.4", "0.6", "0.7")
 
 
+def get_assigned_colors(seriescolors: Sequence[str | None]) -> set[str]:
+    """Return the hex values of the colours that series were given.
+
+    Comparing by value is the single rule for "a series already has this colour", so that the name "C0",
+    the alias "tab:blue" and the value "#1F77B4" all match the first colour of the cycle.
+    """
+    return {mplcolors.to_hex(color) for color in seriescolors if color}
+
+
 def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | None] = ()) -> list[str]:
     """Return the plot colour of each data series.
 
@@ -294,13 +305,13 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
     The other series, and the reference series after the greys, get the colours of the matplotlib cycle.
     The code steps over a colour that the user asked for, thus two series do not get one colour.
     """
-    askedfor = {color for color in usercolors if color}
+    askedfor = get_assigned_colors(usercolors)
     cyclecolors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
-    # the colours of the cycle that no series has, by either the name CN or the colour value
-    freecycleindices = [
-        i for i in range(len(cyclecolors)) if f"C{i}" not in askedfor and cyclecolors[i] not in askedfor
-    ] or list(range(max(len(cyclecolors), 1)))
+    # the colours of the cycle that no series has, by value rather than by spelling
+    freecycleindices = [i for i, color in enumerate(cyclecolors) if mplcolors.to_hex(color) not in askedfor] or list(
+        range(max(len(cyclecolors), 1))
+    )
 
     colors: list[str] = []
     refindex = 0
@@ -312,7 +323,7 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
             continue
 
         # step over a colour that the user asked for, thus two series do not get one colour
-        while isref and refindex < len(refseries_colors) and refseries_colors[refindex] in askedfor:
+        while isref and refindex < len(refseries_colors) and mplcolors.to_hex(refseries_colors[refindex]) in askedfor:
             refindex += 1
 
         if isref and refindex < len(refseries_colors):
@@ -325,13 +336,15 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
     return colors
 
 
-def get_unused_colors(palette: Sequence[t.Any], seriescolors: Sequence[str | None]) -> list[t.Any]:
+def get_unused_colors(
+    palette: Sequence["mplt.ColorType"], seriescolors: Sequence[str | None]
+) -> list["mplt.ColorType"]:
     """Return the colours of palette that no series in seriescolors was given.
 
     A series that takes its colour from the palette, e.g. an extra direction bin, then does not
     repeat the colour of another series. Colours are compared by value, so "C0" matches "#1f77b4".
     """
-    assignedcolors = {mplcolors.to_hex(color) for color in seriescolors if color}
+    assignedcolors = get_assigned_colors(seriescolors)
 
     return [color for color in palette if mplcolors.to_hex(color) not in assignedcolors]
 
@@ -433,14 +446,14 @@ class ExponentLabelFormatter(mplticker.ScalarFormatter):
 
 
 def iter_axes(ax: mplax.Axes | Iterable[t.Any]) -> list[mplax.Axes]:
-    """Return a flat list of the axes, whether the figure has a single axes or a grid of them."""
+    """Return a flat list of the axes, whether the figure has a single axes or a grid of them.
+
+    Iterating a 2D array of axes yields its rows, so the rows are flattened rather than returned as they are.
+    """
     if isinstance(ax, mplax.Axes):
         return [ax]
 
-    axes = list(ax)
-    assert all(isinstance(axis, mplax.Axes) for axis in axes)
-
-    return axes
+    return [axis for item in ax for axis in iter_axes(item)]
 
 
 def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Namespace) -> t.Any:
@@ -449,6 +462,10 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
         args.subplots = False
     if "labelfontsize" not in args:
         args.labelfontsize = 18
+
+    ymin, ymax = getattr(args, "ymin", None), getattr(args, "ymax", None)
+    xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
+    logscalex, logscaley = getattr(args, "logscalex", False), getattr(args, "logscaley", False)
 
     for axis in iter_axes(ax):
         axis.minorticks_on()
@@ -466,16 +483,14 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
 
         # scale first: a limit turns autoscaling off, so setting one before the scale keeps the linear
         # padding on a log axis. A limit of None on both sides is left alone for the same reason
-        if getattr(args, "logscalex", False):
+        if logscalex:
             axis.set_xscale("log")
-        if getattr(args, "logscaley", False):
+        if logscaley:
             axis.set_yscale("log")
 
-        ymin, ymax = getattr(args, "ymin", None), getattr(args, "ymax", None)
         if ymin is not None or ymax is not None:
             axis.set_ylim(ymin, ymax)
 
-        xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
         if xmin is not None or xmax is not None:
             axis.set_xlim(xmin, xmax)
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -454,15 +454,17 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
                 direction="in",
             )
 
-        if "ymin" in args or "ymax" in args:
-            axis.set_ylim(args.ymin, args.ymax)
-        if "xmin" in args or "xmax" in args:
-            axis.set_xlim(args.xmin, args.xmax)
-
+        # scale first: a limit turns autoscaling off, so setting one before the scale keeps the linear
+        # padding on a log axis. A limit of None on both sides is left alone for the same reason
         if getattr(args, "logscalex", False):
             axis.set_xscale("log")
         if getattr(args, "logscaley", False):
             axis.set_yscale("log")
+
+        if getattr(args, "ymin", None) is not None or getattr(args, "ymax", None) is not None:
+            axis.set_ylim(args.ymin, args.ymax)
+        if getattr(args, "xmin", None) is not None or getattr(args, "xmax", None) is not None:
+            axis.set_xlim(args.xmin, args.xmax)
 
     return ax
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -293,9 +293,10 @@ def get_assigned_colors(seriescolors: Sequence[str | None]) -> set[str]:
     """Return the hex values of the colours that series were given.
 
     Comparing by value is the single rule for "a series already has this colour", so that the name "C0",
-    the alias "tab:blue" and the value "#1F77B4" all match the first colour of the cycle.
+    the alias "tab:blue" and the value "#1F77B4" all match the first colour of the cycle. A transparent
+    series holds no colour, and to_hex would report it as black.
     """
-    return {mplcolors.to_hex(color) for color in seriescolors if color}
+    return {mplcolors.to_hex(color) for color in seriescolors if color and mplcolors.to_rgba(color)[3] > 0.0}
 
 
 def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | None] = ()) -> list[str]:
@@ -456,6 +457,19 @@ def iter_axes(ax: mplax.Axes | Iterable[t.Any]) -> list[mplax.Axes]:
     return [axis for item in ax for axis in iter_axes(item)]
 
 
+def log_axis_limit(limit: float | None, *, logscale: bool, argname: str) -> float | None:
+    """Return a plot range limit, or None when a log axis cannot show it.
+
+    matplotlib ignores a non-positive limit on a log scale, but warns in terms of neither the axis nor the
+    argument that asked for it.
+    """
+    if limit is not None and logscale and limit <= 0.0:
+        print(f"WARNING: ignoring {argname} {limit}, which a log axis cannot show")
+        return None
+
+    return limit
+
+
 def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Namespace) -> t.Any:
     """Apply the standard tick, minor tick, and font size settings to one or more axes."""
     if "subplots" not in args:
@@ -463,9 +477,11 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
     if "labelfontsize" not in args:
         args.labelfontsize = 18
 
-    ymin, ymax = getattr(args, "ymin", None), getattr(args, "ymax", None)
-    xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
     logscalex, logscaley = getattr(args, "logscalex", False), getattr(args, "logscaley", False)
+    ymin = log_axis_limit(getattr(args, "ymin", None), logscale=logscaley, argname="-ymin")
+    ymax = log_axis_limit(getattr(args, "ymax", None), logscale=logscaley, argname="-ymax")
+    xmin = log_axis_limit(getattr(args, "xmin", None), logscale=logscalex, argname="-xmin")
+    xmax = log_axis_limit(getattr(args, "xmax", None), logscale=logscalex, argname="-xmax")
 
     for axis in iter_axes(ax):
         axis.minorticks_on()

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -470,18 +470,32 @@ def log_axis_limit(limit: float | None, *, logscale: bool, argname: str) -> floa
     return limit
 
 
-def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Namespace) -> t.Any:
-    """Apply the standard tick, minor tick, and font size settings to one or more axes."""
+def set_axis_properties(
+    ax: Iterable[mplax.Axes] | mplax.Axes,
+    args: argparse.Namespace,
+    xlimits: tuple[float | None, float | None, str] | None = None,
+) -> t.Any:
+    """Apply the standard tick, minor tick, and font size settings to one or more axes.
+
+    A command whose x range has its own argument name, e.g. the -timemin/-timemax of the light curve
+    commands, passes it as xlimits=(min, max, "-timemin") rather than copying the values onto args.xmin:
+    a copied value would also reach every other reader of args.xmin, and a warning about it would name an
+    argument that the user did not give.
+    """
     if "subplots" not in args:
         args.subplots = False
     if "labelfontsize" not in args:
         args.labelfontsize = 18
 
+    if xlimits is None:
+        xlimits = (getattr(args, "xmin", None), getattr(args, "xmax", None), "-xmin")
+
     logscalex, logscaley = getattr(args, "logscalex", False), getattr(args, "logscaley", False)
     ymin = log_axis_limit(getattr(args, "ymin", None), logscale=logscaley, argname="-ymin")
     ymax = log_axis_limit(getattr(args, "ymax", None), logscale=logscaley, argname="-ymax")
-    xmin = log_axis_limit(getattr(args, "xmin", None), logscale=logscalex, argname="-xmin")
-    xmax = log_axis_limit(getattr(args, "xmax", None), logscale=logscalex, argname="-xmax")
+    xargname = xlimits[2]
+    xmin = log_axis_limit(xlimits[0], logscale=logscalex, argname=xargname)
+    xmax = log_axis_limit(xlimits[1], logscale=logscalex, argname=xargname.replace("min", "max"))
 
     for axis in iter_axes(ax):
         axis.minorticks_on()

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -432,6 +432,17 @@ class ExponentLabelFormatter(mplticker.ScalarFormatter):
         self._set_formatted_label_text()
 
 
+def iter_axes(ax: mplax.Axes | Iterable[t.Any]) -> list[mplax.Axes]:
+    """Return a flat list of the axes, whether the figure has a single axes or a grid of them."""
+    if isinstance(ax, mplax.Axes):
+        return [ax]
+
+    axes = list(ax)
+    assert all(isinstance(axis, mplax.Axes) for axis in axes)
+
+    return axes
+
+
 def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Namespace) -> t.Any:
     """Apply the standard tick, minor tick, and font size settings to one or more axes."""
     if "subplots" not in args:
@@ -439,8 +450,7 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
     if "labelfontsize" not in args:
         args.labelfontsize = 18
 
-    for axis in ax if isinstance(ax, Iterable) else [ax]:
-        assert isinstance(axis, mplax.Axes)
+    for axis in iter_axes(ax):
         axis.minorticks_on()
         for which, ticklength in (("minor", 5), ("major", 8)):
             axis.tick_params(
@@ -461,10 +471,13 @@ def set_axis_properties(ax: Iterable[mplax.Axes] | mplax.Axes, args: argparse.Na
         if getattr(args, "logscaley", False):
             axis.set_yscale("log")
 
-        if getattr(args, "ymin", None) is not None or getattr(args, "ymax", None) is not None:
-            axis.set_ylim(args.ymin, args.ymax)
-        if getattr(args, "xmin", None) is not None or getattr(args, "xmax", None) is not None:
-            axis.set_xlim(args.xmin, args.xmax)
+        ymin, ymax = getattr(args, "ymin", None), getattr(args, "ymax", None)
+        if ymin is not None or ymax is not None:
+            axis.set_ylim(ymin, ymax)
+
+        xmin, xmax = getattr(args, "xmin", None), getattr(args, "xmax", None)
+        if xmin is not None or xmax is not None:
+            axis.set_xlim(xmin, xmax)
 
     return ax
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import matplotlib.axes as mplax
 import matplotlib.axis as mplaxis
+import matplotlib.colors as mplcolors
 import matplotlib.figure as mplfig
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mplticker
@@ -324,17 +325,20 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
     return colors
 
 
-def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequence[str | None]) -> None:
-    """Remove the colours of seriescolors from the colour cycle of each axis.
+def get_unused_colors(palette: Sequence[t.Any], seriescolors: Sequence[str | None]) -> list[t.Any]:
+    """Return the colours of palette that no series in seriescolors was given.
 
-    A series that gets its colour from the cycle, e.g. an extra direction bin, then does not
-    repeat the colour of another series.
+    A series that takes its colour from the palette, e.g. an extra direction bin, then does not
+    repeat the colour of another series. Colours are compared by value, so "C0" matches "#1f77b4".
     """
-    colors = [
-        color
-        for i, color in enumerate(plt.rcParams["axes.prop_cycle"].by_key()["color"])
-        if f"C{i}" not in seriescolors and color not in seriescolors
-    ]
+    assignedcolors = {mplcolors.to_hex(color) for color in seriescolors if color}
+
+    return [color for color in palette if mplcolors.to_hex(color) not in assignedcolors]
+
+
+def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequence[str | None]) -> None:
+    """Remove the colours of seriescolors from the colour cycle of each axis."""
+    colors = get_unused_colors(plt.rcParams["axes.prop_cycle"].by_key()["color"], seriescolors)
     if colors:
         for axis in axes:
             axis.set_prop_cycle(color=colors)

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -42,6 +42,7 @@ from artistools.misc import get_escaped_arrivalrange
 from artistools.misc import get_file_metadata
 from artistools.misc import get_filterfunc
 from artistools.misc import get_model_name
+from artistools.misc import get_series_label
 from artistools.misc import get_time_range
 from artistools.misc import get_vpkt_config
 from artistools.misc import get_vspec_dir_labels
@@ -795,7 +796,7 @@ def make_emissionabsorption_plot(
     scale_to_peak: float | None = None,
 ) -> tuple[list[Artist], list[str], pl.DataFrame | None]:
     """Plot the emission and absorption contribution spectra, grouped by ion/line/term for an ARTIS model."""
-    modelname = args.label[0] if args.label and args.label[0] is not None else get_model_name(modelpath)
+    modelname = get_series_label(args.label, 0, get_model_name(modelpath))
 
     print(f"====> {modelname}")
     clamp_to_timesteps = not args.notimeclamp

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1123,6 +1123,46 @@ def test_get_series_colors_knows_the_value_of_a_cycle_colour() -> None:
     assert at.plottools.get_series_colors([False, False], [cyclecolors[1]]) == [cyclecolors[1], "C0"]
 
 
+def test_set_axis_properties_log_scale_keeps_the_data_in_view() -> None:
+    """A log scale must be set before the limits, so an unrequested limit does not freeze the linear view.
+
+    set_ylim turns autoscaling off even when both sides are None, so applying it first left the log axis with
+    the linearly padded limits, whose lower bound is negative and therefore off the axis entirely.
+    """
+    _fig, ax = plt.subplots()
+    ax.plot([1.0, 10.0], [1.0, 1000.0])
+
+    at.plottools.set_axis_properties(ax, argparse.Namespace(logscaley=True, ymin=None, ymax=None))
+
+    ymin, ymax = ax.get_ylim()
+    assert ymin > 0.0, ymin
+    assert ymin < 1.0, ymin
+    assert ymax > 1000.0, ymax
+
+
+def test_set_axis_properties_applies_the_requested_limits() -> None:
+    """A limit that the user did give must still be applied, on either side and on either axis."""
+    _fig, ax = plt.subplots()
+    ax.plot([1.0, 10.0], [1.0, 1000.0])
+
+    at.plottools.set_axis_properties(ax, argparse.Namespace(ymin=None, ymax=500.0, xmin=2.0, xmax=None))
+
+    assert np.isclose(ax.get_ylim()[1], 500.0)
+    assert np.isclose(ax.get_xlim()[0], 2.0)
+    # the side that was not given stays fitted to the data rather than falling back to the default view
+    assert ax.get_ylim()[0] <= 1.0
+    assert ax.get_xlim()[1] >= 10.0
+
+
+def test_iter_axes_flattens_a_subplot_grid() -> None:
+    """One axes and a grid of axes both become a flat list, so the callers need no isinstance dance."""
+    _fig, singleax = plt.subplots()
+    assert at.plottools.iter_axes(singleax) == [singleax]
+
+    _fig, axes = plt.subplots(nrows=2, ncols=3)
+    assert at.plottools.iter_axes(axes.flatten()) == list(axes.flatten())
+
+
 def test_path_is_artis_model_accepts_a_compressed_output_file() -> None:
     """A compressed ARTIS output file is a model, and not a reference data file."""
     assert all(at.path_is_artis_model(f"light_curve.out{ext}") for ext in ("", ".zst", ".gz", ".xz"))

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
+import matplotlib.colors as mplcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
@@ -1123,6 +1124,22 @@ def test_get_series_colors_knows_the_value_of_a_cycle_colour() -> None:
     assert at.plottools.get_series_colors([False, False], [cyclecolors[1]]) == [cyclecolors[1], "C0"]
 
 
+def test_get_series_colors_matches_a_cycle_colour_by_any_spelling() -> None:
+    """A cycle colour must leave the cycle whatever name the user gave it, not only its exact hex string."""
+    at.set_mpl_style()
+    firstcyclecolor = mplcolors.to_hex(plt.rcParams["axes.prop_cycle"].by_key()["color"][0])
+    assert firstcyclecolor == mplcolors.to_hex("tab:blue")
+
+    for spelling in ("tab:blue", firstcyclecolor.upper()):
+        colors = at.plottools.get_series_colors([False, False], [spelling])
+        assert colors[0] == spelling
+        # the second series used to be handed C0, drawing both series in the same blue
+        assert mplcolors.to_hex(colors[1]) != firstcyclecolor
+
+    # a grey that the user asked for is also matched by value, so the next reference series steps over it
+    assert at.plottools.get_series_colors([True, True], ["#000000"]) == ["#000000", "0.4"]
+
+
 def test_set_axis_properties_log_scale_keeps_the_data_in_view() -> None:
     """A log scale must be set before the limits, so an unrequested limit does not freeze the linear view.
 
@@ -1161,6 +1178,9 @@ def test_iter_axes_flattens_a_subplot_grid() -> None:
 
     _fig, axes = plt.subplots(nrows=2, ncols=3)
     assert at.plottools.iter_axes(axes.flatten()) == list(axes.flatten())
+
+    # iterating a 2D array yields its rows, which are arrays rather than axes
+    assert at.plottools.iter_axes(axes) == list(axes.flatten())
 
 
 def test_path_is_artis_model_accepts_a_compressed_output_file() -> None:


### PR DESCRIPTION
Combines the bolometric reference light curve work with fixes for how light curve colours, labels and axes are chosen.

## One reference light curve plotter

The `-reflightcurves` route always used `axis.scatter`, so a data file with `luminosity_errminus_erg/s` and `luminosity_errplus_erg/s` columns (such as the bundled `AT2017gfo_waxmanetal2018.txt`) lost its error bars and its `zorder`, while the same file passed in the model path list got them.

`plot_bol_reflightcurve()` now holds the read, the error-bar/scatter choice, the unit conversion and `zorder=0`, and both branches call it. Colours still come from `get_series_colors` via `args.color` and `args.refspeccolors`.

## Reference and deposition curves follow the y axis units

`at lc --Lsun` and `at lc --magnitude` drew the reference data straight from its erg/s column, so a reference curve appeared a factor of `Lsun_to_erg_per_s` (~3.8e33) above the ARTIS curves on the same axis, under a `[Lsun]` or magnitude label. `plot_deposition_thermalisation` had the same problem in reverse: it always multiplied by `Lsun_to_erg_per_s`.

- `get_plot_lum_unit()` reads the `--magnitude` / `--Lsun` flags in one place and returns a `LumUnit`. The conversions, the light curve column and the y axis label all take that unit rather than the parser&#39;s namespace, so a unit added to the literal is a type error at each branch instead of a plot-time surprise.
- `convert_lum_ergs_to_plotunits()` returns the reference file&#39;s own values unchanged on an erg/s axis, rather than round-tripping through Lsun.
- Magnitude error bars are derived from the luminosity bounds, so they are asymmetric; a bar reaching zero luminosity has no faintest magnitude and is left as NaN.
- The `&#34;Check units&#34;` `sys.exit(1)` guard in the `-reflightcurves` branch is gone — the conversion makes it unnecessary.
- `lum_lsun_to_mag()` owns the bolometric magnitude formula for both numpy callers, whose `np.errstate` handling had drifted apart. A zero deposition rate has no magnitude, and must not warn.
- The magnitude zero point `4.74` is now the shared constant `Mbol_sun`, including in `bolometric_magnitude()`, where a local variable of the same name shadowed it.
- The y label names what is drawn: a gamma-ray light curve in magnitudes is no longer called bolometric, and the deposition qualifier is added when those rates share the axis.

## An averaged magnitude comes from the averaged luminosity

**This changes a numerical result.** `readfile()` derives the magnitude column before `average_direction_bins()` runs, and averaging is linear, so `--average_over_phi_angle --magnitude` plotted the arithmetic mean of magnitudes.

Measured on `tests/data/test-classicmode_3d` over 3–8 d: 4 of 19 points were `inf` (a single dark bin sends the mean there) and the finite ones were up to 0.86 mag off; all 19 are now finite. The `--frompackets` route already averaged packets before deriving the columns, so the two routes had been disagreeing.

The rule now lives in `average_direction_bins()`, which takes the expressions that rebuild any column not linear in the bin contributions and applies them after averaging. The light curve loader declares `derived_lum_unit_cols()`; the spectra callers have only linear columns and declare nothing. A caller that forgets can no longer silently plot the mean of magnitudes.

## Deposition and thermalisation

- `plot_deposition_thermalisation()` passed `label` and the overridden `linestyle`/`color`/`dashes` both explicitly and through the `**plotkwargs` splat, so every `--plotdeposition` and `--plotthermalisation` run died with `TypeError: got multiple values for keyword argument`. The caller now passes a style built from the command line, so a deposition curve no longer inherits whichever direction bin was drawn last (`--colorbarphi` gave them all `alpha=0.75`; `--plotcmf` gave them `linewidth=1`).
- The rates belong to the model, but the call sat at the end of `plot_artis_lightcurve`, which runs once per escape type and once per top nuclide: `--gamma --rpkt --plotdeposition` drew all three curves twice, the second copy labelled as the gamma-ray series. They are now drawn for one series per model.
- The six near-identical deposition plot blocks are one table-driven loop, matching the thermalisation ratios; the drawn colours are unchanged. Both loops skip an absent column, so an older `deposition.out` carrying only the gamma columns no longer raises `ColumnNotFoundError`. The alpha decay curves sat behind a hardcoded `plotalphadep = False`; they now have a `-plotalphadeposition` argument, and take their colour from the axis cycle like the gamma and beta curves rather than from a hardcoded `"C1"` that collided with the second model&#39;s light curve.
- The thermalisation panel keeps its `[0, 1]` range: it holds a ratio, and letting a near-zero denominator at one timestep set the top pushes every curve into the floor of the panel.

## Axes and styles

- `invert_yaxis()` toggles rather than sets, and the subplots share one y axis, so `colour_evolution_plot`&#39;s per-line call left the axis the right way up for an even number of lines — measured un-inverted for 2 direction bins, and for 2 filter pairs. One idempotent `invert_magnitude_yaxis()` helper now serves all three plot functions, called after the limits are set, and in the band plot before `plt.show()` rather than after it.
- The bolometric figure applies its y limits, log scales and tick style through the shared `set_axis_properties()`, as the band and colour evolution figures already did. Limits are applied after the data is drawn: on an empty axes matplotlib turns autoscaling off, so a one-sided `-timemin`/`-ymin` used to freeze the other side at the default view.
- `set_axis_properties()` sets the scales before the limits and skips a limit pair that is entirely unset. Any `set_ylim` turns autoscaling off, so the old order left a log axis with the padding matplotlib had computed for a linear one — that affected every figure using the helper. The time limits follow the same order, so a non-positive `-timemin` on a log axis is rejected rather than silently applied.
- `iter_axes()` replaces three spellings of &#34;one axes or a grid of them&#34;.

## Line colours and labels come from args, without the dead fallbacks

`main()` fills `args.color` and `args.label` with one entry per model path, so every `if args.color:` / `if args.label:` test downstream was always true and its fallback was unreachable.

- Every band and colour evolution legend read the literal string `&#34;None&#34;`, because `get_linelabel()` stringified the value that pads the `-label` list. `get_series_label()` now owns &#34;the `-label` entry for this series, or the model name&#34; for both the light curve legends and the viewing angle scatter plot, which had the same always-truthy bug in `linelabels = args.label or modelnames`.
- `colour_evolution_plot()` warned that &#34;-color argument will not work with viewing angles&#34; even when no `-color` value was given, and the branch that would have applied per-direction-bin colours could never run. Direction bins now take a colour each from the tab20 map, chosen once per bin so it is stable across the filter-pair subplots, wrapping when it runs out — indexing it unwrapped raised `IndexError` past 20 lines, which `-plotviewingangle -2` (100 bins) reaches.
- `get_unused_colors()` owns &#34;the palette colours no series was given&#34;, shared by the direction bin palette and `set_prop_cycle_unusedcolors()`. Comparing by value rather than by name and value also makes `-color C0` match `#1f77b4`.
- Both plot functions decide with `len(dirbins)`, not with the raw `-plotviewingangle` flag: `-color` is honoured whenever a model contributes a single line (`parse_directionbin_args` falls back to the angle-averaged bin when a model has no `*_res.out`), and `-plotvspecpol` bins get distinct colours instead of sharing one.
- `make_band_lightcurves_plot()` shares one `plotkwargs` dict across models, so a model with several direction bins inherited the previous model&#39;s colour. The colour is now always assigned, and those axes exclude the assigned colours from the cycle.
- The unreachable `define_colours_list` / `define_colours_list2` tables in `viewingangleanalysis.py`, a duplicated colorbar kwargs update, and a dead local alias for `args.refspeccolors` are deleted. That alias would have raised `NameError` had its fallback been reachable. An `UnboundLocalError` under `--noangleaveraged` is fixed in the same function.
- Colour evolution integrates each band once per direction bin over the union of the filter pairs, instead of once per pair, and names its figure after the requested pairs rather than whichever the last loop iteration left behind.

## Tests

`test_lightcurve.py` gains coverage for both reference-curve routes in each unit mode, the asymmetric magnitude error bars (using the Waxman+2018 file, whose errors are not symmetric in log10, unlike Smartt+2017), deposition and thermalisation in each unit mode, and the unit resolver. For the colour, label and axis changes it covers `-color` and `-label` reaching the plotted line, the fallback to the model name, direction bins on `test-classicmode_3d` with 21 bins (exercising the wrap around the end of the colour map), colour stability across subplots, axis orientation across bin and filter-pair counts, palette disjointness, deposition style isolation, the deposition curves being drawn once per model in colours no series owns, the alpha deposition argument, one-sided time limits, the gamma magnitude label, and the averaged magnitude. `test_misc.py` covers the derived-column rule in `average_direction_bins()` directly, and `test_artistools.py` covers the `set_axis_properties()` scale and limit order.

The refactors were checked by diffing the plotted labels, colours and axis limits across band, colour evolution, deposition, alpha deposition and phi-averaged magnitude figures: unchanged.

`ruff format`, `ruff check --no-fix`, `refurb`, `mypy`, `pyrefly check` and `ty check` are clean, and the full `pytest artistools` suite passes (356 tests).

https://claude.ai/code/session_01S5QYmkufVc3hXJ9F4YMcHP
https://claude.ai/code/session_01T6PaiJ9uxiUdpMiqXcbx1J