### PR TITLE
Draw every plot command on a frame of one size and in one style

### DIFF
--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -1601,8 +1601,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     plotlist = resolve_plotlist(args, estimatorcolumns, modelpath)
 
-    at.set_mpl_style()
-
     assert args.x is not None
     if args.x in {"time", "timestep"}:
         make_figure(

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -9,7 +9,6 @@ from collections.abc import Sequence
 from functools import partial
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -23,6 +22,7 @@ from artistools.constants import Msun_to_g
 from artistools.inputmodel.rprocess_from_trajectory import fix_fortran_exponents
 from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extracted_path
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 ARTIS_colors = ["r", "g", "b", "m", "c", "orange"]  # reddish colors
@@ -71,6 +71,8 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     )
 
     at.addarg_output(parser, kind="folder", default=Path(), helptext="Path for output PDF and parquet files")
+
+    at.addarg_figscale(parser)
 
 
 def append_electroncapture_betaplus_nuclei(df: pl.DataFrame, nuc_dataset: str) -> pl.DataFrame:
@@ -458,9 +460,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
             setparquetpath = parquet_dir / f"decay_powers_{labelfull}.parquet"
             at.write_parquet_atomic(traj_set_df, setparquetpath, replaces=at.get_file_identity(setparquetpath))
 
-        fig, axes = plt.subplots(
-            nrows=2, ncols=1, figsize=(6, 10), tight_layout={"pad": 0.4, "w_pad": 0.0, "h_pad": 0.0}
-        )
+        fig, axesgrid = make_frame_figure(args, rows=2, aspect=0.913)
+        axes = axesgrid[:, 0]
         ax0 = axes[0]
         ax0.axhline(y=0.45, color=ARTIS_colors[2], linestyle="dotted", label=r"Barnes+16 $\gamma$")
         ax0.axhline(y=0.20, color=ARTIS_colors[0], linestyle="dotted", label=r"Barnes+16 $e^{-}$")

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -21,6 +21,7 @@ from artistools.constants import MEV_to_erg
 from artistools.constants import Msun_to_g
 from artistools.inputmodel.rprocess_from_trajectory import fix_fortran_exponents
 from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extracted_path
+from artistools.misc import addarg_figscale
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
@@ -73,7 +74,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     at.addarg_output(parser, kind="folder", default=Path(), helptext="Path for output PDF and parquet files")
 
-    at.addarg_figscale(parser)
+    addarg_figscale(parser)
 
 
 def append_electroncapture_betaplus_nuclei(df: pl.DataFrame, nuc_dataset: str) -> pl.DataFrame:
@@ -504,15 +505,13 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         )
         ax1.set_ylabel("Energy release rate [erg/s]")
         ax1.set_yscale("log")
-        set_legend(ax1, args)
-
         for ax in axes:
             set_legend(ax, args)
-            ax.set_xlabel("Time [days]")
             ax.set_xscale("log")
+        axes[-1].set_xlabel("Time [days]")
 
         outfilepath = args.outputfile / f"beta_release_ratios_tot_{nuc_dataset}_Ye{label}.pdf"
-        save_figure(fig, outfilepath, bbox_inches="tight")
+        save_figure(fig, outfilepath)
 
 
 if __name__ == "__main__":

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -24,6 +24,7 @@ from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extrac
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 ARTIS_colors = ["r", "g", "b", "m", "c", "orange"]  # reddish colors
 
@@ -503,10 +504,10 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         )
         ax1.set_ylabel("Energy release rate [erg/s]")
         ax1.set_yscale("log")
-        ax1.legend()
+        set_legend(ax1, args)
 
         for ax in axes:
