### PR TITLE
Correct seven faults in the release process

### DIFF
--- a/.github/workflows/deploypypi.yml
+++ b/.github/workflows/deploypypi.yml
@@ -4,6 +4,10 @@ permissions:
     contents: read
 on:
     push:
+        branches: [main]
+        paths:
+            - .github/workflows/deploypypi.yml
+    pull_request:
         paths:
             - .github/workflows/deploypypi.yml
     release:
@@ -31,7 +35,6 @@ jobs:
             fail-fast: false
         runs-on: ${{ matrix.target.runs-on }}
         env:
-            CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ARTISTOOLS
             CIBW_BUILD: cp3??${{ matrix.freethreading }}-${{ matrix.target.os_arch }}
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -83,6 +86,9 @@ jobs:
             url: https://test.pypi.org/project/artistools/
         permissions:
             id-token: write
+        # a pull request from a fork gets no id-token permission, thus it can build the wheels
+        # but it cannot upload them
+        if: github.event.pull_request.head.repo.fork != true
         steps:
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
@@ -101,13 +107,15 @@ jobs:
         timeout-minutes: 15
         name: Upload to PyPI
         needs: [build_wheels, build_sdist]
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-26.04
         environment:
             name: release
             url: https://pypi.org/project/artistools/
         permissions:
             id-token: write
-        if: github.event.inputs.deploy-to-pypi == 'true' || github.event_name == 'release'
+        if: >-
+            github.event.inputs.deploy-to-pypi == 'true'
+            || (github.event_name == 'release' && !github.event.release.prerelease)
         steps:
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
@@ -118,5 +126,7 @@ jobs:
             - name: Publish package to PyPI
               uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
               with:
-                  skip-existing: true
+                  # a version that PyPI already has shows a mistake, thus this job must fail on it.
+                  # The TestPyPI job keeps skip-existing, because the push trigger repeats it often
+                  skip-existing: false
                   verbose: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ permissions:
     contents: read
 on:
     workflow_dispatch:
+        inputs:
+            revision:
+                description: Number of the release on this date. Use 1 or more for a second release on the same date.
+                required: false
+                default: '0'
 # a second run while one is in flight would hit a non-fast-forward push or a duplicate tag
 concurrency:
     group: release
@@ -37,11 +42,18 @@ jobs:
 
             - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
+            # set_version.py runs cargo update, thus the job needs a toolchain of its own and must
+            # not depend on the one that the runner image happens to carry
+            - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+              with:
+                  toolchain: stable
+
             - name: Set the version
               id: setversion
+              env:
+                  REVISION: ${{ inputs.revision }}
               run: |
-                  rustup update stable
-                  python3 set_version.py
+                  python3 set_version.py -revision "${REVISION}"
                   version=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
                   echo "version=${version}" >> "$GITHUB_OUTPUT"
 
@@ -64,6 +76,7 @@ jobs:
             - name: Commit the version bump
               env:
                   VERSION: ${{ steps.setversion.outputs.version }}
+                  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
               run: |
                   # set_version.py is the only thing that edits pyproject.toml here, and the lockfiles
                   # it also refreshes are separate files, so churn alone cannot produce a "Set version
@@ -76,7 +89,7 @@ jobs:
                   git config user.name "${GITHUB_ACTOR}"
                   git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
                   git commit --all --message "Set version to ${VERSION}"
-                  git push
+                  git push origin "HEAD:${DEFAULT_BRANCH}"
 
             # --target pins the release to the version bump commit, and publishing the draft is
             # what fires release:published, which deploypypi.yml already listens for

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,17 +42,12 @@ jobs:
 
             - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-            # set_version.py runs cargo update, thus the job needs a toolchain of its own and must
-            # not depend on the one that the runner image happens to carry
-            - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-              with:
-                  toolchain: stable
-
             - name: Set the version
               id: setversion
               env:
                   REVISION: ${{ inputs.revision }}
               run: |
+                  rustup update stable
                   python3 set_version.py -revision "${REVISION}"
                   version=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
                   echo "version=${version}" >> "$GITHUB_OUTPUT"

