### PR TITLE
Preserve spectrum brackets in band integration

### DIFF
--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -197,7 +197,7 @@ def plot_qdot(
 ) -> None:
     """Plot the ARTIS radioactive heating rate against the rate from the nuclear network trajectories."""
     try:
-        depdata = at.misc.df_filter_minmax_bounded(
+        depdata = at.misc.df_filter_minmax_bracketed(
             at.get_deposition(modelpath=modelpath), "tmid_days", None, xmax
         ).collect()
 
@@ -619,7 +619,7 @@ def plot_qdot_abund_modelcells(
     model_mass_grams = lzdfmodel.select(pl.col("mass_g").sum()).collect().item()
     print(f"model mass: {model_mass_grams / Msun_to_g:.3f} Msun")
 
-    dftimesteps = at.misc.df_filter_minmax_bounded(
+    dftimesteps = at.misc.df_filter_minmax_bracketed(
         at.get_timesteps(modelpath).select("timestep", "tmid_days"), "tmid_days", None, timedaysmax
     ).collect()
 

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -108,7 +108,7 @@ def get_from_packets(
     if directionbins is None:
         directionbins = [-1]
 
-    dftimesteps_selected = at.misc.df_filter_minmax_bounded(
+    dftimesteps_selected = at.misc.df_filter_minmax_bracketed(
         at.get_timesteps(modelpath), "tmid_days", timedaysmin, timedaysmax
     ).collect()
 
@@ -329,11 +329,16 @@ def generate_band_lightcurve_data(
 
                 # interpolate the coarser-sampled series onto the finer wavelength grid before multiplying,
                 # with zero contribution outside the sampled range
-                if len(wavelength_from_spectrum) > len(wavefilter):
-                    integrand = flux * np.interp(
-                        wavelength_from_spectrum, wavefilter, transmission, left=0.0, right=0.0
+                spectrum_in_filter = np.logical_and(
+                    wavelength_from_spectrum >= wavefilter_min, wavelength_from_spectrum <= wavefilter_max
+                )
+                wavelength_in_filter = wavelength_from_spectrum[spectrum_in_filter]
+                flux_in_filter = flux[spectrum_in_filter]
+                if len(wavelength_in_filter) > len(wavefilter):
+                    integrand = flux_in_filter * np.interp(
+                        wavelength_in_filter, wavefilter, transmission, left=0.0, right=0.0
                     )
-                    integration_grid = wavelength_from_spectrum
+                    integration_grid = wavelength_in_filter
                 else:
                     integrand = (
                         np.interp(wavefilter, wavelength_from_spectrum, flux, left=0.0, right=0.0) * transmission
@@ -429,7 +434,7 @@ def get_spectrum_in_filter_range(
     average_over_phi: bool = False,
     average_over_theta: bool = False,
 ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Return the wavelengths and fluxes of the spectrum at one timestep, restricted to a filter's wavelength range."""
+    """Return the spectrum rows that bracket a filter wavelength range."""
     spectrum = at.spectra.get_spectrum_at_time(
         Path(modelpath),
         timestep=timestep,
@@ -441,14 +446,13 @@ def get_spectrum_in_filter_range(
     )
     assert spectrum is not None
 
-    wavelength_from_spectrum: list[float] = []
-    flux: list[float] = []
-    for wavelength, flambda in zip(spectrum["lambda_angstroms"], spectrum["f_lambda"], strict=True):
-        if wavefilter_min <= wavelength <= wavefilter_max:  # to match the spectrum wavelengths to those of the filter
-            wavelength_from_spectrum.append(wavelength)
-            flux.append(flambda)
-
-    return np.array(wavelength_from_spectrum), np.array(flux)
+    spectrum_bracketed = (
+        at.misc
+        .df_filter_minmax_bracketed(spectrum, "lambda_angstroms", wavefilter_min, wavefilter_max)
+        .select("lambda_angstroms", "f_lambda")
+        .collect()
+    )
+    return spectrum_bracketed["lambda_angstroms"].to_numpy(), spectrum_bracketed["f_lambda"].to_numpy()
 
 
 def get_band_lightcurve(

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -412,7 +412,7 @@ def plot_artis_lightcurve(
         zip(
             dirbins,
             pl.collect_all(
-                at.misc.df_filter_minmax_bounded(
+                at.misc.df_filter_minmax_bracketed(
                     lcdataframes[dirbin], colname="time_days", minval=args.timemin, maxval=args.timemax
                 )
                 for dirbin in dirbins
@@ -657,7 +657,7 @@ def make_lightcurve_plot(
                         )
                         top_nuclides = (
                             at.misc
-                            .df_filter_minmax_bounded(
+                            .df_filter_minmax_bracketed(
                                 dfpackets.with_columns(tdecay_d=pl.col("tdecay") / day_to_s),
                                 "tdecay_d" if args.use_pellet_decay_time else "t_arrive_d",
                                 args.timemin,

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -20,6 +20,7 @@ from pytest_codspeed.plugin import BenchmarkFixture
 import artistools as at
 from artistools.constants import Lsun_to_erg_per_s
 from artistools.constants import Mbol_sun
+from artistools.lightcurve import lightcurve
 from artistools.lightcurve import viewingangleanalysis
 
 modelpath = at.get_path("testdata") / "testmodel"
@@ -137,6 +138,22 @@ def test_filter_data_is_sorted_by_wavelength() -> None:
         assert transmit == rawpairs[wavelength]
 
 
+@mock.patch("artistools.spectra.get_spectrum_at_time")
+def test_spectrum_filter_range_includes_bracketing_points(mockgetspectrum: mock.MagicMock) -> None:
+    """Band integration must retain the spectrum point on each side of the filter range."""
+    mockgetspectrum.return_value = pl.DataFrame({
+        "lambda_angstroms": [1000.0, 2000.0, 3000.0, 4000.0],
+        "f_lambda": [1.0, 2.0, 4.0, 8.0],
+    })
+
+    wavelength, flux = lightcurve.get_spectrum_in_filter_range(
+        modelpath=Path(), timestep=0, time=1.0, wavefilter_min=2200.0, wavefilter_max=2800.0
+    )
+
+    assert np.array_equal(wavelength, np.array([2000.0, 3000.0]))
+    assert np.array_equal(flux, np.array([2.0, 4.0]))
+
+
 def test_band_magnitude_calculations() -> None:
     band_magnitude_data = at.lightcurve.generate_band_lightcurve_data(
         modelpath,
@@ -152,16 +169,16 @@ def test_band_magnitude_calculations() -> None:
     expected_summary = {
         "bol": ((290.381, -12.522955565351443), (299.309, -12.290504747994545), -12.486325221679541),
         "U": ((290.381, -11.72755172004823), (299.309, -10.940395871435907), -11.552651445171437),
-        "B": ((290.381, -12.80311303703452), (299.309, -12.468614058886018), -12.729462436319448),
-        "V": ((290.381, -13.134615284653417), (299.309, -12.922527436514791), -13.018633619232805),
-        "I": ((290.381, -12.353784741224969), (299.309, -12.099751514986119), -12.443177921324608),
+        "B": ((290.381, -12.803113515779813), (299.309, -12.468614058886018), -12.72946419132831),
+        "V": ((290.381, -13.134621676461588), (299.309, -12.922533596999637), -13.018642833106346),
+        "I": ((290.381, -12.353786573875853), (299.309, -12.099768401014884), -12.443185093790348),
     }
     expected_brightest = {
         "bol": (291.359, -12.572391488690043),
         "U": (298.303, -11.927722052704134),
-        "B": (298.303, -12.885253294760465),
-        "V": (293.327, -13.166532931259166),
-        "I": (295.307, -12.701305015349229),
+        "B": (298.303, -12.8852578600296),
+        "V": (293.327, -13.16654427664928),
+        "I": (295.307, -12.701314848818333),
     }
 
     assert band_magnitude_data.keys() == expected_summary.keys()
@@ -189,21 +206,21 @@ def test_band_magnitude_selection_and_colour() -> None:
     times, b_magnitudes = at.lightcurve.get_band_lightcurve(band_magnitude_data, "B", timemin=293.0, timemax=296.0)
 
     assert times == pytest.approx([293.327, 294.315, 295.307])
-    assert b_magnitudes == pytest.approx([-12.708765155582157, -12.656976514620492, -12.794116835974194])
+    assert b_magnitudes == pytest.approx([-12.708769275316618, -12.656976514620492, -12.794120144812808])
 
     colour_times, b_minus_v = at.lightcurve.get_colour_delta_mag(band_magnitude_data, ["B", "V"])
     assert colour_times == pytest.approx([time for time, _ in band_magnitude_data["B"]])
     assert b_minus_v == pytest.approx([
-        0.33150224761889824,
-        0.2741971168171453,
-        0.23314295407410945,
-        0.4577677756770093,
-        0.34487289523804776,
-        0.0984198887313692,
-        0.2854667714378305,
-        0.38998118936833315,
-        0.022447612542014994,
-        0.4539133776287727,
+        0.3315081606817749,
+        0.2742048700430537,
+        0.2331501773840028,
+        0.4577750013326618,
+        0.34488607340471944,
+        0.09842377150842907,
+        0.2854726927324762,
+        0.38998827189773166,
+        0.022457860681898367,
+        0.4539195381136185,
     ])
 
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -150,8 +150,8 @@ def test_spectrum_filter_range_includes_bracketing_points(mockgetspectrum: mock.
         modelpath=Path(), timestep=0, time=1.0, wavefilter_min=2200.0, wavefilter_max=2800.0
     )
 
-    assert np.array_equal(wavelength, np.array([2000.0, 3000.0]))
-    assert np.array_equal(flux, np.array([2.0, 4.0]))
+    assert np.allclose(wavelength, np.array([2000.0, 3000.0]))
+    assert np.allclose(flux, np.array([2.0, 4.0]))
 
 
 def test_band_magnitude_calculations() -> None:

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -54,7 +54,7 @@ from artistools.misc.fileio import write_parquet_atomic as write_parquet_atomic
 from artistools.misc.fileio import zopen as zopen
 from artistools.misc.fileio import zopen_unshadowed as zopen_unshadowed
 from artistools.misc.fileio import zopenpl as zopenpl
-from artistools.misc.general import df_filter_minmax_bounded as df_filter_minmax_bounded
+from artistools.misc.general import df_filter_minmax_bracketed as df_filter_minmax_bracketed
 from artistools.misc.general import gaussian_filter_wrap as gaussian_filter_wrap
 from artistools.misc.general import parallel_map as parallel_map
 from artistools.misc.general import savgol_filter as savgol_filter

--- a/artistools/misc/general.py
+++ b/artistools/misc/general.py
@@ -13,10 +13,10 @@ import numpy.typing as npt
 import polars as pl
 
 
-def df_filter_minmax_bounded(
+def df_filter_minmax_bracketed(
     df: pl.LazyFrame | pl.DataFrame, colname: str, minval: float | None, maxval: float | None
 ) -> pl.LazyFrame:
-    """Filter a DataFrame to selects rows where the value in colname is between minval and maxval, and also include the closest exterior rows if xmin/xmax are between two rows. This enables linear interpolation at xmin and xmax (if the surrounding values existed in the DataFrame)."""
+    """Filter rows by bounds and include the nearest exterior row at each bound for interpolation."""
     df = df.lazy()
     if minval is maxval is None:
         return df

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -638,21 +638,21 @@ def test_get_file_identity(tmp_path: Path) -> None:
 # --- general.py --------------------------------------------------------------------------------
 
 
-def test_df_filter_minmax_bounded() -> None:
+def test_df_filter_minmax_bracketed() -> None:
     df = pl.DataFrame({"x": list(range(11))})  # 0..10
 
     # both bounds: keep the interior plus the nearest exterior row on each side (for interpolation)
-    bounded = at.misc.df_filter_minmax_bounded(df, "x", 2.5, 7.5).collect()
+    bounded = at.misc.df_filter_minmax_bracketed(df, "x", 2.5, 7.5).collect()
     assert bounded["x"].to_list() == [2, 3, 4, 5, 6, 7, 8]
 
     # no bounds is a pass-through
-    unbounded = at.misc.df_filter_minmax_bounded(df, "x", None, None).collect()
+    unbounded = at.misc.df_filter_minmax_bracketed(df, "x", None, None).collect()
     assert unbounded["x"].to_list() == list(range(11))
 
     # single-sided bounds
-    minonly = at.misc.df_filter_minmax_bounded(df, "x", 2.5, None).collect()
+    minonly = at.misc.df_filter_minmax_bracketed(df, "x", 2.5, None).collect()
     assert minonly["x"].to_list() == [2, 3, 4, 5, 6, 7, 8, 9, 10]
-    maxonly = at.misc.df_filter_minmax_bounded(df, "x", None, 7.5).collect()
+    maxonly = at.misc.df_filter_minmax_bracketed(df, "x", None, 7.5).collect()
     assert maxonly["x"].to_list() == [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -35,7 +35,7 @@ from artistools.misc import add_timedays_arg
 from artistools.misc import add_timeminmax_args
 from artistools.misc import add_timestep_arg
 from artistools.misc import add_viewingangle_args
-from artistools.misc import df_filter_minmax_bounded
+from artistools.misc import df_filter_minmax_bracketed
 from artistools.misc import firstexisting
 from artistools.misc import get_dirbin_labels
 from artistools.misc import get_escaped_arrivalrange
@@ -554,7 +554,7 @@ def plot_artis_spectrum(
         dirbin_dfspec = zip(
             directionbins,
             pl.collect_all([
-                df_filter_minmax_bounded(
+                df_filter_minmax_bracketed(
                     atspectra.get_dfspectrum_x_y_with_units(
                         viewinganglespectra[dirbin], xunit=xunit, yvariable=yvariable, fluxdistance_mpc=args.distmpc
                     ).sort("x"),

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -26,7 +26,7 @@ from artistools.atomic import get_linelist_pldf
 from artistools.atomic import get_nuclides
 from artistools.misc import average_direction_bins
 from artistools.misc import check_averaging_angles
-from artistools.misc import df_filter_minmax_bounded
+from artistools.misc import df_filter_minmax_bracketed
 from artistools.misc import drop_trailing_null_column
 from artistools.misc import firstexisting
 from artistools.misc import get_dirbins
@@ -281,7 +281,7 @@ def get_lambda_bin_edges(
         lambda_min_plot, lambda_max_plot = convert_xlimits_to_lambda_range(xmin_plot, xmax_plot, xunit)
         lambda_bin_edges_fullrange = get_exspec_lambda_bin_edges(modelpath=modelpath, gamma=gamma)
         lambda_bin_edges = (
-            df_filter_minmax_bounded(
+            df_filter_minmax_bracketed(
                 pl.LazyFrame({
                     "lambda_bin_lower": lambda_bin_edges_fullrange[:-1],
                     "lambda_bin_upper": lambda_bin_edges_fullrange[1:],


### PR DESCRIPTION
## Summary

- Retain the nearest spectrum point outside each filter limit for linear interpolation.
- Exclude those exterior points from the integration grid.
- Rename `df_filter_minmax_bounded()` to `df_filter_minmax_bracketed()` across all callers.
- Update the verified B, V, and I band results.
- Add regression coverage for a filter range between two spectrum samples.

## Validation

- `ruff format --check`
- `ruff check --no-fix`
- `pyrefly check`
- `ty check`
- `refurb artistools --quiet -- --follow-imports=skip`
- Light-curve, misc, spectra, and gsinetwork tests (181 passed)
- All commit hooks

The multiprocessing tests require access to system semaphores. They passed outside the filesystem sandbox.

`vulture` reports two mock `return_value` assignments as unused. The mocks consume these values at run time.