-            ax.legend()
+            set_legend(ax, args)
             ax.set_xlabel("Time [days]")
             ax.set_xscale("log")
 

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -10,7 +10,6 @@ from collections.abc import Sequence
 from functools import partial
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -24,6 +23,7 @@ from artistools.inputmodel.rprocess_from_trajectory import fix_fortran_exponents
 from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extracted_path
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 
@@ -229,14 +229,8 @@ def plot_qdot(
     else:
         dfgsiglobalheating = None
 
-    fig, axis = plt.subplots(
-        nrows=1,
-        ncols=1,
-        sharex=True,
-        sharey=False,
-        figsize=(6, 1 + 3),
-        tight_layout={"pad": 0.4, "w_pad": 0.0, "h_pad": 0.0},
-    )
+    fig, axesgrid = make_frame_figure(aspect=0.676)
+    axis = axesgrid[0][0]
 
     axis.set_xlabel("Time [days]")
     axis.set_yscale("log")
@@ -358,18 +352,8 @@ def plot_cell_abund_evolution(
     else:
         df_gsi_abunds = None
 
-    fig, axes = plt.subplots(
-        nrows=len(arr_species),
-        ncols=1,
-        sharex=False,
-        sharey=False,
-        figsize=(6, 1 + 2.0 * len(arr_species)),
-        tight_layout={"pad": 0.4, "w_pad": 0.0, "h_pad": 0.0},
-    )
-    if len(arr_species) == 1:
-        axes = np.array([axes])
-    fig.subplots_adjust(top=0.8)
-    assert isinstance(axes, np.ndarray)
+    fig, axesgrid = make_frame_figure(rows=len(arr_species), aspect=0.383, sharex=False)
+    axes = axesgrid[:, 0]
     axes[-1].set_xlabel("Time [days]")
     axis = axes[0]
     print(f"{'':7s}  gsi_abund artis_abund")

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -302,7 +302,7 @@ def plot_qdot(
             label=r"$\dot{Q}_{sponfis}$ ARTIS",
         )
 
-    set_legend(axis, loc="best", frameon=False, handlelength=2, ncol=3, numpoints=1)
+    set_legend(axis, ncol=3)
 
     axis.autoscale(enable=True, axis="both")
     axis.set_xmargin(0.02)
@@ -393,14 +393,14 @@ def plot_cell_abund_evolution(
         else:
             print(" [no ARTIS data]")
 
-        set_legend(axis, loc="best", frameon=False, handlelength=1, ncol=1, numpoints=1)
+        set_legend(axis, handlelength=1)
 
         axis.autoscale(enable=True, axis="both")
         axis.set_xmargin(0.02)
         axis.set_ymargin(0.05)
 
     strcell = f"cell {mgi}" if mgi >= 0 else "global"
-    fig.suptitle(f"{at.get_model_name(modelpath)} {strcell}", y=0.999)
+    axes[0].set_title(f"{at.get_model_name(modelpath)} {strcell}")
     save_figure(fig, pdfoutpath, format="pdf")
 
 

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -25,6 +25,7 @@ from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 
 def get_abundance_correction_factors(
@@ -301,7 +302,7 @@ def plot_qdot(
             label=r"$\dot{Q}_{sponfis}$ ARTIS",
         )
 
-    axis.legend(loc="best", frameon=False, handlelength=2, ncol=3, numpoints=1)
+    set_legend(axis, loc="best", frameon=False, handlelength=2, ncol=3, numpoints=1)
 
     axis.autoscale(enable=True, axis="both")
     axis.set_xmargin(0.02)
@@ -392,7 +393,7 @@ def plot_cell_abund_evolution(
         else:
             print(" [no ARTIS data]")
 
-        axis.legend(loc="best", frameon=False, handlelength=1, ncol=1, numpoints=1)
+        set_legend(axis, loc="best", frameon=False, handlelength=1, ncol=1, numpoints=1)
 
         axis.autoscale(enable=True, axis="both")
         axis.set_xmargin(0.02)

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -229,7 +229,7 @@ def plot_qdot(
     else:
         dfgsiglobalheating = None
 
-    fig, axesgrid = make_frame_figure(aspect=0.676)
+    fig, axesgrid = make_frame_figure()
     axis = axesgrid[0][0]
 
     axis.set_xlabel("Time [days]")

--- a/artistools/hesma_scripts.py
+++ b/artistools/hesma_scripts.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import matplotlib.axes as mplax
-import matplotlib.figure as mplfig
 import numpy as np
 import polars as pl
 import polars.selectors as cs
@@ -18,6 +17,7 @@ from artistools.misc import addarg_unsupported
 from artistools.misc import require_action
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_or_show
+from artistools.plottools import set_legend
 
 
 def plot_hesma_spectrum(timeavg: float, axes: Sequence[mplax.Axes], hesmafile: Path | str) -> None:
@@ -37,7 +37,7 @@ def plot_hesma_spectrum(timeavg: float, axes: Sequence[mplax.Axes], hesmafile: P
         ax.plot(hesma_spec["0.00"], hesma_spec[closest_time], label="HESMA model")
 
 
-def plothesmaresspec(fig: mplfig.Figure, ax: mplax.Axes, specfiles: Sequence[Path | str]) -> None:
+def plothesmaresspec(ax: mplax.Axes, specfiles: Sequence[Path | str]) -> None:
     """Plot the first five direction bins of each HESMA direction-resolved spectrum file."""
     for specfilename in specfiles:
         specdata = at.read_wsv(specfilename, has_header=False).cast(pl.Float64)
@@ -59,7 +59,7 @@ def plothesmaresspec(fig: mplfig.Figure, ax: mplax.Axes, specfiles: Sequence[Pat
                 res_specdata[dirbin]["lambda"], res_specdata[dirbin]["11.7935"] * (1e-5) ** 2, label=f"hesma {dirbin}"
             )
 
-    fig.legend()
+    set_legend(ax)
 
 
 def make_hesma_vspecfiles(modelpath: Path, outpath: Path | None = None) -> None:
@@ -156,7 +156,7 @@ def plot_hesma_peakmag_dm15_dm40(pathtofiles: Path | str, outputfile: Path | str
     axis.invert_yaxis()
     axis.set_xlabel(r"$\Delta m_{15}$")
     axis.set_ylabel("Peak magnitude")
-    axis.legend()
+    set_legend(axis)
 
     save_or_show(fig, outputfile)
 
@@ -254,7 +254,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     else:
         fig, axesgrid = make_frame_figure()
         axis = axesgrid[0][0]
-        plothesmaresspec(fig, axis, require(args.hesmafile, "-hesmafile", args.action))
+        plothesmaresspec(axis, require(args.hesmafile, "-hesmafile", args.action))
         save_or_show(fig, args.plotfile)
 
 

--- a/artistools/hesma_scripts.py
+++ b/artistools/hesma_scripts.py
@@ -146,7 +146,7 @@ def make_hesma_peakmag_dm15_dm40(
 
 def plot_hesma_peakmag_dm15_dm40(pathtofiles: Path | str, outputfile: Path | str | None = None) -> None:
     """Plot peak magnitude against dm15 for every width-luminosity file in a folder."""
-    fig, axesgrid = make_frame_figure(aspect=0.770)
+    fig, axesgrid = make_frame_figure()
     axis = axesgrid[0][0]
     for filepath in sorted(Path(pathtofiles).iterdir()):
         print(f"Reading {filepath}")
@@ -242,7 +242,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         plot_hesma_peakmag_dm15_dm40(require(args.pathtofiles, "-pathtofiles", args.action), args.plotfile)
 
     elif args.action == "plotspectrum":
-        fig, axesgrid = make_frame_figure(aspect=0.770)
+        fig, axesgrid = make_frame_figure()
         axis = axesgrid[0][0]
         plot_hesma_spectrum(
             require(args.timedays, "-timedays", args.action),
@@ -252,7 +252,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         save_or_show(fig, args.plotfile)
 
     else:
-        fig, axesgrid = make_frame_figure(aspect=0.770)
+        fig, axesgrid = make_frame_figure()
         axis = axesgrid[0][0]
         plothesmaresspec(fig, axis, require(args.hesmafile, "-hesmafile", args.action))
         save_or_show(fig, args.plotfile)

--- a/artistools/hesma_scripts.py
+++ b/artistools/hesma_scripts.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import matplotlib.axes as mplax
 import matplotlib.figure as mplfig
-import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 import polars.selectors as cs
@@ -17,6 +16,7 @@ from artistools.misc import addarg_action
 from artistools.misc import addarg_timedays
 from artistools.misc import addarg_unsupported
 from artistools.misc import require_action
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_or_show
 
 
@@ -146,7 +146,8 @@ def make_hesma_peakmag_dm15_dm40(
 
 def plot_hesma_peakmag_dm15_dm40(pathtofiles: Path | str, outputfile: Path | str | None = None) -> None:
     """Plot peak magnitude against dm15 for every width-luminosity file in a folder."""
-    fig, axis = plt.subplots()
+    fig, axesgrid = make_frame_figure(aspect=0.770)
+    axis = axesgrid[0][0]
     for filepath in sorted(Path(pathtofiles).iterdir()):
         print(f"Reading {filepath}")
         dfwidthlum = at.read_wsv(filepath)
@@ -241,7 +242,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         plot_hesma_peakmag_dm15_dm40(require(args.pathtofiles, "-pathtofiles", args.action), args.plotfile)
 
     elif args.action == "plotspectrum":
-        fig, axis = plt.subplots()
+        fig, axesgrid = make_frame_figure(aspect=0.770)
+        axis = axesgrid[0][0]
         plot_hesma_spectrum(
             require(args.timedays, "-timedays", args.action),
             [axis],
@@ -250,7 +252,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         save_or_show(fig, args.plotfile)
 
     else:
-        fig, axis = plt.subplots()
+        fig, axesgrid = make_frame_figure(aspect=0.770)
+        axis = axesgrid[0][0]
         plothesmaresspec(fig, axis, require(args.hesmafile, "-hesmafile", args.action))
         save_or_show(fig, args.plotfile)
 

--- a/artistools/inputmodel/downscale3dgrid.py
+++ b/artistools/inputmodel/downscale3dgrid.py
@@ -11,6 +11,7 @@ from artistools.constants import day_to_s
 from artistools.inputmodel.inputmodel_misc import save_initelemabundances
 from artistools.inputmodel.inputmodel_misc import save_modeldata
 from artistools.plottools import save_figure
+from artistools.plottools import set_mpl_style
 
 
 def make_downscaled_3d_grid(
@@ -120,6 +121,7 @@ def make_downscaled_3d_grid(
         import matplotlib.pyplot as plt
         from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+        set_mpl_style()
         fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(6.8 * 1.5, 4.8))
         assert isinstance(axes, np.ndarray)
         (ax1, ax2) = axes

--- a/artistools/inputmodel/downscale3dgrid.py
+++ b/artistools/inputmodel/downscale3dgrid.py
@@ -149,6 +149,6 @@ def make_downscaled_3d_grid(
         fig.tight_layout()
 
         diagnosticpath = outputfolder / "downscaled_density_diagnostic.png"
-        save_figure(fig, diagnosticpath, dpi=300, bbox_inches="tight")
+        save_figure(fig, diagnosticpath, dpi=300)
 
     return outputfolder

--- a/artistools/inputmodel/energyinputfiles.py
+++ b/artistools/inputmodel/energyinputfiles.py
@@ -8,7 +8,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import matplotlib.axes as mplax
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -16,8 +15,10 @@ import polars as pl
 import artistools as at
 from artistools.constants import day_to_s
 from artistools.misc import addarg_action
+from artistools.misc import addarg_figscale
 from artistools.misc import require_action
 from artistools.misc import resolve_outputfile
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_or_show
 
 
@@ -237,6 +238,8 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     )
     at.addarg_modelpath(parser, default=Path())
     at.addarg_output(parser, kind="file", helptext="Path for the plot, or omit to show it interactively")
+
+    addarg_figscale(parser)
     parser.add_argument("-trajthermofile", type=Path, help="Trajectory energy_thermo.dat (fromtrajectory)")
 
 
@@ -249,7 +252,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     modelpath = Path(args.modelpath)
 
     if args.action == "plotrate":
-        fig, axis = plt.subplots()
+        fig, axesgrid = make_frame_figure(args, aspect=0.770)
+        axis = axesgrid[0][0]
         plot_energy_rate(modelpath, axis)
         axis.set_xlabel("time [days]")
         axis.set_ylabel("Nuclear heating power [erg/s]")

--- a/artistools/inputmodel/energyinputfiles.py
+++ b/artistools/inputmodel/energyinputfiles.py
@@ -252,7 +252,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     modelpath = Path(args.modelpath)
 
     if args.action == "plotrate":
-        fig, axesgrid = make_frame_figure(args, aspect=0.770)
+        fig, axesgrid = make_frame_figure(args)
         axis = axesgrid[0][0]
         plot_energy_rate(modelpath, axis)
         axis.set_xlabel("time [days]")

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -172,7 +172,7 @@ def append_cell_to_output(
 
 def make_plot(xlist: list[float], ylists: list[list[float]], pdfoutputfile: str) -> None:
     """Plot density and the Ni56 and Co mass fractions of the slice against velocity, and save it as a PDF."""
-    fig, axesgrid = make_frame_figure(aspect=0.676)
+    fig, axesgrid = make_frame_figure()
     axis = axesgrid[0][0]
     axis.set_xlabel(r"Velocity [km/s]")
     axis.set_ylabel(r"Density [g/cm$^3$] or mass fraction")

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -13,6 +13,7 @@ from artistools.constants import km_to_cm
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 
 def addargs(parser: argparse.ArgumentParser) -> None:
@@ -180,7 +181,7 @@ def make_plot(xlist: list[float], ylists: list[list[float]], pdfoutputfile: str)
     for ylist, ylabel in zip(ylists, ylabels, strict=False):
         axis.plot(xlist, ylist, linewidth=1.5, label=ylabel)
     axis.set_yscale("log", nonpositive="clip")
-    axis.legend(loc="best", handlelength=2, frameon=False, numpoints=1, prop={"size": 10})
+    set_legend(axis, loc="best", handlelength=2, frameon=False, numpoints=1)
     save_figure(fig, pdfoutputfile, format="pdf")
 
 

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -7,12 +7,11 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-
 import artistools as at
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 
@@ -173,9 +172,8 @@ def append_cell_to_output(
 
 def make_plot(xlist: list[float], ylists: list[list[float]], pdfoutputfile: str) -> None:
     """Plot density and the Ni56 and Co mass fractions of the slice against velocity, and save it as a PDF."""
-    fig, axis = plt.subplots(
-        nrows=1, ncols=1, sharey=True, figsize=(6, 4), tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0}
-    )
+    fig, axesgrid = make_frame_figure(aspect=0.676)
+    axis = axesgrid[0][0]
     axis.set_xlabel(r"Velocity [km/s]")
     axis.set_ylabel(r"Density [g/cm$^3$] or mass fraction")
     ylabels = [r"$\rho$", "fNi56", "fCo"]

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -181,7 +181,7 @@ def make_plot(xlist: list[float], ylists: list[list[float]], pdfoutputfile: str)
     for ylist, ylabel in zip(ylists, ylabels, strict=False):
         axis.plot(xlist, ylist, linewidth=1.5, label=ylabel)
     axis.set_yscale("log", nonpositive="clip")
-    set_legend(axis, loc="best", handlelength=2, frameon=False, numpoints=1)
+    set_legend(axis)
     save_figure(fig, pdfoutputfile, format="pdf")
 
 

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -18,6 +18,7 @@ from artistools.misc import addarg_seriesstyle
 from artistools.misc import addarg_show
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 
 def addargs(parser: argparse.ArgumentParser) -> None:
@@ -136,7 +137,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     axes[1].set_ylabel(r"$\Delta$M/$\Delta v$ $\left[\mathrm{M}_\odot/c\right]$")
     if args.plotye:
         axes[2].set_ylabel(r"Electron fraction Ye")
-    axes[1].legend(frameon=False)
+    set_legend(axes[1], args, frameon=False)
 
     axes[0].set_ylim(bottom=0.0)
     axes[1].set_ylim(bottom=0.0)

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -45,7 +45,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     addarg_output(parser, kind="file", defaultname="densityprofile.pdf")
 
-    addarg_figscale(parser)
+    addarg_figscale(parser, helptext="Scale factor for plot area. 1.0 fills one column of a page")
     addarg_show(parser)
 
 
@@ -137,7 +137,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     axes[1].set_ylabel(r"$\Delta$M/$\Delta v$ $\left[\mathrm{M}_\odot/c\right]$")
     if args.plotye:
         axes[2].set_ylabel(r"Electron fraction Ye")
-    set_legend(axes[1], args, frameon=False)
+    set_legend(axes[1], args)
 
     axes[0].set_ylim(bottom=0.0)
     axes[1].set_ylim(bottom=0.0)

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -54,7 +54,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     at.plottools.set_mpl_style()
 
-    fig, axesgrid = make_frame_figure(args, rows=3 if args.plotye else 2, aspect=0.45)
+    fig, axesgrid = make_frame_figure(args, rows=3 if args.plotye else 2, aspect=0.45, fullwidth=False)
     axes = axesgrid[:, 0]
 
     args.modelpath = at.normalize_path_list(args.modelpath)

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -52,8 +52,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     """Plot the radial density profile of an ARTIS model."""
     args = at.parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
 
-    at.plottools.set_mpl_style()
-
     fig, axesgrid = make_frame_figure(args, rows=3 if args.plotye else 2, aspect=0.45, fullwidth=False)
     axes = axesgrid[:, 0]
 

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -5,18 +5,18 @@ import argparse
 import typing as t
 from collections.abc import Sequence
 
-import matplotlib.pyplot as plt
-import numpy as np
 import polars as pl
 
 import artistools as at
 from artistools.constants import C_cm_per_s
 from artistools.constants import Msun_to_g
 from artistools.misc import addarg_axislimits
+from artistools.misc import addarg_figscale
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
 from artistools.misc import addarg_seriesstyle
 from artistools.misc import addarg_show
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 
@@ -43,6 +43,8 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--plotye", action="store_true", help="Plot electron fraction versus velocity")
 
     addarg_output(parser, kind="file", defaultname="densityprofile.pdf")
+
+    addarg_figscale(parser)
     addarg_show(parser)
 
 
@@ -52,15 +54,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     at.plottools.set_mpl_style()
 
-    fig, axes = plt.subplots(
-        nrows=3 if args.plotye else 2,
-        ncols=1,
-        sharex=True,
-        sharey=False,
-        figsize=(4, 4),
-        tight_layout={"pad": 0.5, "w_pad": 0.5, "h_pad": 0.0},
-    )
-    assert isinstance(axes, np.ndarray)
+    fig, axesgrid = make_frame_figure(args, rows=3 if args.plotye else 2, aspect=0.45)
+    axes = axesgrid[:, 0]
 
     args.modelpath = at.normalize_path_list(args.modelpath)
 

--- a/artistools/inputmodel/plotinitialabundances.py
+++ b/artistools/inputmodel/plotinitialabundances.py
@@ -7,12 +7,13 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import polars as pl
 import polars.selectors as cs
 
 import artistools as at
+from artistools.misc import addarg_figscale
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 
@@ -21,7 +22,8 @@ def make_plot(args: argparse.Namespace) -> None:
     args.xaxis = {"Z": "atomicnumber", "A": "massnumber"}.get(args.xaxis, args.xaxis)
 
     at.plottools.set_mpl_style()
-    fig, ax = plt.subplots(tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0})
+    fig, axesgrid = make_frame_figure(args, aspect=0.770)
+    ax = axesgrid[0][0]
 
     for model_path in args.modelpath:
         df, _ = at.inputmodel.get_modeldata(modelpath=Path(model_path), derived_cols=["mass_g"])
@@ -81,6 +83,8 @@ def make_plot(args: argparse.Namespace) -> None:
 def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     at.addarg_output(parser, kind="file", default=Path())
+
+    addarg_figscale(parser)
     at.addarg_modelpath(
         parser,
         positional=True,

--- a/artistools/inputmodel/plotinitialabundances.py
+++ b/artistools/inputmodel/plotinitialabundances.py
@@ -15,6 +15,7 @@ from artistools.misc import addarg_figscale
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 
 def make_plot(args: argparse.Namespace) -> None:
@@ -71,7 +72,7 @@ def make_plot(args: argparse.Namespace) -> None:
 
     ax.set_ylim(*((1e-5, 1.0) if args.yaxis == "massfraction" else (1e-7, 0.1)))
 
-    ax.legend()
+    set_legend(ax, args)
 
     strxaxis = "A" if args.xaxis == "massnumber" else "Z"
     stryaxis = "X" if args.yaxis == "massfraction" else "abundance"

--- a/artistools/inputmodel/plotinitialabundances.py
+++ b/artistools/inputmodel/plotinitialabundances.py
@@ -21,7 +21,6 @@ def make_plot(args: argparse.Namespace) -> None:
     """Plot the mass-weighted abundances of every model in args.modelpath and save the figure."""
     args.xaxis = {"Z": "atomicnumber", "A": "massnumber"}.get(args.xaxis, args.xaxis)
 
-    at.plottools.set_mpl_style()
     fig, axesgrid = make_frame_figure(args, aspect=0.770)
     ax = axesgrid[0][0]
 

--- a/artistools/inputmodel/plotinitialabundances.py
+++ b/artistools/inputmodel/plotinitialabundances.py
@@ -21,7 +21,7 @@ def make_plot(args: argparse.Namespace) -> None:
     """Plot the mass-weighted abundances of every model in args.modelpath and save the figure."""
     args.xaxis = {"Z": "atomicnumber", "A": "massnumber"}.get(args.xaxis, args.xaxis)
 
-    fig, axesgrid = make_frame_figure(args, aspect=0.770)
+    fig, axesgrid = make_frame_figure(args)
     ax = axesgrid[0][0]
 
     for model_path in args.modelpath:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -52,6 +52,7 @@ from artistools.misc import print_product
 from artistools.misc import print_theta_phi_definitions
 from artistools.misc import print_warning
 from artistools.misc import trim_or_pad
+from artistools.plottools import add_cax_for_fixed_frames
 from artistools.plottools import AxesTree
 from artistools.plottools import get_series_colors
 from artistools.plottools import get_unused_colors
@@ -818,7 +819,11 @@ def get_linelabel(
 
 
 def set_lightcurveplot_legend(ax: AxesTree, args: argparse.Namespace) -> None:
-    """Add the legend, placing it on args.legendsubplotnumber when the figure has subplots."""
+    """Add the legend, and place it on args.legendsubplotnumber when the figure has subplots."""
+    if args.nolegend:
+        # set_legend would draw nothing, and the subplot index below must not run for it
+        return
+
     if args.subplots:
         axis = iter_axes(ax)[args.legendsubplotnumber]
         set_legend(axis, args, loc=args.legendposition, frameon=args.legendframeon, ncol=args.ncolslegend)
@@ -916,13 +921,24 @@ def make_colorbar_viewingangles(
 
     # colorbar takes a flat sequence of axes, thus flatten the grid that subplots() gives
     axeslist = iter_axes(ax) if ax is not None else None
-    if fig:
+    targetfig = fig
+    if targetfig is None:
+        assert axeslist is not None
+        targetfig = axeslist[0].get_figure()
+    assert isinstance(targetfig, mplfig.Figure)
+    if any(axis.get_axes_locator() is not None for axis in targetfig.axes):
+        # a frame that a Divider places takes back the space that colorbar steals, thus the
+        # colorbar gets its own axes on a grown page
+        cax = add_cax_for_fixed_frames(targetfig, horizontal=fig is not None)
+        cbar = targetfig.colorbar(scaledmap, cax=cax, orientation="horizontal" if fig is not None else "vertical")
+        if fig is not None:
+            cbar.ax.xaxis.set_ticks_position("top")
+            cbar.ax.xaxis.set_label_position("top")
+    elif fig:
         cbar = fig.colorbar(scaledmap, orientation="horizontal", location="top", pad=0.10, ax=axeslist, shrink=0.95)
     else:
         assert axeslist is not None
-        axisfigure = axeslist[0].get_figure()
-        assert axisfigure is not None
-        cbar = axisfigure.colorbar(scaledmap, ax=axeslist)
+        cbar = targetfig.colorbar(scaledmap, ax=axeslist)
     if label:
         cbar.set_label(label, rotation=0)
     cbar.locator = mplticker.FixedLocator(ticklocs)

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -819,15 +819,14 @@ def get_linelabel(
 
 def set_lightcurveplot_legend(ax: AxesTree, args: argparse.Namespace) -> None:
     """Add the legend, placing it on args.legendsubplotnumber when the figure has subplots."""
-    if args.nolegend:
-        return
-
     if args.subplots:
         axis = iter_axes(ax)[args.legendsubplotnumber]
-        axis.legend(loc=args.legendposition, frameon=args.legendframeon, ncol=args.ncolslegend)
+        set_legend(axis, args, loc=args.legendposition, frameon=args.legendframeon, ncol=args.ncolslegend)
     else:
         assert isinstance(ax, mplax.Axes)
-        ax.legend(loc=args.legendposition, frameon=args.legendframeon, ncol=args.ncolslegend, handlelength=0.7)
+        set_legend(
+            ax, args, loc=args.legendposition, frameon=args.legendframeon, ncol=args.ncolslegend, handlelength=0.7
+        )
 
 
 def set_lightcurve_plot_labels(

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -1032,8 +1032,6 @@ def make_band_lightcurves_plot(
             bandnames, reflightcurve, args.refspeccolors[refindex], args.refspecmarkers[refindex], ax
         )
 
-    at.set_mpl_style()
-
     ax = at.plottools.set_axis_properties(ax, args, xlimits=(args.timemin, args.timemax, "-timemin"))
     fig, ax = set_lightcurve_plot_labels(fig, ax, args, band_name=bandnames[0] if bandnames else None)
     set_lightcurveplot_legend(ax, args)
@@ -1578,8 +1576,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     if getattr(args, "average_every_tenth_viewing_angle", False):
         print_warning("--average_every_tenth_viewing_angle is deprecated. use --average_over_phi_angle instead")
         args.average_over_phi_angle = True
-
-    at.set_mpl_style()
 
     args.modelpath = at.normalize_path_list(args.modelpath)
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1319,11 +1319,11 @@ def run_set_scatterplot_plot_params(
     magnitudes: Sequence[float], ymin: float | None, ymax: float | None
 ) -> tuple[float, float, float]:
     """Plot the magnitudes, apply the shared scatter plot setup, and return xmax, ymin, ymax."""
-    fig, axis = plt.subplots()
+    _fig, axis = plt.subplots()
     axis.plot([1.0, 10.0], list(magnitudes))
     args = argparse.Namespace(colouratpeak=False, ymin=ymin, ymax=ymax, colorbarcostheta=False, colorbarphi=False)
 
-    viewingangleanalysis.set_scatterplot_plot_params(fig, axis, args)
+    viewingangleanalysis.set_scatterplot_plot_params(axis, args)
 
     ymin, ymax = axis.get_ylim()
     return axis.get_xlim()[1], ymin, ymax

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -297,7 +297,7 @@ def make_plot_test_viewing_angle_fit(
     args: argparse.Namespace,
 ) -> None:
     """Plot a band light curve against its fit, so the quality of the fit can be checked by eye."""
-    fig, axesgrid = make_frame_figure(aspect=0.770)
+    fig, axesgrid = make_frame_figure()
     axis = axesgrid[0][0]
     axis.plot(time, magnitude)
     axis.plot(xfit, fxfit)
@@ -380,7 +380,7 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
     modelnames: Sequence[str], key: str, args: argparse.Namespace
 ) -> None:
     """Scatter plot peak magnitude against rise time or decline rate, one point per direction bin per model."""
-    fig, axesgrid = make_frame_figure(aspect=0.766)
+    fig, axesgrid = make_frame_figure()
     ax = axesgrid[0][0]
 
     for ii, modelname in enumerate(modelnames):
@@ -453,7 +453,7 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
 
 def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
     """Scatter plot the colour at peak against the peak magnitude, one point per direction bin per model."""
-    fig, axesgrid = make_frame_figure(args, aspect=0.766)
+    fig, axesgrid = make_frame_figure(args)
     ax = axesgrid[0][0]
 
     for modelnumber, modelpath in enumerate(args.modelpath):
@@ -635,7 +635,7 @@ def peakmag_risetime_declinerate_init(
 
 def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Namespace) -> None:
     """Plot the luminosity of each direction bin at one time, to show the angular brightness variation."""
-    fig, axesgrid = make_frame_figure(args, aspect=0.627)
+    fig, axesgrid = make_frame_figure(args)
     axis = axesgrid[0][0]
 
     costheta_viewing_angle_bins, phi_viewing_angle_bins = at.get_costhetabin_phibin_labels(usedegrees=args.usedegrees)

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import matplotlib.axes as mplax
 import matplotlib.figure as mplfig
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -18,6 +17,7 @@ import artistools as at
 from artistools.lightcurve.lightcurve import FILTERNAME_ALIASES
 from artistools.misc import get_series_label
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 from artistools.plottools import set_legend
 
@@ -297,7 +297,8 @@ def make_plot_test_viewing_angle_fit(
     args: argparse.Namespace,
 ) -> None:
     """Plot a band light curve against its fit, so the quality of the fit can be checked by eye."""
-    fig, axis = plt.subplots()
+    fig, axesgrid = make_frame_figure(aspect=0.770)
+    axis = axesgrid[0][0]
     axis.plot(time, magnitude)
     axis.plot(xfit, fxfit)
 
@@ -379,9 +380,8 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
     modelnames: Sequence[str], key: str, args: argparse.Namespace
 ) -> None:
     """Scatter plot peak magnitude against rise time or decline rate, one point per direction bin per model."""
-    fig, ax = plt.subplots(
-        nrows=1, ncols=1, sharex=True, figsize=(8, 6), tight_layout={"pad": 0.5, "w_pad": 1.5, "h_pad": 0.3}
-    )
+    fig, axesgrid = make_frame_figure(aspect=0.766)
+    ax = axesgrid[0][0]
 
     for ii, modelname in enumerate(modelnames):
         viewing_angle_plot_data = at.read_wsv(f"{key}band_{modelname!s}_viewing_angle_data.txt")
@@ -453,9 +453,8 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
 
 def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
     """Scatter plot the colour at peak against the peak magnitude, one point per direction bin per model."""
-    fig, ax = plt.subplots(
-        nrows=1, ncols=1, sharex=True, figsize=(8, 6), tight_layout={"pad": 0.5, "w_pad": 1.5, "h_pad": 0.3}
-    )
+    fig, axesgrid = make_frame_figure(args, aspect=0.766)
+    ax = axesgrid[0][0]
 
     for modelnumber, modelpath in enumerate(args.modelpath):
         modelname = at.get_model_name(modelpath)
@@ -636,9 +635,8 @@ def peakmag_risetime_declinerate_init(
 
 def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Namespace) -> None:
     """Plot the luminosity of each direction bin at one time, to show the angular brightness variation."""
-    fig, axis = plt.subplots(
-        nrows=1, ncols=1, sharey=True, figsize=(8, 5), tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0}
-    )
+    fig, axesgrid = make_frame_figure(args, aspect=0.627)
+    axis = axesgrid[0][0]
 
     costheta_viewing_angle_bins, phi_viewing_angle_bins = at.get_costhetabin_phibin_labels(usedegrees=args.usedegrees)
     scaledmap = at.lightcurve.plotlightcurve.make_colorbar_viewingangles_colormap()

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -440,8 +440,8 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
     if args.make_viewing_angle_peakmag_risetime_scatter_plot:
         xlabel = "Rise Time [days]"
 
-    ax.set_xlabel(xlabel, fontsize=14)
-    ax.set_ylabel(rf"M$_{{\mathrm{{{key}}}}}$, max", fontsize=14)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(rf"M$_{{\mathrm{{{key}}}}}$, max")
     set_scatterplot_plot_params(fig, ax, args)
 
     if args.make_viewing_angle_peakmag_delta_m15_scatter_plot:
@@ -501,9 +501,9 @@ def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
         zorder=-1,
     )
 
-    ax.legend(loc="upper right", fontsize=8, ncol=1, columnspacing=1, frameon=False)
-    ax.set_xlabel(f"{bands[0]}-{bands[1]} at {bands[0]}max", fontsize=14)
-    ax.set_ylabel(f"{bands[0]}max", fontsize=14)
+    set_legend(ax, args, loc="upper right", ncol=1, columnspacing=1, frameon=False)
+    ax.set_xlabel(f"{bands[0]}-{bands[1]} at {bands[0]}max")
+    ax.set_ylabel(f"{bands[0]}max")
     set_scatterplot_plot_params(fig, ax, args)
     plotname = f"plotviewinganglecolour{bands[0]}-{bands[1]}.pdf"
     save_figure(fig, plotname, format="pdf")

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -7,7 +7,6 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import matplotlib.axes as mplax
-import matplotlib.figure as mplfig
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -297,7 +296,7 @@ def make_plot_test_viewing_angle_fit(
     args: argparse.Namespace,
 ) -> None:
     """Plot a band light curve against its fit, so the quality of the fit can be checked by eye."""
-    fig, axesgrid = make_frame_figure()
+    fig, axesgrid = make_frame_figure(args)
     axis = axesgrid[0][0]
     axis.plot(time, magnitude)
     axis.plot(xfit, fxfit)
@@ -315,7 +314,6 @@ def make_plot_test_viewing_angle_fit(
     axis.axvline(x=tmax_polyfit, color="black", linestyle="--")
     axis.axvline(x=float(time_after15days_polyfit), color="black", linestyle="--")
     print("time after 15 days polyfit = ", time_after15days_polyfit)
-    fig.tight_layout()
     plotname = f"{key}_band_{modelname}_viewing_angle{angle!s}.png"
     save_figure(fig, plotname)
 
@@ -357,7 +355,7 @@ def update_plotkwargs_for_viewingangle_colorbar(
     return plotkwargsviewingangles
 
 
-def set_scatterplot_plot_params(fig: mplfig.Figure, axis: mplax.Axes, args: argparse.Namespace) -> None:
+def set_scatterplot_plot_params(axis: mplax.Axes, args: argparse.Namespace) -> None:
     """Set the axis limits, labels, and legend shared by the viewing angle scatter plots."""
     # the x axis here is a rise time or a decline rate, not a time since explosion, so it takes no limit
     # from the command line: this parser spells -xmin/-xmax as aliases of the -timemin/-timemax time range
@@ -369,7 +367,6 @@ def set_scatterplot_plot_params(fig: mplfig.Figure, axis: mplax.Axes, args: argp
     axis.minorticks_on()
     axis.tick_params(axis="both", which="minor", top=False, right=False, length=5, width=2, labelsize=12)
     axis.tick_params(axis="both", which="major", top=False, right=False, length=8, width=2, labelsize=12)
-    fig.tight_layout()
 
     if args.colorbarcostheta or args.colorbarphi:
         scaledmap = at.lightcurve.plotlightcurve.make_colorbar_viewingangles_colormap()
@@ -380,7 +377,7 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
     modelnames: Sequence[str], key: str, args: argparse.Namespace
 ) -> None:
     """Scatter plot peak magnitude against rise time or decline rate, one point per direction bin per model."""
-    fig, axesgrid = make_frame_figure()
+    fig, axesgrid = make_frame_figure(args)
     ax = axesgrid[0][0]
 
     for ii, modelname in enumerate(modelnames):
@@ -442,7 +439,7 @@ def make_viewing_angle_risetime_peakmag_delta_m15_scatter_plot(
 
     ax.set_xlabel(xlabel)
     ax.set_ylabel(rf"M$_{{\mathrm{{{key}}}}}$, max")
-    set_scatterplot_plot_params(fig, ax, args)
+    set_scatterplot_plot_params(ax, args)
 
     if args.make_viewing_angle_peakmag_delta_m15_scatter_plot:
         filename = rf"{key}_band_{modelnames[0]}_dm15_peakmag.pdf"
@@ -501,10 +498,10 @@ def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
         zorder=-1,
     )
 
-    set_legend(ax, args, loc="upper right", ncol=1, columnspacing=1, frameon=False)
+    set_legend(ax, args, loc="upper right")
     ax.set_xlabel(f"{bands[0]}-{bands[1]} at {bands[0]}max")
     ax.set_ylabel(f"{bands[0]}max")
-    set_scatterplot_plot_params(fig, ax, args)
+    set_scatterplot_plot_params(ax, args)
     plotname = f"plotviewinganglecolour{bands[0]}-{bands[1]}.pdf"
     save_figure(fig, plotname, format="pdf")
 

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -887,8 +887,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         for index, modelpath in enumerate(args.modelpath)
     ]
 
-    at.plottools.set_mpl_style()
-
     if args.plotemittingregions:
         make_emitting_regions_plot(args)
     else:

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -733,7 +733,6 @@ def make_emitting_regions_plot(args: argparse.Namespace) -> None:
                     ncol=1,
                     borderpad=0,
                     numpoints=1,
-                    fontsize=11,
                     markerscale=2.5,
                 )
 

--- a/artistools/logfiles.py
+++ b/artistools/logfiles.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import artistools as at
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
+from artistools.plottools import set_legend
 
 defaultoutputfile = "plotlogfiles_{0}.pdf"
 
@@ -95,7 +96,7 @@ def make_plot(logfiledict: dict[str, dict[int, dict[int, int]]], outputfile: Pat
             axis.set_xlabel("mpi rank")
             axis.set_ylabel("Time [s]")
             axis.set_title(f"{modelname} timestep {timestep}" if modelname else f"timestep {timestep}")
-            axis.legend()
+            set_legend(axis)
             # save_figure holds this rule for a figure of its own, and this pdf writes its own pages
             pdf.savefig(fig, bbox_inches="tight", pad_inches=0.02)
             plt.close(fig)

--- a/artistools/logfiles.py
+++ b/artistools/logfiles.py
@@ -85,7 +85,7 @@ def make_plot(logfiledict: dict[str, dict[int, dict[int, int]]], outputfile: Pat
 
     with PdfPages(outputfile) as pdf:
         for timestep in timesteps:
-            fig, axesgrid = make_frame_figure(aspect=0.770)
+            fig, axesgrid = make_frame_figure()
             axis = axesgrid[0][0]
             for stage, bytimestep in logfiledict.items():
                 if timestep not in bytimestep:

--- a/artistools/logfiles.py
+++ b/artistools/logfiles.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 
 import artistools as at
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 
 defaultoutputfile = "plotlogfiles_{0}.pdf"
 
@@ -84,7 +85,8 @@ def make_plot(logfiledict: dict[str, dict[int, dict[int, int]]], outputfile: Pat
 
     with PdfPages(outputfile) as pdf:
         for timestep in timesteps:
-            fig, axis = plt.subplots()
+            fig, axesgrid = make_frame_figure(aspect=0.770)
+            axis = axesgrid[0][0]
             for stage, bytimestep in logfiledict.items():
                 if timestep not in bytimestep:
                     continue

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -5,17 +5,18 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 
 import artistools as at
 from artistools.misc import addarg_axislimits
+from artistools.misc import addarg_figscale
 from artistools.misc import addarg_modelgridindex
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
 from artistools.misc import addarg_show
 from artistools.misc import addarg_timestep
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 defaultoutputfile = "plotmacroatom_cell{cell:05d}_ts{timestep:03d}-{timestep2:03d}.pdf"
@@ -24,6 +25,8 @@ defaultoutputfile = "plotmacroatom_cell{cell:05d}_ts{timestep:03d}-{timestep2:03
 def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     addarg_modelpath(parser, default=Path())
+
+    addarg_figscale(parser)
     # deprecated double-dash spelling kept as a hidden alias
     parser.add_argument("--modelpath", dest="modelpath", type=Path, help=argparse.SUPPRESS)
     addarg_timestep(parser, default=10, helptext="Timestep number to plot, e.g. 40 or last")
@@ -76,9 +79,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     dfmacroatom = read_files(input_files, modelgridindex, timestepmin, timestepmax, atomic_number)
     print(f"Plotting {len(dfmacroatom)} transitions")
 
-    fig, axis = plt.subplots(
-        nrows=1, ncols=1, sharex=True, figsize=(6, 6), tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0}
-    )
+    fig, axesgrid = make_frame_figure(args, aspect=1.059)
+    axis = axesgrid[0][0]
 
     axis.annotate(
         f"Timestep {timestepmin:d} to {timestepmax:d} (t={time_days_min} to {time_days_max})\nCell {modelgridindex:d}",

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -88,7 +88,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         xycoords="axes fraction",
         horizontalalignment="left",
         verticalalignment="top",
-        fontsize=8,
+        fontsize="x-small",
     )
 
     with np.errstate(divide="ignore"):

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -460,11 +460,16 @@ def addarg_seriesstyle(
         group.add_argument("-dashes", default=[], nargs="*", help="Dashes property of lines")
 
 
-def addarg_figscale(parser: argparse.ArgumentParser, *, include_figwidthscale: bool = False) -> None:
+def addarg_figscale(
+    parser: argparse.ArgumentParser, *, include_figwidthscale: bool = False, helptext: str | None = None
+) -> None:
     """Add the figure size scale factor arguments."""
     group = arggroup(parser, "appearance")
     group.add_argument(
-        "-figscale", type=float, default=1.0, help="Scale factor for plot area. 1.0 fills the text width of a page"
+        "-figscale",
+        type=float,
+        default=1.0,
+        help=helptext or "Scale factor for plot area. 1.0 fills the text width of a page",
     )
     if include_figwidthscale:
         group.add_argument("-figwidthscale", type=float, default=1.0, help="Scale factor for plot width")

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -832,7 +832,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     """Plot ARTIS non-LTE populations."""
     args = at.parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
 
-    at.set_mpl_style()
     modelpath = args.modelpath
     if args.x in {"time", "velocity"}:
         args.modelpath = at.normalize_path_list(args.modelpath)

--- a/artistools/nonthermal/leptontransport.py
+++ b/artistools/nonthermal/leptontransport.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 
 import artistools as at
 from artistools.constants import K_B_ev_per_K as CONST_KB  # Boltzmann constant [eV / K]
+from artistools.misc import addarg_figscale
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 from artistools.plottools import set_legend
@@ -100,7 +101,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("-nsteps", type=int, default=1000000, help="Number of energy steps to integrate over")
     at.addarg_output(parser, kind="file", defaultname=defaultoutputfile, helptext="Filename for PDF file")
 
-    at.addarg_figscale(parser)
+    addarg_figscale(parser)
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
@@ -163,7 +164,9 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         energy += delta_energy
 
         steps += 1
-        if energy <= 0:
+        # the energy falls by one step at a time, thus a value below half a step is a float
+        # residual of zero. One more pass would give beta = 0 and divide by zero
+        if energy <= -delta_energy / 2:
             break
 
     print(f"steps: {steps}")

--- a/artistools/nonthermal/leptontransport.py
+++ b/artistools/nonthermal/leptontransport.py
@@ -5,11 +5,9 @@ import math
 import typing as t
 from collections.abc import Sequence
 
-import matplotlib.pyplot as plt
-import numpy as np
-
 import artistools as at
 from artistools.constants import K_B_ev_per_K as CONST_KB  # Boltzmann constant [eV / K]
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 # CONST_KB above is shared with the rest of artistools. The constants below stay local because this module works in
@@ -101,6 +99,8 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("-nsteps", type=int, default=1000000, help="Number of energy steps to integrate over")
     at.addarg_output(parser, kind="file", defaultname=defaultoutputfile, helptext="Filename for PDF file")
 
+    at.addarg_figscale(parser)
+
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
     """Integrate a fast lepton's energy loss over distance and plot the result."""
@@ -170,10 +170,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     print(f"distance travelled: {x:.1} m")
     print(f"mean free path: {mean_free_path:.1} m")
 
-    fig, axes = plt.subplots(
-        nrows=2, ncols=1, sharex=False, figsize=(5, 8), tight_layout={"pad": 0.5, "w_pad": 0.0, "h_pad": 1.0}
-    )
-    assert isinstance(axes, np.ndarray)
+    fig, axesgrid = make_frame_figure(args, rows=2, aspect=0.836, sharex=False)
+    axes = axesgrid[:, 0]
     axes[0].plot(arr_dist, arr_energy_ev)
     axes[0].set_xlabel(r"Distance [m]")
     axes[0].set_ylabel(r"Energy [eV]")

--- a/artistools/nonthermal/leptontransport.py
+++ b/artistools/nonthermal/leptontransport.py
@@ -9,6 +9,7 @@ import artistools as at
 from artistools.constants import K_B_ev_per_K as CONST_KB  # Boltzmann constant [eV / K]
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 # CONST_KB above is shared with the rest of artistools. The constants below stay local because this module works in
 # SI units (J, m, kg, s), which artistools.constants does not provide
@@ -183,7 +184,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     axes[1].set_ylabel(r"dE/dx [eV / m]")
     axes[1].set_xscale("log")
     axes[1].set_yscale("log")
-    axes[1].legend()
+    set_legend(axes[1], args)
     save_figure(fig, outputfile, format="pdf")
 
 

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -6,7 +6,6 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 
@@ -17,6 +16,7 @@ from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_timedays
 from artistools.misc import addarg_timestep
 from artistools.misc import print_warning
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 minionfraction = 0.0  # minimum number fraction of the total population to include in SF solution
@@ -26,9 +26,8 @@ defaultoutputfile = "spencerfano_cell{cell:05d}_ts{timestep:03d}_{timedays:.2f}d
 
 def make_ntstats_plot(ntstatfile: str | Path) -> None:
     """Plot the fractions of nonthermal energy going to heating, ionisation, and excitation over time."""
-    fig, ax = plt.subplots(
-        nrows=1, ncols=1, sharex=True, figsize=(4, 3), tight_layout={"pad": 0.5, "w_pad": 0.3, "h_pad": 0.3}
-    )
+    fig, axesgrid = make_frame_figure(aspect=0.786)
+    ax = axesgrid[0][0]
 
     # the header line was written as a "#" comment
     dfstats = at.read_wsv(ntstatfile, comment_prefix="#", header_from_comment=True).fill_null(0)

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -26,7 +26,7 @@ defaultoutputfile = "spencerfano_cell{cell:05d}_ts{timestep:03d}_{timedays:.2f}d
 
 def make_ntstats_plot(ntstatfile: str | Path) -> None:
     """Plot the fractions of nonthermal energy going to heating, ionisation, and excitation over time."""
-    fig, axesgrid = make_frame_figure(aspect=0.786)
+    fig, axesgrid = make_frame_figure(aspect=0.786, fullwidth=False)
     ax = axesgrid[0][0]
 
     # the header line was written as a "#" comment

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -18,6 +18,7 @@ from artistools.misc import addarg_timestep
 from artistools.misc import print_warning
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 
 minionfraction = 0.0  # minimum number fraction of the total population to include in SF solution
 
@@ -49,7 +50,7 @@ def make_ntstats_plot(ntstatfile: str | Path) -> None:
 
     ax.set_ylabel(r"Energy fraction")
     ax.set_xlabel(r"log x$_e$")
-    ax.legend(loc="best", handlelength=2, frameon=False, numpoints=1)
+    set_legend(ax, loc="best", handlelength=2, frameon=False, numpoints=1)
     ax.autoscale(enable=True, axis="both", tight=True)
     outputfilename = Path(ntstatfile).with_suffix(".pdf")
     save_figure(fig, outputfilename, format="pdf")

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -50,7 +50,7 @@ def make_ntstats_plot(ntstatfile: str | Path) -> None:
 
     ax.set_ylabel(r"Energy fraction")
     ax.set_xlabel(r"log x$_e$")
-    set_legend(ax, loc="best", handlelength=2, frameon=False, numpoints=1)
+    set_legend(ax)
     ax.autoscale(enable=True, axis="both", tight=True)
     outputfilename = Path(ntstatfile).with_suffix(".pdf")
     save_figure(fig, outputfilename, format="pdf")

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -26,7 +26,7 @@ defaultoutputfile = "spencerfano_cell{cell:05d}_ts{timestep:03d}_{timedays:.2f}d
 
 def make_ntstats_plot(ntstatfile: str | Path) -> None:
     """Plot the fractions of nonthermal energy going to heating, ionisation, and excitation over time."""
-    fig, axesgrid = make_frame_figure(aspect=0.786, fullwidth=False)
+    fig, axesgrid = make_frame_figure(fullwidth=False)
     ax = axesgrid[0][0]
 
     # the header line was written as a "#" comment

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -94,7 +94,6 @@ def packets_2d_hist_bin_and_ejecta_vel(
     binwidth: float | None = None,
 ) -> None:
     """Plot a 2D histogram of packet emission position against ejecta velocity, and save the figure."""
-    at.plottools.set_mpl_style()
     start_of_filename = "" if modelpath == Path() else f"{modelpath.name}_"
     if wavelen is not None:
         start_of_filename = f"{wavelen:.0f}A_"

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -6,6 +6,7 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 
@@ -14,8 +15,8 @@ from artistools.constants import c_ang_per_s
 from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 from artistools.misc import addarg_modelpath
-from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_mpl_style
 
 
 def get_required_packets(
@@ -181,8 +182,10 @@ def packets_2d_hist_bin_and_ejecta_vel(
     if colorlogscale:
         heatmap = np.ma.log(heatmap)
 
-    fig, axesgrid = make_frame_figure(aspect=1.482, fullwidth=False)
-    ax = axesgrid[0][0]
+    # an image with a colorbar keeps plt.subplots: fig.colorbar takes space that the
+    # Divider of make_frame_figure gives back at draw time, and the two then overlap
+    set_mpl_style()
+    fig, ax = plt.subplots(figsize=(3.5, 4.5), layout="constrained")
     z = heatmap.T
 
     im = ax.imshow(z, origin="lower", cmap="viridis", extent=(xedges[0], xedges[-1], yedges[0], yedges[-1]))

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -182,7 +182,7 @@ def packets_2d_hist_bin_and_ejecta_vel(
     if colorlogscale:
         heatmap = np.ma.log(heatmap)
 
-    fig, axesgrid = make_frame_figure(aspect=1.482)
+    fig, axesgrid = make_frame_figure(aspect=1.482, fullwidth=False)
     ax = axesgrid[0][0]
     z = heatmap.T
 

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -202,7 +202,7 @@ def packets_2d_hist_bin_and_ejecta_vel(
     ax.set_yticks(np.linspace(yedges[0], yedges[-1], 6))
 
     outfilename = start_of_filename + f"ts{timestep}_into_dirbin{dirbin}.pdf"
-    save_figure(fig, outfilename, dpi=300, bbox_inches="tight")
+    save_figure(fig, outfilename, dpi=300)
 
 
 def addargs(parser: argparse.ArgumentParser) -> None:

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -6,7 +6,6 @@ import typing as t
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import polars as pl
 
@@ -15,6 +14,7 @@ from artistools.constants import c_ang_per_s
 from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 from artistools.misc import addarg_modelpath
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 
 
@@ -182,7 +182,8 @@ def packets_2d_hist_bin_and_ejecta_vel(
     if colorlogscale:
         heatmap = np.ma.log(heatmap)
 
-    fig, ax = plt.subplots(figsize=(3.5, 4.5))
+    fig, axesgrid = make_frame_figure(aspect=1.482)
+    ax = axesgrid[0][0]
     z = heatmap.T
 
     im = ax.imshow(z, origin="lower", cmap="viridis", extent=(xedges[0], xedges[-1], yedges[0], yedges[-1]))

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -532,8 +532,13 @@ def make_frame_figure(
     return fig, axes
 
 
-def set_legend(ax: mplax.Axes, args: argparse.Namespace, **legendkwargs: t.Any) -> "mpllegend.Legend | None":
-    """Draw the legend of the axes and return it. Return None when -nolegend was given."""
+def set_legend(
+    ax: mplax.Axes, args: argparse.Namespace | None = None, **legendkwargs: t.Any
+) -> "mpllegend.Legend | None":
+    """Draw the legend of the axes and return it. Return None when -nolegend was given.
+
+    A helper that parses no arguments passes no args, and the legend then always draws.
+    """
     if getattr(args, "nolegend", False):
         return None
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -5,7 +5,6 @@ import math
 import typing as t
 from collections.abc import Iterable
 from collections.abc import Sequence
-from functools import cache
 
 import matplotlib.axes as mplax
 import matplotlib.axis as mplaxis
@@ -387,6 +386,7 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
     The code steps over a colour that the user asked for, thus two series do not get one colour.
     """
     askedfor = get_assigned_colors(usercolors)
+    set_mpl_style()  # the artistools cycle holds far more colours than the matplotlib default
     cyclecolors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
     # the colours of the cycle that no series has, by value rather than by spelling
@@ -576,12 +576,12 @@ def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequen
             axis.set_prop_cycle(color=colors)
 
 
-@cache
 def set_mpl_style() -> None:
     """Apply the bundled artistools matplotlibrc style.
 
-    The style holds global state, thus one call serves the process. make_frame_figure calls this,
-    so that every figure draws the same fonts and ticks whether or not its command asks.
+    make_frame_figure and get_series_colors call this, thus every figure draws the same fonts and
+    ticks whether or not its command asks. The call reads the file each time, because a cache would
+    keep the style from coming back after other code changes rcParams. One call costs a millisecond.
     """
     plt.style.use("file://" + str(get_path("artistools_dir") / "matplotlibrc"))
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -441,7 +441,7 @@ TOPMARGIN_INCHES: t.Final[float] = 0.28
 
 
 def make_frame_figure(
-    args: argparse.Namespace,
+    args: argparse.Namespace | None = None,
     *,
     rows: int = 1,
     cols: int = 1,
@@ -462,12 +462,15 @@ def make_frame_figure(
     file that hides its x labels keeps its width and loses only the height of those labels.
 
     The axes come back in a 2D array of [row][column], with row 0 at the top, as plt.subplots gives.
+    A caller that has no parsed arguments gives no args, and the figure then takes a scale of 1.
     """
     from mpl_toolkits.axes_grid1 import Divider
     from mpl_toolkits.axes_grid1 import Size
 
-    framewidth = FRAMEWIDTH_INCHES * getattr(args, "figwidthscale", 1.0) * args.figscale
-    frameheight = FRAMEWIDTH_INCHES * aspect * args.figscale
+    # a helper that draws a figure without parsing arguments passes no args, thus it takes scale 1
+    figscale = getattr(args, "figscale", 1.0)
+    framewidth = FRAMEWIDTH_INCHES * getattr(args, "figwidthscale", 1.0) * figscale
+    frameheight = FRAMEWIDTH_INCHES * aspect * figscale
 
     # a column that shows its own y label needs the width of one beside it, and likewise a row
     colgap = RIGHTMARGIN_INCHES if sharey else LABELWIDTH_INCHES

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -5,6 +5,7 @@ import math
 import typing as t
 from collections.abc import Iterable
 from collections.abc import Sequence
+from functools import cache
 
 import matplotlib.axes as mplax
 import matplotlib.axis as mplaxis
@@ -475,6 +476,8 @@ def make_frame_figure(
     from mpl_toolkits.axes_grid1 import Divider
     from mpl_toolkits.axes_grid1 import Size
 
+    set_mpl_style()
+
     # a helper that draws a figure without parsing arguments passes no args, thus it takes scale 1
     figscale = getattr(args, "figscale", 1.0)
     basewidth = FRAMEWIDTH_INCHES if fullwidth else COLUMNFRAMEWIDTH_INCHES
@@ -568,8 +571,13 @@ def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequen
             axis.set_prop_cycle(color=colors)
 
 
+@cache
 def set_mpl_style() -> None:
-    """Apply the bundled artistools matplotlibrc style."""
+    """Apply the bundled artistools matplotlibrc style.
+
+    The style holds global state, thus one call serves the process. make_frame_figure calls this,
+    so that every figure draws the same fonts and ticks whether or not its command asks.
+    """
     plt.style.use("file://" + str(get_path("artistools_dir") / "matplotlibrc"))
 
 

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -5,6 +5,7 @@ import math
 import typing as t
 from collections.abc import Iterable
 from collections.abc import Sequence
+from functools import cache
 
 import matplotlib.axes as mplax
 import matplotlib.axis as mplaxis
@@ -385,8 +386,8 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
     The other series, and the reference series after the greys, get the colours of the matplotlib cycle.
     The code steps over a colour that the user asked for, thus two series do not get one colour.
     """
+    set_mpl_style()  # a name such as "C7" and the free colours must both come from the artistools cycle
     askedfor = get_assigned_colors(usercolors)
-    set_mpl_style()  # the artistools cycle holds far more colours than the matplotlib default
     cyclecolors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 
     # the colours of the cycle that no series has, by value rather than by spelling
@@ -418,13 +419,12 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
 
 
 # the size in inches of one subplot frame at a figure scale of 1, measured from a plot of one row
-# and one column. A file of this width fills the text block of a two-column page, which measures
-# 180 mm in MNRAS and in A&A
+# and one column
 FRAMEWIDTH_INCHES: t.Final[float] = 6.47
 FRAMEHEIGHT_INCHES: t.Final[float] = 4.08
 
-# the frame of a plot that fills one column of such a page, which measures 84 mm and 88 mm. A plot
-# that draws few series needs no more, and a paper then sets it beside the text
+# the frame of a plot that fills one column: 84 mm in MNRAS and 88 mm in A&A. A plot that draws
+# few series needs no more, and a paper then sets it beside the text
 COLUMNFRAMEWIDTH_INCHES: t.Final[float] = 2.99
 
 # the y label and its tick numbers to the left of each frame, and the x label below the lowest one.
@@ -469,7 +469,7 @@ def make_frame_figure(
     file that hides its x labels keeps its width and loses only the height of those labels.
 
     The axes come back in a 2D array of [row][column], with row 0 at the top, as plt.subplots gives.
-    A caller that has no parsed arguments gives no args, and the figure then takes a scale of 1.
+    A helper that parses no arguments passes no args, and the figure then takes a scale of 1.
     A plot that draws few series gives fullwidth=False, and its frame then fills one column of the
     page in place of the whole text block. aspect stays the height of a frame as a part of its width.
     """
@@ -478,7 +478,6 @@ def make_frame_figure(
 
     set_mpl_style()
 
-    # a helper that draws a figure without parsing arguments passes no args, thus it takes scale 1
     figscale = getattr(args, "figscale", 1.0)
     basewidth = FRAMEWIDTH_INCHES if fullwidth else COLUMNFRAMEWIDTH_INCHES
     framewidth = basewidth * getattr(args, "figwidthscale", 1.0) * figscale
@@ -576,14 +575,46 @@ def set_prop_cycle_unusedcolors(axes: Iterable[mplax.Axes], seriescolors: Sequen
             axis.set_prop_cycle(color=colors)
 
 
+@cache
+def read_mpl_style() -> dict[str, t.Any]:
+    """Read the bundled matplotlibrc one time and return its settings."""
+    import matplotlib as mpl
+
+    rcparams = mpl.rc_params_from_file(get_path("artistools_dir") / "matplotlibrc", use_default_template=False)
+    return dict(rcparams.items())
+
+
 def set_mpl_style() -> None:
     """Apply the bundled artistools matplotlibrc style.
 
     make_frame_figure and get_series_colors call this, thus every figure draws the same fonts and
-    ticks whether or not its command asks. The call reads the file each time, because a cache would
-    keep the style from coming back after other code changes rcParams. One call costs a millisecond.
+    ticks whether or not its command asks. The application runs on each call, thus the style comes
+    back after other code changes rcParams. Only the parse of the file is cached.
     """
-    plt.style.use("file://" + str(get_path("artistools_dir") / "matplotlibrc"))
+    plt.style.use(read_mpl_style())
+
+
+def add_cax_for_fixed_frames(fig: mplfig.Figure, *, horizontal: bool) -> mplax.Axes:
+    """Grow the figure and return a new axes that holds a colorbar beside the fixed frames.
+
+    fig.colorbar(ax=...) takes space from an axes, and a Divider gives that space back at draw
+    time, thus the colorbar would lie on the frame. This grows the page for the colorbar instead.
+    save_figure crops the part of the new margin that the colorbar does not fill.
+    """
+    frames = [axis for axis in fig.axes if axis.get_axes_locator() is not None]
+    if horizontal:
+        fig.set_figheight(fig.get_figheight() + 1.0)
+    else:
+        fig.set_figwidth(fig.get_figwidth() + 1.0)
+    fig.canvas.draw()
+    figwidth, figheight = fig.get_size_inches()
+    x0 = min(axis.get_position().x0 for axis in frames)
+    x1 = max(axis.get_position().x1 for axis in frames)
+    y0 = min(axis.get_position().y0 for axis in frames)
+    y1 = max(axis.get_position().y1 for axis in frames)
+    if horizontal:
+        return fig.add_axes((x0, y1 + 0.15 / figheight, x1 - x0, 0.18 / figheight))
+    return fig.add_axes((x1 + 0.15 / figwidth, y0, 0.18 / figwidth, y1 - y0))
 
 
 def save_figure(

--- a/artistools/plottools.py
+++ b/artistools/plottools.py
@@ -417,9 +417,14 @@ def get_series_colors(isreference: Sequence[bool], usercolors: Sequence[str | No
 
 
 # the size in inches of one subplot frame at a figure scale of 1, measured from a plot of one row
-# and one column
+# and one column. A file of this width fills the text block of a two-column page, which measures
+# 180 mm in MNRAS and in A&A
 FRAMEWIDTH_INCHES: t.Final[float] = 6.47
 FRAMEHEIGHT_INCHES: t.Final[float] = 4.08
+
+# the frame of a plot that fills one column of such a page, which measures 84 mm and 88 mm. A plot
+# that draws few series needs no more, and a paper then sets it beside the text
+COLUMNFRAMEWIDTH_INCHES: t.Final[float] = 2.99
 
 # the y label and its tick numbers to the left of each frame, and the x label below the lowest one.
 # Each column pays the width, which a log tick number such as 10^-12 drives to 0.63 inches
@@ -448,6 +453,7 @@ def make_frame_figure(
     aspect: float = FRAMEHEIGHT_INCHES / FRAMEWIDTH_INCHES,
     sharex: bool = True,
     sharey: bool = False,
+    fullwidth: bool = True,
 ) -> "tuple[mplfig.Figure, npt.NDArray[t.Any]]":
     """Return a figure whose frames each hold exactly the same size, and the axes of that figure.
 
@@ -463,14 +469,17 @@ def make_frame_figure(
 
     The axes come back in a 2D array of [row][column], with row 0 at the top, as plt.subplots gives.
     A caller that has no parsed arguments gives no args, and the figure then takes a scale of 1.
+    A plot that draws few series gives fullwidth=False, and its frame then fills one column of the
+    page in place of the whole text block. aspect stays the height of a frame as a part of its width.
     """
     from mpl_toolkits.axes_grid1 import Divider
     from mpl_toolkits.axes_grid1 import Size
 
     # a helper that draws a figure without parsing arguments passes no args, thus it takes scale 1
     figscale = getattr(args, "figscale", 1.0)
-    framewidth = FRAMEWIDTH_INCHES * getattr(args, "figwidthscale", 1.0) * figscale
-    frameheight = FRAMEWIDTH_INCHES * aspect * figscale
+    basewidth = FRAMEWIDTH_INCHES if fullwidth else COLUMNFRAMEWIDTH_INCHES
+    framewidth = basewidth * getattr(args, "figwidthscale", 1.0) * figscale
+    frameheight = basewidth * aspect * figscale
 
     # a column that shows its own y label needs the width of one beside it, and likewise a row
     colgap = RIGHTMARGIN_INCHES if sharey else LABELWIDTH_INCHES

--- a/artistools/radfield.py
+++ b/artistools/radfield.py
@@ -405,8 +405,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     """Plot the radiation field estimators."""
     args = at.parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
 
-    at.set_mpl_style()
-
     modelpath = args.modelpath
 
     pdf_list: list[str] = []

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -80,7 +80,6 @@ from artistools.plottools import save_figure
 from artistools.plottools import set_auto_yscale
 from artistools.plottools import set_exponent_label
 from artistools.plottools import set_legend
-from artistools.plottools import set_mpl_style
 from artistools.plottools import set_plot_title
 from artistools.plottools import set_prop_cycle_unusedcolors
 from artistools.spectra.writespectra import write_flambda_spectra
@@ -1649,8 +1648,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.xmax = atspectra.convert_angstroms_to_unit(0.004 if args.gamma else 19000.0, args.xunit)
 
     args.xmin, args.xmax = sorted([args.xmin, args.xmax])
-
-    set_mpl_style()
 
     assert (
         not args.plotvspecpol or not args.plotviewingangle

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -193,7 +193,7 @@ def make_plot(
         for ion_index, axis in enumerate(axes):
             axis.plot(xvalues, yvalues[seriesindex][ion_index], linewidth=1.5, label=serieslabel)
 
-            set_legend(axis, args, loc="upper left", handlelength=1, frameon=False, numpoints=1)
+            set_legend(axis, args, loc="upper left", handlelength=1)
 
     axislabels = [
         f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[IonTuple(Z, ion_stage)]:.1e}/cm³)"

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -27,6 +27,7 @@ from artistools.misc import addarg_timedays
 from artistools.misc import addarg_timestep
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
+from artistools.plottools import set_legend
 from artistools.plottools import set_plot_title
 
 if t.TYPE_CHECKING:
@@ -192,7 +193,7 @@ def make_plot(
         for ion_index, axis in enumerate(axes):
             axis.plot(xvalues, yvalues[seriesindex][ion_index], linewidth=1.5, label=serieslabel)
 
-            axis.legend(loc="upper left", handlelength=1, frameon=False, numpoints=1, prop={"size": 8})
+            set_legend(axis, args, loc="upper left", handlelength=1, frameon=False, numpoints=1)
 
     axislabels = [
         f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[IonTuple(Z, ion_stage)]:.1e}/cm³)"
@@ -206,7 +207,7 @@ def make_plot(
             xycoords="axes fraction",
             horizontalalignment="right",
             verticalalignment="top",
-            fontsize=10,
+            fontsize="small",
         )
 
     # at.spectra.plot_reference_spectrum(

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 import polars as pl
@@ -18,6 +17,7 @@ from artistools.constants import hc_in_ev_cm
 from artistools.constants import K_B_ev_per_K
 from artistools.constants import km_to_cm
 from artistools.misc import addarg_axislimits
+from artistools.misc import addarg_figscale
 from artistools.misc import addarg_modelgridindex
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_notitle
@@ -25,6 +25,7 @@ from artistools.misc import addarg_output
 from artistools.misc import addarg_show
 from artistools.misc import addarg_timedays
 from artistools.misc import addarg_timestep
+from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 from artistools.plottools import set_plot_title
 
@@ -179,19 +180,8 @@ def make_plot(
     args: argparse.Namespace,
 ) -> None:
     """Plot one panel for each ion, and save the figure."""
-    fig, axes = plt.subplots(
-        nrows=len(ionlist),
-        ncols=1,
-        sharex=True,
-        sharey=False,
-        figsize=(6, 2 * (len(ionlist) + 1)),
-        tight_layout={"pad": 0.2, "w_pad": 0.0, "h_pad": 0.0},
-    )
-
-    if len(ionlist) == 1:
-        axes = np.array([axes])
-
-    assert isinstance(axes, np.ndarray)
+    fig, axesgrid = make_frame_figure(args, rows=len(ionlist), aspect=0.383)
+    axes = axesgrid[:, 0]
 
     if figure_title:
         print(figure_title)
@@ -259,6 +249,8 @@ def add_upper_lte_pop(
 def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     addarg_modelpath(parser, default=None)
+
+    addarg_figscale(parser)
 
     addarg_notitle(parser)
 


### PR DESCRIPTION
Every plot command now draws its frame at one size and in one style. PR #605 gave
six commands a frame that `make_frame_figure` places, and fourteen commands kept a
figure size of their own.

## The frame

Those fourteen commands called `plt.subplots` with sizes from 3.5 x 4.5 inches to
8 x 6, and each one asked `tight_layout` for a different pad. A paper that put two
such files side by side at one width drew two frames of different sizes.

| file | before | after |
| --- | --- | --- |
| plotdensity | 4.00 in | 6.98 in |
| plotspectra | 7.02 in | 7.02 in |
| mismatch | 43 % | 0.6 % |

Each command keeps the shape that it drew, because the `aspect` argument takes the
height of the old frame as a part of its width.

## One column or the full text width

A detailed plot needs the text block of a two-column page, and a plot that draws
few series needs one column. `make_frame_figure` takes `fullwidth` for this.

| | saved file | the page gives |
| --- | --- | --- |
| one column | 3.37 in | 84 mm to 88 mm, thus 3.31 in to 3.46 in |
| text width | 7.02 in | 180 mm, thus 7.09 in |

`plotdensity`, `plotlastpacketinteraction`, and `spencerfano` take one column. Each
of the three drew 4.5 inches or less before, thus the author of each asked for a
narrow figure already.

## The style

`set_mpl_style` applied the bundled `matplotlibrc`, and eleven commands called it
under three spellings. Every other command drew with the matplotlib defaults: a
sans-serif font in place of a serif one, ticks that point out in place of in, and
no minor ticks. Thus `plotmacroatom` did not match `plotspectra` in more than size.

`make_frame_figure` calls `set_mpl_style` now, thus each figure takes the style
whether or not its command asks. A cache gives the file one read: 200 further calls
cost 0.01 ms. The entry point cannot make this call, because a command such as
`getpath` would then import matplotlib and start slowly.

## Two faults that the migration removed

`transitions` and `comparetogsinetwork` held the wrap that `plt.subplots` needed
when it squeezed one row to a scalar. `make_frame_figure` always gives a 2D array,
thus that wrap made a 2D array of arrays and the command stopped. `plotnltepops`
held the same fault, which an earlier review found.

## What keeps plt.subplots

- `plotspherical` draws a mollweide projection, which holds no rectangular frame.
- `downscale3dgrid` places a colorbar with `make_axes_locatable`, which the Divider
  of `make_frame_figure` would fight. It calls `set_mpl_style` instead.

## Other changes

- `make_frame_figure` takes no `args`, thus a helper that parses no arguments can
  call it. Seven commands that pass `args` gain `-figscale`.
- `viewingangleanalysis` drew four figures with `plt.subplots` and set no style.

## Checks

`ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`, and
`pytest -n auto` all pass. 541 tests pass and 1 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