--- a/check_wheel.py
+++ b/check_wheel.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Check that an installed artistools wheel contains a rustext extension that loads.
+
+cibuildwheel runs this as its test command. A full run of the command-line interface would prove
+more, but it needs every run-time dependency, and the installation of those on Linux arm64 takes
+about 20 minutes. This check loads the extension module directly from its file, thus it imports
+neither the artistools package nor polars, and it needs nothing outside the wheel. It still fails
+if the wheel omits the extension or if the extension has an incompatible ABI.
+"""
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """Load artistools.rustext from the installed wheel and raise an error if it fails."""
+    pkgspec = importlib.util.find_spec("artistools")
+    if pkgspec is None or pkgspec.submodule_search_locations is None:
+        msg = "Found no installed artistools package"
+        raise RuntimeError(msg)
+
+    pkgpath = Path(next(iter(pkgspec.submodule_search_locations)))
+    # find_spec("artistools.rustext") would import the parent package first, and that needs polars
+    extpaths = sorted(
+        path for suffix in importlib.machinery.EXTENSION_SUFFIXES for path in pkgpath.glob(f"rustext{suffix}")
+    )
+    if not extpaths:
+        contents = sorted(path.name for path in pkgpath.iterdir())
+        msg = f"Found no rustext extension in {pkgpath}, which contains: {contents}"
+        raise RuntimeError(msg)
+
+    extspec = importlib.util.spec_from_file_location("rustext", extpaths[0])
+    if extspec is None or extspec.loader is None:
+        msg = f"Could not make a module spec for {extpaths[0]}"
+        raise RuntimeError(msg)
+
+    extspec.loader.exec_module(importlib.util.module_from_spec(extspec))
+
+    print(f"Loaded {extpaths[0]} on Python {sys.version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,8 @@ plotartisviewingangles = 'artistools.viewing_angles_visualization:main'
 [tool.cibuildwheel]
 build-frontend = "uv"
 archs = ["auto64"]
-# installing dependencies on Linux arm64 takes ~20 minutes
-#test-command = "python -m artistools"
+# check_wheel.py gives the reason why this is not a full run of the command-line interface
+test-command = "python {project}/check_wheel.py"
 
 [tool.cibuildwheel.linux]
 before-all = [
@@ -147,6 +147,7 @@ include = [
 exclude = [
     { path = "**/test_*.py", format = "wheel" },
     { path = "set_version.py", format = "sdist" },
+    { path = "check_wheel.py", format = "sdist" },
 ]
 
 [tool.pyrefly]

--- a/set_version.py
+++ b/set_version.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Set the package version and release date to today, across pyproject.toml and the other files that carry them."""
 
+import argparse
 import datetime as dt
 import re
 import subprocess
