### PR TITLE
Give the Spencer-Fano excitation path the derived transition columns

### DIFF
--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -255,7 +255,13 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
             adata = None
             dfpops = None
         else:
-            adata = at.atomic.get_levels(modelpath, get_transitions=True, ionlist=tuple(ions))
+            # the excitation cross sections read epsilon_trans_ev, lower_g, and upper_g from each transition
+            adata = at.atomic.get_levels(
+                modelpath,
+                get_transitions=True,
+                ionlist=tuple(ions),
+                derived_transitions_columns=("epsilon_trans_ev", "lower_g", "upper_g"),
+            )
 
         if step == 0 and args.ostat:
             strheader = "#emin emax npts x_e frac_sum frac_excitation frac_ionization frac_heating"

--- a/artistools/nonthermal/test_nonthermal.py
+++ b/artistools/nonthermal/test_nonthermal.py
@@ -14,6 +14,11 @@ def test_spencerfano() -> None:
     )
 
 
+def test_spencerfano_excitation() -> None:
+    """Solve with the excitation path. The solver reads the derived transition columns, e.g. epsilon_trans_ev."""
+    at.nonthermal.solvespencerfanocmd.main(argsraw=[], modelpath=modelpath, timedays=300, npts=200)
+
+
 @pytest.mark.parametrize("x_e", [0.0, 0.01, 0.5, 1.0, 1.5, 2.0, 3.7, 26.0])
 def test_ionpops_for_electronfraction(x_e: float) -> None:
     """The ion populations must average to x_e free electrons per nucleus, for x_e above one as well as below.


### PR DESCRIPTION
## Summary

The command `artistools spencerfano` failed with a `ColumnNotFoundError` when the excitation path was on. The solver in pynonthermal filters the transitions on the column `epsilon_trans_ev`, but the call to `at.atomic.get_levels` in `solvespencerfanocmd.py` did not request the derived transition columns. The excitation cross sections read `epsilon_trans_ev`, `lower_g`, and `upper_g` from each transition. The call now requests these three columns.

The only test passed `noexcitation=True`, thus no test reached the excitation path. The new test `test_spencerfano_excitation` solves with the excitation path on a small energy grid, and it fails without this correction.

## Test plan

- [x] `uv run -- ruff format` and `uv run -- ruff check --no-fix`
- [x] `uv run -- pyrefly check` and `uv run -- ty check` (no errors)
- [x] `uv run -- refurb artistools --quiet -- --follow-imports=skip`
- [x] Full `pytest -n auto`: 542 passed, 1 skipped
- [x] `python -m artistools spencerfano -modelpath tests/data/testmodel -ts 40 -o /tmp/sf.pdf` completes and reports `frac_excitation_tot: 0.0061`

🤖 Generated with [Claude Code](https://claude.com/claude-code)