### PR TITLE
Honour packet time in contribution plots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Do not report that a check passed if you did not run it. Tell the user which che
 
 - Write code for Python 3.13 or a later version. The syntax must also be correct on the later versions and on the free-threaded builds that CI tests. The file `.github/workflows/pytest.yml` gives the list of versions. Do not add mutable state at module level. Do not use the GIL for thread safety.
 - Give a full annotation to every function. The type checkers run in strict mode, and they report an untyped def or an untyped call as an error.
+- Do not prefix a function name with an underscore.
 - Use the modern generics: `list[str]`, `X | None`, and PEP 695 (`def f[T](...)`, `type Alias = ...`). Do not use `typing.List` or `typing.Optional`. Use `Any` only if no more accurate type is possible.
 - Pyrefly must infer the parameter types of a lambda from the call site (`implicit-any-lambda`). A lambda accepts no annotations. Thus, if pyrefly cannot infer the types of a `sorted`, `min`, or `filter` key, write an annotated `def`. Use a comprehension in place of `filter(lambda ...)`.
 - Put the message of an exception in a variable. Do not use a literal:

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -833,6 +833,14 @@ def make_emissionabsorption_plot(
 
     dirbin = args.plotviewingangle[0] if args.plotviewingangle else args.plotvspecpol[0] if args.plotvspecpol else None
     if args.frompackets:
+        use_time: t.Literal["escape", "emission", "arrival"]
+        if args.use_escapetime:
+            use_time = "escape"
+        elif args.use_emissiontime:
+            use_time = "emission"
+        else:
+            use_time = "arrival"
+
         if args.groupby in {"nuc", "nucmass"}:
             emtypecolumn = "pellet_nucindex"
         elif args.use_thermalemissiontype:
@@ -862,6 +870,7 @@ def make_emissionabsorption_plot(
                 maxpacketfiles=args.maxpacketfiles,
                 filterfunc=filterfunc,
                 groupby=args.groupby,
+                use_time=use_time,
                 fixedionlist=args.fixedionlist,
                 maxseriescount=args.maxseriescount + 20,
                 gamma=args.gamma,

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -485,6 +485,49 @@ def select_dirbins(alldirbins: list[int], requested: Sequence[int] | None) -> li
     return list(requested)
 
 
+@lru_cache(maxsize=16)
+def _get_escape_surface_gamma(modelpath: Path | str) -> float:
+    """Return the Lorentz factor correction at the outer model boundary."""
+    from artistools.inputmodel import get_modeldata
+
+    _, modelmeta = get_modeldata(modelpath)
+    vmax_beta = float(modelmeta["vmax_cmps"]) / const.C_cm_per_s
+    return math.sqrt(1 - vmax_beta**2)
+
+
+def _filter_packets_by_time(
+    dfpackets: pl.LazyFrame,
+    modelpath: Path | str,
+    timelowdays: float,
+    timehighdays: float,
+    use_time: t.Literal["arrival", "emission", "escape"],
+    gamma: bool,
+) -> tuple[pl.LazyFrame, float | None]:
+    """Filter packets with the selected time and return the escape correction when applicable."""
+    if use_time == "arrival":
+        return dfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays)), None
+
+    if use_time == "escape":
+        escapesurfacegamma = _get_escape_surface_gamma(modelpath)
+        return (
+            dfpackets.filter(
+                (pl.col("escape_time") * escapesurfacegamma / const.day_to_s).is_between(timelowdays, timehighdays)
+            ),
+            escapesurfacegamma,
+        )
+
+    col_emit_time = "tdecay" if gamma else "em_time"
+    mean_correction = (pl.col(col_emit_time) - pl.col("t_arrive_d") * const.day_to_s).mean()
+    return (
+        dfpackets.filter(
+            pl.col(col_emit_time).is_between(
+                timelowdays * const.day_to_s + mean_correction, timehighdays * const.day_to_s + mean_correction
+            )
+        ),
+        None,
+    )
+
+
 def get_from_packets(
     modelpath: Path | str,
     timelowdays: float,
@@ -500,6 +543,7 @@ def get_from_packets(
     directionbins_are_vpkt_observers: bool = False,
     directionbins: Sequence[int] | None = None,
     gamma: bool = False,
+    packets_are_time_filtered: bool = False,
 ) -> dict[int, pl.LazyFrame]:
     """Return a spectrum dataframe. The packets files are the input.
 
@@ -507,6 +551,9 @@ def get_from_packets(
     A query for each direction bin has a cost. Thus a caller that needs one bin must request one bin.
     """
     assert use_time in {"arrival", "emission", "escape"}
+    if directionbins_are_vpkt_observers and use_time != "arrival":
+        msg = "Virtual packet spectra support only observer arrival time"
+        raise ValueError(msg)
 
     if nu_column == "absorption_freq":
         nu_column = "nu_absorbed"
@@ -554,7 +601,9 @@ def get_from_packets(
             dirbin_spectra[vspecindex] = (
                 atpackets
                 .bin_and_sum(
-                    dfpackets.filter(pl.col(f"dir{obsdirindex}_t_arrive_d").is_between(timelowdays, timehighdays)),
+                    dfpackets
+                    if packets_are_time_filtered
+                    else dfpackets.filter(pl.col(f"dir{obsdirindex}_t_arrive_d").is_between(timelowdays, timehighdays)),
                     bincol=lambda_column,
                     bins=lambda_bin_edges.tolist(),
                     sumcols=[energy_column],
@@ -577,38 +626,17 @@ def get_from_packets(
                     .with_columns(f_nu=(pl.col("f_lambda") * pl.col("lambda_angstroms") / pl.col("nu")))
                 )
 
-        assert use_time == "arrival"
     else:
         alldirbins = [-1, *get_dirbins(average_over_phi=average_over_phi, average_over_theta=average_over_theta)]
         lambda_column = nu_column.replace("nu_", "lambda_angstroms_")
         energy_column = "e_cmf" if use_time == "escape" else "e_rf"
 
-        if use_time == "arrival":
-            dfpackets = dfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays))
-
-        elif use_time == "escape":
-            from artistools.inputmodel import get_modeldata
-
-            dfmodel, _ = get_modeldata(modelpath)
-            vmax_beta = (
-                dfmodel.select(pl.col("vel_r_max_kmps").max() * const.km_to_cm / const.C_cm_per_s).collect().item()
-            )
-            escapesurfacegamma = math.sqrt(1 - vmax_beta**2)
-
-            dfpackets = dfpackets.filter(
-                (pl.col("escape_time") * escapesurfacegamma / const.day_to_s).is_between(timelowdays, timehighdays)
-            )
-
-        elif use_time == "emission":
-            # We bin packets according to the emission time, but we shift times so we're still centered around the observer arrival time.
-            # This makes easier to directly compare specta between emission time (no relative light travel time effects) and the standard arrival time
-            col_emit_time = "tdecay" if gamma else "em_time"
-            mean_correction = (pl.col(col_emit_time) - pl.col("t_arrive_d") * const.day_to_s).mean()
-
-            dfpackets = dfpackets.filter(
-                pl.col(col_emit_time).is_between(
-                    timelowdays * const.day_to_s + mean_correction, timehighdays * const.day_to_s + mean_correction
-                )
+        if packets_are_time_filtered:
+            if use_time == "escape":
+                escapesurfacegamma = _get_escape_surface_gamma(modelpath)
+        else:
+            dfpackets, escapesurfacegamma = _filter_packets_by_time(
+                dfpackets, modelpath, timelowdays, timehighdays, use_time, gamma
             )
 
         dfpackets = dfpackets.filter(pl.col(lambda_column).is_between(lambda_bin_edges[0], lambda_bin_edges[-1]))
@@ -1279,6 +1307,7 @@ def get_flux_contributions_from_packets(
     groupby selects whether the packets are grouped by ion, line, nuclide, or nuclide mass.
     """
     assert groupby in {"ion", "line", "nuc", "nucmass"}
+    assert use_time in {"arrival", "emission", "escape"}
     assert emtypecolumn in {"emissiontype", "trueemissiontype", "pellet_nucindex"}
     if getabsorption and groupby == "nuc":
         # A nuclide emits a packet, but a nuclide does not absorb a packet.
@@ -1297,11 +1326,15 @@ def get_flux_contributions_from_packets(
         assert groupby in {"nuc", "nucmass"}
         assert emtypecolumn == "pellet_nucindex"
 
+    if directionbins_are_vpkt_observers and use_time != "arrival":
+        msg = "Virtual packet contributions support only observer arrival time"
+        raise ValueError(msg)
+
     if directionbin is None:
         directionbin = -1
 
-    cols = {"e_rf"}
-    cols.add({"arrival": "t_arrive_d", "emission": "em_time", "escape": "escape_time"}[use_time])
+    energy_column = "e_cmf" if use_time == "escape" else "e_rf"
+    cols = {energy_column}
 
     nu_min = const.c_ang_per_s / lambda_bin_edges[-1]
     nu_max = const.c_ang_per_s / lambda_bin_edges[0]
@@ -1327,7 +1360,7 @@ def get_flux_contributions_from_packets(
         )
         dirbin_nu_column = "nu_rf"
 
-        lzdfpackets = lzdfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays))
+        lzdfpackets, _ = _filter_packets_by_time(lzdfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
 
         lzdfpackets, _ = atpackets.filter_packets_dirbin(
             lzdfpackets, directionbin, average_over_phi=average_over_phi, average_over_theta=average_over_theta
@@ -1453,18 +1486,18 @@ def get_flux_contributions_from_packets(
 
     del dfpackets, dflines
 
-    group_e_rf_sum: dict[str, float] = {}
+    group_energy_sum: dict[str, float] = {}
     for groups in (emissiongroups, absorptiongroups):
         for groupname, dfgroup in groups.items():
-            group_e_rf_sum[groupname] = group_e_rf_sum.get(groupname, 0.0) + float(dfgroup["e_rf"].sum())
+            group_energy_sum[groupname] = group_energy_sum.get(groupname, 0.0) + float(dfgroup[energy_column].sum())
 
-    allgroupnames = list(group_e_rf_sum)
+    allgroupnames = list(group_energy_sum)
 
     if fixedionlist is not None and (unrecognised_items := [x for x in fixedionlist if x not in allgroupnames]):
         print(f"WARNING: (packets) did not find {len(unrecognised_items)} items in fixedionlist: {unrecognised_items}")
 
     def sortkey(groupname: str) -> tuple[int, float | int]:
-        grouptotal = group_e_rf_sum[groupname]
+        grouptotal = group_energy_sum[groupname]
 
         if fixedionlist is None:
             return (0, -grouptotal)
@@ -1519,6 +1552,7 @@ def get_flux_contributions_from_packets(
                     average_over_phi=average_over_phi,
                     average_over_theta=average_over_theta,
                     gamma=gamma,
+                    packets_are_time_filtered=True,
                 )[directionbin].select("lambda_angstroms", "f_lambda")
                 for dfpkts in emissiongroups.values()
             ]),
@@ -1542,6 +1576,8 @@ def get_flux_contributions_from_packets(
                     directionbins=[directionbin],
                     average_over_phi=average_over_phi,
                     average_over_theta=average_over_theta,
+                    gamma=gamma,
+                    packets_are_time_filtered=True,
                 )[directionbin].select("lambda_angstroms", "f_lambda")
                 for dfpkts in absorptiongroups.values()
             ]),

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -486,7 +486,7 @@ def select_dirbins(alldirbins: list[int], requested: Sequence[int] | None) -> li
 
 
 @lru_cache(maxsize=16)
-def _get_escape_surface_gamma(modelpath: Path | str) -> float:
+def get_escape_surface_gamma(modelpath: Path | str) -> float:
     """Return the Lorentz factor correction at the outer model boundary."""
     from artistools.inputmodel import get_modeldata
 
@@ -495,7 +495,7 @@ def _get_escape_surface_gamma(modelpath: Path | str) -> float:
     return math.sqrt(1 - vmax_beta**2)
 
 
-def _filter_packets_by_time(
+def filter_packets_by_time(
     dfpackets: pl.LazyFrame,
     modelpath: Path | str,
     timelowdays: float,
@@ -508,7 +508,7 @@ def _filter_packets_by_time(
         return dfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays)), None
 
     if use_time == "escape":
-        escapesurfacegamma = _get_escape_surface_gamma(modelpath)
+        escapesurfacegamma = get_escape_surface_gamma(modelpath)
         return (
             dfpackets.filter(
                 (pl.col("escape_time") * escapesurfacegamma / const.day_to_s).is_between(timelowdays, timehighdays)
@@ -633,9 +633,9 @@ def get_from_packets(
 
         if packets_are_time_filtered:
             if use_time == "escape":
-                escapesurfacegamma = _get_escape_surface_gamma(modelpath)
+                escapesurfacegamma = get_escape_surface_gamma(modelpath)
         else:
-            dfpackets, escapesurfacegamma = _filter_packets_by_time(
+            dfpackets, escapesurfacegamma = filter_packets_by_time(
                 dfpackets, modelpath, timelowdays, timehighdays, use_time, gamma
             )
 
@@ -1360,7 +1360,7 @@ def get_flux_contributions_from_packets(
         )
         dirbin_nu_column = "nu_rf"
 
-        lzdfpackets, _ = _filter_packets_by_time(lzdfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
+        lzdfpackets, _ = filter_packets_by_time(lzdfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
 
         lzdfpackets, _ = atpackets.filter_packets_dirbin(
             lzdfpackets, directionbin, average_over_phi=average_over_phi, average_over_theta=average_over_theta

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -387,6 +387,130 @@ def test_spectra_get_flux_contributions_from_packets(benchmark: BenchmarkFixture
     assert max(diff) / integrated_flux_specout < 1e-10
 
 
+@pytest.mark.parametrize(
+    ("use_emissiontime", "use_escapetime", "expected_use_time"), [(True, False, "emission"), (False, True, "escape")]
+)
+@mock.patch("artistools.spectra.plotspectra.atspectra.get_flux_contributions_from_packets")
+def test_spectra_contribution_plot_forwards_packet_time(
+    mockgetcontributions: mock.MagicMock,
+    tmp_path: Path,
+    use_emissiontime: bool,
+    use_escapetime: bool,
+    expected_use_time: str,
+) -> None:
+    """The contribution plot must use the packet time that the command selects."""
+    contribution_list: list[atspectra.FluxContributionTuple] = []
+    mockgetcontributions.return_value = (contribution_list, np.zeros(2), np.array([4000.0, 5000.0]))
+
+    at.spectra.plot(
+        argsraw=[],
+        specpath=modelpath,
+        outputfile=tmp_path / f"contributions_{expected_use_time}.pdf",
+        timemin=290.0,
+        timemax=320.0,
+        emissionabsorption=True,
+        use_emissiontime=use_emissiontime,
+        use_escapetime=use_escapetime,
+    )
+
+    assert mockgetcontributions.call_args.kwargs["use_time"] == expected_use_time
+
+
+def test_spectra_gamma_emission_time_uses_decay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gamma packet selection must use the decay time and not the radiation packet emission time."""
+    dfpackets = pl.DataFrame({
+        "e_rf": [1.0, 2.0],
+        "t_arrive_d": [1.0, 3.0],
+        "tdecay": [1.0 * at.constants.day_to_s, 3.0 * at.constants.day_to_s],
+        "em_time": [3.0 * at.constants.day_to_s, 1.0 * at.constants.day_to_s],
+        "nu_rf": [at.constants.c_ang_per_s / 5000.0] * 2,
+    })
+
+    def get_packets(*_args: t.Any, **_kwargs: t.Any) -> tuple[int, pl.LazyFrame]:
+        return 1, dfpackets.lazy()
+
+    monkeypatch.setattr(atspectra.atpackets, "get_packets", get_packets)
+    dfspectrum = atspectra.get_from_packets(
+        modelpath=Path(),
+        timelowdays=0.5,
+        timehighdays=1.5,
+        lambda_bin_edges=np.array([4000.0, 5000.0, 6000.0]),
+        use_time="emission",
+        gamma=True,
+        directionbins=[-1],
+    )[-1].collect()
+
+    integrated_flux = dfspectrum.select((pl.col("f_lambda") * pl.col("delta_lambda")).sum()).item()
+    expected_flux = 1.0 / at.constants.day_to_s / (4 * math.pi * at.constants.megaparsec_to_cm**2)
+    assert np.isclose(integrated_flux, expected_flux)
+
+
+def test_spectra_contributions_use_escape_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Contribution spectra must use the same escape-time packet set and energy as the total spectrum."""
+    nu_rf = at.constants.c_ang_per_s / 5000.0
+    dfpackets = pl.DataFrame({
+        "e_rf": [1.0, 2.0],
+        "e_cmf": [10.0, 20.0],
+        "t_arrive_d": [1.5, 3.0],
+        "escape_time": [3.0 * at.constants.day_to_s, 1.5 * at.constants.day_to_s],
+        "pellet_nucindex": [0, 0],
+        "nu_rf": [nu_rf, nu_rf],
+    })
+    lambda_bin_edges = np.array([4000.0, 5000.0, 6000.0])
+
+    def get_packets(*_args: t.Any, **_kwargs: t.Any) -> tuple[int, pl.LazyFrame]:
+        return 1, dfpackets.lazy()
+
+    def get_escape_surface_gamma(_modelpath: Path | str) -> float:
+        return 1.0
+
+    def get_nuclides(modelpath: Path | str) -> pl.LazyFrame:
+        del modelpath
+        return pl.LazyFrame({"pellet_nucindex": [0], "nucname": ["Ni56"]})
+
+    monkeypatch.setattr(atspectra.atpackets, "get_packets", get_packets)
+    monkeypatch.setattr(atspectra, "_get_escape_surface_gamma", get_escape_surface_gamma)
+    monkeypatch.setattr(atspectra, "get_nuclides", get_nuclides)
+
+    dfspectrum = atspectra.get_from_packets(
+        modelpath=Path(),
+        timelowdays=1.0,
+        timehighdays=2.0,
+        lambda_bin_edges=lambda_bin_edges,
+        use_time="escape",
+        directionbins=[-1],
+    )[-1].collect()
+    contributions, array_flambda_emission_total, array_lambda = atspectra.get_flux_contributions_from_packets(
+        modelpath=Path(),
+        timelowdays=1.0,
+        timehighdays=2.0,
+        lambda_bin_edges=lambda_bin_edges,
+        getabsorption=False,
+        groupby="nuc",
+        use_time="escape",
+        emtypecolumn="pellet_nucindex",
+    )
+
+    assert [contribution.linelabel for contribution in contributions] == ["Ni56"]
+    assert np.array_equal(array_lambda, dfspectrum["lambda_angstroms"].to_numpy())
+    assert np.allclose(array_flambda_emission_total, dfspectrum["f_lambda"].to_numpy())
+
+
+def test_spectra_escape_time_with_3d_model() -> None:
+    """Escape-time spectra must get the outer velocity from metadata for a 3D model."""
+    dfspectrum = atspectra.get_from_packets(
+        modelpath=modelpath_classic_3d,
+        timelowdays=3.0,
+        timehighdays=8.0,
+        lambda_bin_edges=np.linspace(3500.0, 8000.0, 101),
+        use_time="escape",
+        directionbins=[-1],
+    )[-1].collect()
+
+    assert dfspectrum["f_lambda"].is_finite().all()
+    assert dfspectrum["f_lambda"].sum() > 0.0
+
+
 @pytest.mark.benchmark
 def test_spectra_timeseries_subplots() -> None:
     timedayslist = [295, 300]

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -469,7 +469,7 @@ def test_spectra_contributions_use_escape_time(monkeypatch: pytest.MonkeyPatch) 
         return pl.LazyFrame({"pellet_nucindex": [0], "nucname": ["Ni56"]})
 
     monkeypatch.setattr(atspectra.atpackets, "get_packets", get_packets)
-    monkeypatch.setattr(atspectra, "_get_escape_surface_gamma", get_escape_surface_gamma)
+    monkeypatch.setattr(atspectra, "get_escape_surface_gamma", get_escape_surface_gamma)
     monkeypatch.setattr(atspectra, "get_nuclides", get_nuclides)
 
     dfspectrum = atspectra.get_from_packets(


### PR DESCRIPTION
## Summary

- Pass the selected packet time to emission and absorption contribution plots.
- Select one common packet set before the code divides packets into contribution groups.
- Use decay time for gamma emission and comoving energy for escape-time spectra.
- Read the outer velocity from model metadata, which also supports 3D models.
- Reject unsupported non-arrival times for virtual packets with a clear error.

## Validation

- `ruff format --check`
- `ruff check --no-fix`
- `pyrefly check`
- `ty check`
- `refurb artistools --quiet -- --follow-imports=skip`
- `pytest artistools/spectra -n auto` (40 passed)
- `prek run --files artistools/spectra/plotspectra.py artistools/spectra/spectra.py artistools/spectra/test_spectra.py`

`vulture` reports the mock `return_value` assignment in the new test as unused. The mock consumes this value at run time.