@@ -23,14 +24,36 @@ def replace_line(path: Path, pattern: str, replacement: str) -> None:
 
 def main() -> None:
     """Write today's date as the version and release date wherever they appear in the repository."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-revision",
+        type=int,
+        default=0,
+        help="Number of the release on this date. Use 1 or more for a second release on the same date.",
+    )
+    args = parser.parse_args()
+
+    if args.revision < 0:
+        msg = f"revision must be zero or more, but it is {args.revision}"
+        raise ValueError(msg)
+
     today = dt.datetime.now(dt.UTC).date()
     date_released = today.isoformat()
     # version has no zero padding and '.' for separator, e.g. 2026.4.20
     version = f"{today.year}.{today.month}.{today.day}"
-    print(f"Setting version to: {version}")
+    # PEP 440 permits a fourth release segment, thus a second release on one date is possible.
+    # Cargo accepts only three segments, thus rust/Cargo.toml keeps the date on its own. Nothing
+    # reads the version of the crate: maturin takes the version of the wheel from pyproject.toml,
+    # and the crate is a cdylib that does not go to crates.io
+    version_py = f"{version}.{args.revision}" if args.revision else version
+    print(f"Setting version to: {version_py}")
     print(f"Date released: {date_released}")
 
-    replace_line(repo_path / "pyproject.toml", r"^version = .*$", f'version = "{version}"')
+    # a stale lockfile would otherwise join the version bump in one commit, and the workflows that
+    # set UV_FROZEN would then use a lockfile that no test run has seen
+    subprocess.check_call(["uv", "lock", "--check"], cwd=repo_path)
+
+    replace_line(repo_path / "pyproject.toml", r"^version = .*$", f'version = "{version_py}"')
 
     # dependency versions sit inside inline tables, so only the [package] version starts a line
     rust_path = repo_path / "rust"
@@ -39,7 +62,7 @@ def main() -> None:
     # --workspace syncs Cargo.lock with the new package version, leaving the dependencies alone
     subprocess.check_call(["cargo", "update", "--workspace"], cwd=rust_path)
 
-    replace_line(repo_path / "CITATION.cff", r"^version: .*$", f"version: {version}")
+    replace_line(repo_path / "CITATION.cff", r"^version: .*$", f"version: {version_py}")
     replace_line(repo_path / "CITATION.cff", r"^date-released: .*$", f"date-released: {date_released}")
 
     subprocess.check_call(["uv", "lock"], cwd=repo_path)


### PR DESCRIPTION
## What changed

`release.yml`, `deploypypi.yml`, and `set_version.py` had gaps that let a bad wheel or a repeated upload pass without an error. This corrects seven of them.

### Nothing tested a built wheel

`test-command` was commented out, because a full run of the command-line interface needs every run-time dependency, and their installation on Linux arm64 takes about 20 minutes. Thus a wheel that omitted `artistools.rustext`, or that had an incompatible ABI, went to PyPI undetected.

The new `check_wheel.py` runs as the cibuildwheel test command. It resolves the installed package with `find_spec("artistools")`, then loads the extension straight from its file with `spec_from_file_location`. This skips `artistools/__init__.py`, which imports numpy, polars, and every submodule, thus the check needs nothing outside the wheel and keeps the 20 minutes.

### Dead configuration

`CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_ARTISTOOLS` had no effect. The build backend is maturin and `version` in `pyproject.toml` is static, thus setuptools-scm has no part in the build. No other file mentions it.

### A pre-release went to the real PyPI

The condition on the `deploy` job tested only `github.event_name == 'release'`. A draft marked as a pre-release would still go to PyPI. It now also needs `!github.event.release.prerelease`.

### `skip-existing` hid a repeated upload

A second publication of one version reported success and uploaded nothing. The real PyPI job now fails on it. The TestPyPI job keeps the option, because the `push` trigger repeats that job often.

### A second release on one date was impossible

`set_version.py` derived the version from the UTC date, and `release.yml` then rejected the existing tag. Thus you could not correct a bad release on the day that you made it.

`set_version.py` now takes `-revision N`, which appends a fourth PEP 440 release segment (`2026.8.20.2`) to `pyproject.toml` and `CITATION.cff`. `release.yml` passes the value through a `workflow_dispatch` input. `rust/Cargo.toml` keeps the three-segment date, because Cargo rejects a fourth segment. That is safe: nothing reads the version of the crate. There is no `CARGO_PKG_VERSION` in `rust/src/`, maturin takes the wheel version from `pyproject.toml`, and the crate is a `cdylib` that does not go to crates.io.

### A stale lockfile joined the version bump

`set_version.py` calls `uv lock` last. If `uv.lock` was already stale, the "Set version to" commit carried that update too, and the workflows that set `UV_FROZEN` then used a lockfile that no test run had seen. `uv lock --check` now runs first, before any edit.

### Three small faults

- The `deploy` job ran on `ubuntu-24.04`; every other job uses `ubuntu-26.04`.
- The `push` trigger started the full six-job wheel matrix and a TestPyPI upload on any branch. It is now restricted to `main`, with a `pull_request` trigger for the same paths.
- `git push` pushed the current branch. It now names the target, in agreement with the branch check at the top of the job.

## For the reviewer

One judgement call. Revert it if you disagree: the new `pull_request` trigger would break `testdeploy` on a fork, because a fork pull request gets no `id-token` permission. I guarded that job with `if: github.event.pull_request.head.repo.fork != true`, thus a fork pull request builds the wheels but skips the upload.

I first replaced `rustup update stable` with a pinned `dtolnay/rust-toolchain`, then reverted that on your request. `release.yml` keeps `rustup update stable`, thus this branch adds no third-party action.

**Still open:** nothing gates the deployment on the tests. `release.yml` drafts the release without a check on CI, and `deploy` needs only `build_wheels` and `build_sdist`. Thus a broken commit on `main` can reach PyPI, and only the memory of the maintainer prevents it. Two options: query the last "Test and lint" conclusion for `main` in `release.yml` before the bump, or add a job to `deploypypi.yml` that tests an installed wheel and put it in the `needs` list of `deploy`. Tell me which you prefer and I will add it.

## Checks

Run from the repository root: `ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `vulture` (nothing for the changed files), and `prek run` on the changed files (all hooks pass, including `yamlfmt`, `check-yaml`, and `uv-lock`).

Not run, with the reason for each:

- `pytest`: no code below `artistools/` changed.
- `cargo clippy`: no code below `rust/src/` changed.
- `refurb`: the documented command scopes it to `artistools/`, thus it does not cover these two root-level scripts.

I tested `set_version.py -revision 2` against the repository and restored the files afterwards. I also confirmed that `check_wheel.py` fails loudly on an ABI mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

