### PR TITLE
Apply the cleanup findings of a full code review

### DIFF
--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -498,7 +498,7 @@ def get_z_a_nucname(nucname: str) -> tuple[int, int]:
 
 
 @lru_cache(maxsize=1)
-def _get_elements_df() -> pl.DataFrame:
+def get_elements_df() -> pl.DataFrame:
     """Return the whole element table (Z, symbol, name, mass) from data/elements.csv.
 
     The single place that knows the file's schema, so adding a column does not have to be mirrored into
@@ -530,7 +530,7 @@ def get_elsymbolslist() -> tuple[str, ...]:
     get_elsymbolslist()[26] = 'Fe'.
 
     """
-    return ("n", *_get_elements_df()["symbol"].to_list())
+    return ("n", *get_elements_df()["symbol"].to_list())
 
 
 @lru_cache(maxsize=1)
@@ -543,12 +543,12 @@ def get_atomic_masses() -> Mapping[int, float]:
 
     A read-only mapping, because the single cached instance is shared by every caller.
     """
-    dfelements = _get_elements_df()
+    dfelements = get_elements_df()
     return MappingProxyType(dict(zip(dfelements["Z"].to_list(), dfelements["mass"].to_list(), strict=True)))
 
 
 @lru_cache(maxsize=1)
-def _get_atomic_number_of_elsymbol() -> dict[str, int]:
+def get_atomic_number_of_elsymbol() -> dict[str, int]:
     """Return a mapping of element symbol to atomic number, for lookups that would otherwise scan the whole list."""
     return {elsymbol: atomic_number for atomic_number, elsymbol in enumerate(get_elsymbolslist())}
 
@@ -567,7 +567,7 @@ def get_elsymbols_df() -> pl.LazyFrame:
 
     Only the two columns, so that a join against this frame never picks up the rest of the element table.
     """
-    return _get_elements_df().lazy().select(pl.col("Z").alias("atomic_number"), pl.col("symbol").alias("elsymbol"))
+    return get_elements_df().lazy().select(pl.col("Z").alias("atomic_number"), pl.col("symbol").alias("elsymbol"))
 
 
 def get_atomic_number(elsymbol: str) -> int:
@@ -577,7 +577,7 @@ def get_atomic_number(elsymbol: str) -> int:
     elsymbol = elsymbol.split("_")[0].split("-")[0].rstrip(string.digits)
 
     # a dict lookup, because this is called once per column name in some loops
-    return _get_atomic_number_of_elsymbol().get(elsymbol.title(), -1)
+    return get_atomic_number_of_elsymbol().get(elsymbol.title(), -1)
 
 
 ROMANNUMERALCHARS = frozenset("IVXLCDM")

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -370,7 +370,7 @@ def get_units_string(variable: str) -> str:
     return f" [{units}]" if (units := get_units(variable)) else ""
 
 
-def _estimator_colsortkey(col: str) -> str:
+def estimator_colsortkey(col: str) -> str:
     """Sort timestep, modelgridindex, and titeration first, then the remaining columns alphabetically."""
     return f"-{col!r}" if col in {"timestep", "modelgridindex", "titeration"} else col
 
@@ -458,7 +458,7 @@ def get_estimators_rankbatch_parquetfile(
             cs.by_name("titeration", "timestep", "modelgridindex", require_all=False).cast(pl.Int32)
         )
 
-        sortedcols: list[str] = sorted(pldf_batch.columns, key=_estimator_colsortkey)
+        sortedcols: list[str] = sorted(pldf_batch.columns, key=estimator_colsortkey)
         pldf_batch = pldf_batch.select(sortedcols)
         print(f"took {time.perf_counter() - time_start:.1f} s. Writing parquet file...", end="", flush=True)
         time_start = time.perf_counter()
@@ -604,7 +604,7 @@ def scan_estimators(
         assert estimatorsdict is not None
         pldflazy = lazyframe_from_estimator_dict(estimatorsdict)
     else:
-        pldflazy = _scan_artis_estimators(
+        pldflazy = scan_artis_estimators(
             modelpath, match_modelgridindex=match_modelgridindex, match_timestep=match_timestep, verbose=verbose
         )
 
@@ -622,7 +622,7 @@ def scan_estimators(
     return pldflazy
 
 
-def _scan_artis_estimators(
+def scan_artis_estimators(
     modelpath: Path, match_modelgridindex: Sequence[int] | None, match_timestep: Sequence[int] | None, verbose: bool
 ) -> pl.LazyFrame:
     """Scan the parquet estimator caches of an ARTIS run, or cross join model cells with timesteps if there are none."""
@@ -768,7 +768,7 @@ def get_averageexcitation(
         .collect()
     )
 
-    dfsuperlevelenergy = _superlevel_energy(dfsuperlevel, dflevels.collect(), groupcols)
+    dfsuperlevelenergy = superlevel_energy(dfsuperlevel, dflevels.collect(), groupcols)
 
     # inner join on dftexc, so the result covers exactly the cells a temperature was given for and a
     # missing one cannot silently drop the superlevel term
@@ -784,7 +784,7 @@ def get_averageexcitation(
     )
 
 
-def _superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupcols: list[str]) -> pl.DataFrame:
+def superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupcols: list[str]) -> pl.DataFrame:
     """Return the energy the superlevel population contributes, Boltzmann-distributed at T_exc."""
     schema: dict[str, pl.DataType] = {
         **{col: dfsuperlevel.schema[col] for col in groupcols},

--- a/artistools/inputmodel/energyinputfiles.py
+++ b/artistools/inputmodel/energyinputfiles.py
@@ -22,14 +22,14 @@ from artistools.plottools import make_frame_figure
 from artistools.plottools import save_or_show
 
 
-def _cumulative_trapezoid(y: npt.ArrayLike, x: npt.ArrayLike) -> npt.NDArray[np.float64]:
+def cumulative_trapezoid(y: npt.ArrayLike, x: npt.ArrayLike) -> npt.NDArray[np.float64]:
     """Cumulatively integrate y over x with the trapezoidal rule, starting from zero."""
     yarr = np.asarray(y, dtype=np.float64)
     xarr = np.asarray(x, dtype=np.float64)
     return np.concatenate(([0.0], np.cumsum(np.diff(xarr) * (yarr[:-1] + yarr[1:]) / 2.0)))
 
 
-def _quad_adaptive(
+def quad_adaptive(
     func: Callable[[float], float], a: float, b: float, *, rtol: float = 1.5e-8, maxdepth: int = 20
 ) -> float:
     """Integrate a smooth function over [a, b] with adaptive Simpson quadrature.
@@ -74,7 +74,7 @@ def get_cumulative_heating_fraction() -> tuple[pl.DataFrame, float]:
     times = np.logspace(np.log10(tmin), np.log10(tmax), num=300)  # days
     qdot = 5e9 * (times) ** (-1.3)  # define energy power law (5e9*t^-1.3)
 
-    cumulative_energy = _cumulative_trapezoid(y=qdot, x=times)
+    cumulative_energy = cumulative_trapezoid(y=qdot, x=times)
     E_tot = float(cumulative_energy[-1])
 
     rate = cumulative_energy / E_tot
@@ -150,7 +150,7 @@ def rprocess_const_and_powerlaw() -> tuple[pl.DataFrame, float]:
     times = np.logspace(np.log10(tmin), np.log10(tmax), num=200)
     energy_per_gram_cumulative = [0.0]
     for tlow, thigh in itertools.pairwise(times):
-        energy_per_gram_cumulative.append(energy_per_gram_cumulative[-1] + _quad_adaptive(integrand, tlow, thigh))
+        energy_per_gram_cumulative.append(energy_per_gram_cumulative[-1] + quad_adaptive(integrand, tlow, thigh))
 
     E_tot = energy_per_gram_cumulative[-1]  # ergs/g
     print("Etot per gram", E_tot)
@@ -175,7 +175,7 @@ def energy_from_rprocess_calculation(
     times = energy_thermo_data["time/s"][skipfirstnrows:]
     qdot = energy_thermo_data["Qdot"][skipfirstnrows:]
 
-    cumulative_energy = _cumulative_trapezoid(y=qdot, x=times)
+    cumulative_energy = cumulative_trapezoid(y=qdot, x=times)
     E_tot = float(cumulative_energy[-1])  # erg / g
 
     if get_rate:

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -219,7 +219,7 @@ def get_grid(
     # ... cylindrical coordinates of the particle positions
     vmax_cmps = vmax_on_c * CLIGHT  # maximum velocity in coordinate direction (!)
     rcyltraj, zcyltraj = np.zeros(ntraj), np.zeros(ntraj)
-    for i in [int(j) for j in np.arange(ntraj)]:
+    for i in range(ntraj):
         rcyltraj[i] = vtraj[i] * np.sin(atraj[i]) * CLIGHT * t_model_init_s
         zcyltraj[i] = vtraj[i] * np.cos(atraj[i]) * CLIGHT * t_model_init_s
     if model_dim == 2:
@@ -284,7 +284,7 @@ def get_grid(
     print("computing particle densities...")
     rho2dtraj = np.zeros(ntraj)  # this is the 2D density!!!
     hsmooth = np.zeros(ntraj)
-    for i in [int(j) for j in np.arange(ntraj)]:
+    for i in range(ntraj):
         cont = True
         hl, hr = 0.00001 * CLIGHT * t_model_init_s, 1.0 * CLIGHT * t_model_init_s
         dist = np.sqrt((rcyltraj[i] - rcyltraj) ** 2 + (zcyltraj[i] - zcyltraj) ** 2)
@@ -315,7 +315,7 @@ def get_grid(
 
     # cross check: count number of neighbors within smoothing length
     neinum = np.zeros(ntraj)
-    for i in [int(j) for j in np.arange(ntraj)]:
+    for i in range(ntraj):
         dist = np.sqrt((rcyltraj[i] - rcyltraj) ** 2 + (zcyltraj[i] - zcyltraj) ** 2)
         neinum[i] = np.sum(np.where(dist / hsmooth < 2.0, 1.0, 0.0))
     neinumavg = np.sum(neinum * mtraj) / np.sum(mtraj)
@@ -383,25 +383,22 @@ def get_grid(
     mtot = np.sum(dmgrid)
 
     # test outputs
+    testelements = [("He", 2), ("Zr", 40), ("Sn", 50), ("Te", 52), ("Xe", 54), ("W", 74), ("Pt", 78)]
     print("===> mapped data")
     print("total mass                :", mtot / msol * eqsymfac)
-    print("total element mass He Z=2 :", np.sum(np.sum(xint[iso[:, 1] == 2, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass Zr Z=40:", np.sum(np.sum(xint[iso[:, 1] == 40, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass Sn Z=50:", np.sum(np.sum(xint[iso[:, 1] == 50, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass Te Z=52:", np.sum(np.sum(xint[iso[:, 1] == 52, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass Xe Z=54:", np.sum(np.sum(xint[iso[:, 1] == 54, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass W  Z=74:", np.sum(np.sum(xint[iso[:, 1] == 74, :, :], axis=0) * dmgrid) * eqsymfac / msol)
-    print("total element mass Pt Z=78:", np.sum(np.sum(xint[iso[:, 1] == 78, :, :], axis=0) * dmgrid) * eqsymfac / msol)
+    for elsymbol, atomic_number in testelements:
+        print(
+            f"total element mass {elsymbol:<2} Z={atomic_number:<2}:",
+            np.sum(np.sum(xint[iso[:, 1] == atomic_number, :, :], axis=0) * dmgrid) * eqsymfac / msol,
+        )
 
     print("===> tracer data")
     print("total mass                :", np.sum(dat.f.mass) * eqsymfac)
-    print("total element mass He Z=2 :", np.sum(np.sum(xiso0[:, iso[:, 1] == 2], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass Zr Z=40:", np.sum(np.sum(xiso0[:, iso[:, 1] == 40], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass Sn Z=50:", np.sum(np.sum(xiso0[:, iso[:, 1] == 50], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass Te Z=52:", np.sum(np.sum(xiso0[:, iso[:, 1] == 52], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass Xe Z=54:", np.sum(np.sum(xiso0[:, iso[:, 1] == 54], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass W  Z=74:", np.sum(np.sum(xiso0[:, iso[:, 1] == 74], axis=1) * dat.f.mass) * eqsymfac)
-    print("total element mass Pt Z=78:", np.sum(np.sum(xiso0[:, iso[:, 1] == 78], axis=1) * dat.f.mass) * eqsymfac)
+    for elsymbol, atomic_number in testelements:
+        print(
+            f"total element mass {elsymbol:<2} Z={atomic_number:<2}:",
+            np.sum(np.sum(xiso0[:, iso[:, 1] == atomic_number], axis=1) * dat.f.mass) * eqsymfac,
+        )
 
     test = np.sum(xint, axis=0) - 1.0
     test = np.where(test > -1, test, 0.0)
@@ -416,9 +413,6 @@ def get_grid(
             for nr in range(nvr):
                 cellid = nz * nvr + nr + 1
                 if dmgrid[nr, nz] > (1e-100 * mtot):
-                    # print(
-                    # f"{nr} {nz} {temint[nr, nz]} {q_ergperg[nr, nz]} {rhoint[nr, nz]} {dmgrid[nr, nz]} {xint[nr, nz]}"
-                    # )
                     wloc = wall[nr, nz, :] * rho2dtraj / rho2dhat
                     wloc /= np.sum(wloc)
                     pids = np.where(wloc > 1.0e-20)[0]

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -825,7 +825,7 @@ def get_standard_columns(dimensions: int, includenico57: bool = False, pos_unkno
     return cols
 
 
-def _customcolsortkey(col: str) -> tuple[float, int]:
+def customcolsortkey(col: str) -> tuple[float, int]:
     """Sort nuclide mass fraction columns by atomic number then mass number, and other columns last."""
     return get_z_a_nucname(col) if col.startswith("X_") else (math.inf, 0)
 
@@ -944,7 +944,7 @@ def save_modeldata(
 
     dfmodel = dfmodel.with_columns(pl.col("inputcellid").cast(pl.Int32))
     customcols = [col for col in dfmodel.collect_schema().names() if col not in standardcols]
-    customcols.sort(key=_customcolsortkey)
+    customcols.sort(key=customcolsortkey)
 
     modelfilepath = resolve_outputfile(outpath, "model.txt")
 

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -66,7 +66,7 @@ def get_dfelemabund_from_dfmodel(dfmodel: pl.DataFrame) -> pl.DataFrame:
     return dfelabundances
 
 
-def _extracted_file_is_complete(path_extracted_file: Path) -> bool:
+def extracted_file_is_complete(path_extracted_file: Path) -> bool:
     """Report whether a previously extracted member is present and non-empty."""
     if not path_extracted_file.is_file() or path_extracted_file.stat().st_size == 0:
         return False
@@ -77,7 +77,7 @@ def _extracted_file_is_complete(path_extracted_file: Path) -> bool:
     return False
 
 
-def _extract_tar_member_atomic(tarfilepath: Path, memberfilename: str, path_extracted_file: Path) -> None:
+def extract_tar_member_atomic(tarfilepath: Path, memberfilename: str, path_extracted_file: Path) -> None:
     """Extract one tar member into place through a temporary file and an atomic replace.
 
     Several processes routinely want the same trajectory member at once. Extracting straight to the destination
@@ -127,7 +127,7 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
     ]
     tarfilepath = next((tarfilepath for tarfilepath in tarfilepaths if tarfilepath.is_file()), None)
 
-    if _extracted_file_is_complete(path_extracted_file):
+    if extracted_file_is_complete(path_extracted_file):
         return path_extracted_file
 
     if tarfilepath is None:
@@ -138,7 +138,7 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
 
     # and memberfilename.endswith(".dat")
     try:
-        _extract_tar_member_atomic(tarfilepath, memberfilename, path_extracted_file)
+        extract_tar_member_atomic(tarfilepath, memberfilename, path_extracted_file)
     except OSError:
         print(f"Problem extracting file {memberfilename} from {tarfilepath}")
         raise

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -28,7 +28,7 @@ testdatapath = at.get_path("testdata")
 modelpath_classic_3d = testdatapath / "test-classicmode_3d"
 
 
-def _trajectory_member_size(traj_root: Path, memberfilename: str, _worker: int) -> int:
+def trajectory_member_size(traj_root: Path, memberfilename: str, _worker: int) -> int:
     """Return the byte count one process sees for a trajectory tar member, extracting it if needed."""
     filepath = at.inputmodel.rprocess_from_trajectory.get_tar_member_extracted_path(
         traj_root=traj_root, particleid=114511, memberfilename=memberfilename
@@ -50,7 +50,7 @@ def test_tar_member_extraction_is_atomic(tmp_path: Path) -> None:
     with tarfile.open(traj_root / "114511.tar.xz", "r:*") as tarfilehandle:
         membersize = tarfilehandle.getmember(memberfilename).size
 
-    readsize = partial(_trajectory_member_size, traj_root, memberfilename)
+    readsize = partial(trajectory_member_size, traj_root, memberfilename)
     # at.parallel_map would give a thread pool on free-threaded builds, and only separate processes can race on
     # the filesystem. Spawn for the same reason parallel_map does: forking with polars/rayon threads live is unsafe.
     with ProcessPoolExecutor(max_workers=nworkers, mp_context=multiprocessing.get_context("spawn")) as executor:
@@ -1935,7 +1935,7 @@ def test_energyfiles_from_trajectory() -> None:
     assert dftimes_and_rate["rate"].max() == pytest.approx(1.0)
 
 
-def _write_2d_model(
+def write_2d_model(
     modeldir: Path, ncoordgridrcyl: int, ncoordgridz: int, vmax_cmps: float, t_model_days: float, zshift: float = 0.0
 ) -> Path:
     """Write a 2D cylindrical model.txt whose cell midpoints follow the ARTIS grid definition."""
@@ -1960,7 +1960,7 @@ def test_get_modeldata_2d(tmp_path: Path) -> None:
     """A 2D cylindrical model must be read with the right grid metadata and cell positions."""
     ncoordgridrcyl, ncoordgridz = 4, 6
     vmax_cmps, t_model_days = 1.0e9, 1.0
-    modelfile = _write_2d_model(tmp_path, ncoordgridrcyl, ncoordgridz, vmax_cmps, t_model_days)
+    modelfile = write_2d_model(tmp_path, ncoordgridrcyl, ncoordgridz, vmax_cmps, t_model_days)
 
     dfmodel, modelmeta = at.inputmodel.get_modeldata(modelfile)
 
@@ -1990,7 +1990,7 @@ def test_get_modeldata_2d_rejects_misplaced_cells(tmp_path: Path) -> None:
     vmax_cmps, t_model_days = 1.0e9, 1.0
     wid_init_z = 2 * vmax_cmps * t_model_days * at.constants.day_to_s / ncoordgridz
     # shift every cell a whole cell width along z, which no cell centre can be
-    modelfile = _write_2d_model(tmp_path, ncoordgridrcyl, ncoordgridz, vmax_cmps, t_model_days, zshift=1.5 * wid_init_z)
+    modelfile = write_2d_model(tmp_path, ncoordgridrcyl, ncoordgridz, vmax_cmps, t_model_days, zshift=1.5 * wid_init_z)
 
     with pytest.raises(AssertionError, match="pos_z_mid"):
         at.inputmodel.get_modeldata(modelfile)

--- a/artistools/lightcurve/__init__.py
+++ b/artistools/lightcurve/__init__.py
@@ -7,6 +7,7 @@ from artistools.lightcurve.lightcurve import find_bol_reflightcurve_file as find
 from artistools.lightcurve.lightcurve import find_lightcurve_file as find_lightcurve_file
 from artistools.lightcurve.lightcurve import generate_band_lightcurve_data as generate_band_lightcurve_data
 from artistools.lightcurve.lightcurve import get_band_lightcurve as get_band_lightcurve
+from artistools.lightcurve.lightcurve import get_bolometric_luminosities as get_bolometric_luminosities
 from artistools.lightcurve.lightcurve import get_colour_delta_mag as get_colour_delta_mag
 from artistools.lightcurve.lightcurve import get_filter_data as get_filter_data
 from artistools.lightcurve.lightcurve import get_from_packets as get_from_packets

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -363,6 +363,35 @@ def generate_band_lightcurve_data(
     return filters_dict
 
 
+def get_bolometric_luminosities(
+    modelpath: Path,
+    timesteps: Sequence[int],
+    dirbin: int = -1,
+    average_over_phi: bool = False,
+    average_over_theta: bool = False,
+) -> list[float]:
+    """Return the bolometric luminosity in erg/s of one direction bin at each given timestep.
+
+    The luminosity comes from an integral of the emergent spectrum at a distance of 1 Mpc.
+    One collect_all call evaluates the queries of all the timesteps together.
+    """
+    lazyspectra = [
+        at.spectra.get_spectra(
+            modelpath=modelpath,
+            timestepmin=timestep,
+            timestepmax=timestep,
+            average_over_phi=average_over_phi,
+            average_over_theta=average_over_theta,
+        )[dirbin]
+        for timestep in timesteps
+    ]
+    Mpc_to_cm = at.constants.megaparsec_to_cm
+    return [
+        float(np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"]) * 4 * np.pi * np.power(Mpc_to_cm, 2))
+        for spectrum in pl.collect_all(lazyspectra)
+    ]
+
+
 def bolometric_magnitude(
     modelpath: Path,
     timearray: Collection[float | str],
@@ -372,31 +401,35 @@ def bolometric_magnitude(
     average_over_theta: bool = False,
 ) -> tuple[list[float], list[float]]:
     """Return the times and bolometric magnitudes obtained by integrating the spectra of one direction bin."""
-    magnitudes = []
-    times = []
+    selectedtimes = [
+        (timestep, time)
+        for timestep, time in enumerate(float(time) for time in timearray)
+        if (args.timemin is None or args.timemin <= time) and (args.timemax is None or args.timemax >= time)
+    ]
 
-    Mpc_to_cm = at.constants.megaparsec_to_cm
-    for timestep, time in enumerate(float(time) for time in timearray):
-        if (args.timemin is None or args.timemin <= time) and (args.timemax is None or args.timemax >= time):
-            if angle == -1:
-                spectrum = at.spectra.get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep)[
-                    -1
-                ].collect()
-            elif args.plotvspecpol:
-                spectrum = at.spectra.get_vspecpol_spectrum(modelpath, time, angle, args).collect()
-            else:
-                spectrum = at.spectra.get_spectra(
-                    modelpath=modelpath,
-                    timestepmin=timestep,
-                    timestepmax=timestep,
-                    average_over_phi=average_over_phi,
-                    average_over_theta=average_over_theta,
-                )[angle].collect()
-            integrated_flux = np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"])
-            integrated_luminosity = integrated_flux * 4 * np.pi * np.power(Mpc_to_cm, 2)
-            magnitude = float(lum_lsun_to_mag(np.asarray(integrated_luminosity / Lsun_to_erg_per_s)))
-            magnitudes.append(magnitude)
-            times.append(time)
+    if angle != -1 and args.plotvspecpol:
+        Mpc_to_cm = at.constants.megaparsec_to_cm
+        luminosities = [
+            float(np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"]) * 4 * np.pi * np.power(Mpc_to_cm, 2))
+            for spectrum in (
+                at.spectra.get_vspecpol_spectrum(modelpath, time, angle, args).collect() for _, time in selectedtimes
+            )
+        ]
+    else:
+        # spec.out supplies the angle-averaged spectrum, and the direction-bin average options do not apply to it
+        if angle == -1:
+            average_over_phi = False
+            average_over_theta = False
+        luminosities = get_bolometric_luminosities(
+            modelpath,
+            [timestep for timestep, _ in selectedtimes],
+            dirbin=angle,
+            average_over_phi=average_over_phi,
+            average_over_theta=average_over_theta,
+        )
+
+    times = [time for _, time in selectedtimes]
+    magnitudes = [float(lum_lsun_to_mag(np.asarray(lum / Lsun_to_erg_per_s))) for lum in luminosities]
 
     return times, magnitudes
 

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -777,9 +777,7 @@ def make_lightcurve_plot(
 
 def create_axes(args: argparse.Namespace) -> tuple[mplfig.Figure, npt.NDArray[np.object_] | mplax.Axes]:
     """Return the figure and axes, using a subplot grid when several filters or colours are plotted."""
-    args.subplots = False  # TODO: set as command line arg
-
-    if (args.filter and len(args.filter) > 1) or args.subplots:
+    if args.filter and len(args.filter) > 1:
         args.subplots = True
         rows = 2
         cols = 3
@@ -1425,11 +1423,6 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     addarg_show(parser)
     addarg_verbose(parser)
-
-    # parser.add_argument('--calculate_peakmag_risetime_delta_m15', action='store_true',
-    #                     help='Calculate band risetime, peak mag and delta m15 values for '
-    #                     'the models specified using a polynomial fitting method and '
-    #                     'print to screen')
 
     parser.add_argument(
         "--save_angle_averaged_peakmag_risetime_delta_m15_to_file",

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -79,27 +79,18 @@ def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: a
     """Write one model's per-direction-bin peak magnitude, rise time, and decline rate to a text file."""
     if args.save_viewing_angle_peakmag_risetime_delta_m15_to_file:
         outputfolder = at.resolve_outputfile(args.outputfile, "viewingangledata.txt").parent
+        columns = [args.band_peakmag_polyfit, args.band_risetime_polyfit, args.band_deltam15_polyfit]
+        header = "peak_mag_polyfit risetime_polyfit deltam15_polyfit"
         if args.include_delta_m40:
-            np.savetxt(
-                outputfolder / f"{band_name}band_{modelname}_viewing_angle_data.txt",
-                np.c_[
-                    args.band_peakmag_polyfit,
-                    args.band_risetime_polyfit,
-                    args.band_deltam15_polyfit,
-                    args.band_deltam40_polyfit,
-                ],
-                delimiter=" ",
-                header="peak_mag_polyfit risetime_polyfit deltam15_polyfit deltam40_polyfit",
-                comments="",
-            )
-        else:
-            np.savetxt(
-                outputfolder / f"{band_name}band_{modelname}_viewing_angle_data.txt",
-                np.c_[args.band_peakmag_polyfit, args.band_risetime_polyfit, args.band_deltam15_polyfit],
-                delimiter=" ",
-                header="peak_mag_polyfit risetime_polyfit deltam15_polyfit",
-                comments="",
-            )
+            columns.append(args.band_deltam40_polyfit)
+            header += " deltam40_polyfit"
+        np.savetxt(
+            outputfolder / f"{band_name}band_{modelname}_viewing_angle_data.txt",
+            np.column_stack(columns),
+            delimiter=" ",
+            header=header,
+            comments="",
+        )
 
     elif wants_angle_averaged_data(args):
         args.band_risetime_angle_averaged_polyfit.append(args.band_risetime_polyfit)
@@ -111,13 +102,6 @@ def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: a
     args.band_deltam15_polyfit = []
     if args.include_delta_m40:
         args.band_deltam40_polyfit = []
-
-    # if args.magnitude and not (
-    #         args.calculate_peakmag_risetime_delta_m15 or args.save_angle_averaged_peakmag_risetime_delta_m15_to_file
-    #         or args.save_viewing_angle_peakmag_risetime_delta_m15_to_file or args.test_viewing_angle_fit
-    #         or args.make_viewing_angle_peakmag_risetime_scatter_plot or
-    #         args.make_viewing_angle_peakmag_delta_m15_scatter_plot or args.plotviewingangle):
-    #     plt.plot(time, magnitude, label=modelname, color=colours[modelnumber], linewidth=3)
 
 
 def write_viewing_angle_data(band_name: str, modelnames: list[str], args: argparse.Namespace) -> None:
@@ -523,14 +507,7 @@ def second_band_brightness_at_peak_first_band(
 
         fxfit, xfit = lightcurve_polyfit(time, brightness_in_mag, args)
 
-        closest_list_time_to_first_band_peak = at.match_closest_time(
-            reftime=data[f"time_{bands[0]}max"][anglenumber], searchtimes=xfit
-        )
-
-        for ii, xfits in enumerate(xfit):
-            if float(xfits) == closest_list_time_to_first_band_peak:
-                index_at_max = ii
-                break
+        index_at_max = int(np.abs(np.asarray(xfit, dtype=float) - data[f"time_{bands[0]}max"][anglenumber]).argmin())
 
         brightness_in_second_band_at_first_band_peak = fxfit[index_at_max]
         print(brightness_in_second_band_at_first_band_peak)
@@ -640,11 +617,12 @@ def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Names
 
     plotkwargs: dict[str, t.Any] = {}
 
-    lcdataframes = at.lightcurve.readfile(at.lightcurve.find_lightcurve_file(modelpath, directionresolved=True))
+    lcdataframes_lazy = at.lightcurve.readfile(at.lightcurve.find_lightcurve_file(modelpath, directionresolved=True))
 
-    timetoplot = at.match_closest_time(
-        reftime=args.timedays, searchtimes=lcdataframes[0].collect()["time_days"].to_list()
-    )
+    # one collect_all call parses light_curve_res.out one time for all the direction bins
+    lcdataframes = dict(zip(lcdataframes_lazy.keys(), pl.collect_all(list(lcdataframes_lazy.values())), strict=True))
+
+    timetoplot = at.match_closest_time(reftime=args.timedays, searchtimes=lcdataframes[0]["time_days"].to_list())
     print(timetoplot)
 
     for angleindex, lcdata in lcdataframes.items():
@@ -654,7 +632,7 @@ def plot_viewanglebrightness_at_fixed_time(modelpath: Path, args: argparse.Names
         )
 
         # readfile derives the erg/s column, so it does not have to be converted here again
-        brightness = lcdata.filter(pl.col("time_days") == timetoplot).select("luminosity_erg/s").collect().item(0, 0)
+        brightness = lcdata.filter(pl.col("time_days") == timetoplot).select("luminosity_erg/s").item(0, 0)
         if args.colorbarphi:
             xvalues = int(angleindex / 10)
             xlabels = costheta_viewing_angle_bins

--- a/artistools/lightcurve/writebollightcurvedata.py
+++ b/artistools/lightcurve/writebollightcurvedata.py
@@ -10,6 +10,7 @@ import polars as pl
 import polars.selectors as cs
 
 import artistools as at
+from artistools.lightcurve.lightcurve import get_bolometric_luminosities
 
 
 def get_bol_lc_from_spec(modelpath: Path) -> pl.DataFrame:
@@ -19,16 +20,9 @@ def get_bol_lc_from_spec(modelpath: Path) -> pl.DataFrame:
     # one pass gives both the time labels and the timesteps they came from, so the two cannot drift apart
     selected = [(ts, timestr) for ts, timestr in enumerate(timearray) if 5 < float(timestr) < 80]
     lightcurvedata: dict[str, t.Any] = {"time": [timestr for _, timestr in selected]}
-    Mpc_to_cm = at.constants.megaparsec_to_cm
-    bol_luminosity: dict[int, list[t.Any]] = {angle: [] for angle in range(len(res_specdata))}
-    for timestep, _ in selected:
-        spectra_alldirbins = at.spectra.get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep)
-        for angle in range(len(res_specdata)):
-            spectrum = spectra_alldirbins[angle].collect()
-            integrated_flux = np.trapezoid(spectrum["f_lambda"], spectrum["lambda_angstroms"])
-            bol_luminosity[angle].append(integrated_flux * 4 * np.pi * Mpc_to_cm**2)
-
-    for angle, luminosities in bol_luminosity.items():
+    timesteps = [ts for ts, _ in selected]
+    for angle in range(len(res_specdata)):
+        luminosities = get_bolometric_luminosities(modelpath, timesteps, dirbin=angle)
         lightcurvedata[f"angle={angle}"] = np.log10(luminosities)
 
     lightcurvedataframe = pl.DataFrame(lightcurvedata).with_columns(cs.float().replace([np.inf, -np.inf], 0.0))

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -1,7 +1,6 @@
 """Plotting of emission line fluxes and flux ratios."""
 
 import argparse
-import contextlib
 import json
 import math
 import typing as t
@@ -535,7 +534,7 @@ def make_emitting_regions_plot(args: argparse.Namespace) -> None:
     args.outputfile = at.resolve_outputfile(args.outputfile, "emittingregions.pdf")
 
     args.modelpath.append(None)
-    args.label.append(f"All models: {args.label}")
+    args.label.append(f"All models: {', '.join(args.label)}")
     args.modeltag.append("all")
     for modelindex, (modelpath, modellabel, modeltag) in enumerate(
         zip(args.modelpath, args.label, args.modeltag, strict=False)
@@ -576,46 +575,32 @@ def make_emitting_regions_plot(args: argparse.Namespace) -> None:
 
             dfpackets = dfpackets.join(dfestimators, on=["em_timestep", em_mgicolumn], how="inner")
 
-            for tmid, tstart, tend in zip(times_days, args.timebins_tstart, args.timebins_tend, strict=False):
-                for feature in emfeatures:
-                    dfpackets_selected = (
-                        dfpackets
-                        .filter(pl.col("t_arrive_d").is_between(tstart, tend, closed="both"))
-                        .filter(pl.col(args.emtypecolumn).is_in(feature.linelistindices))
-                        .select("em_log10nne", "em_Te")
-                        .collect()
-                    )
-                    if dfpackets_selected.is_empty():
-                        emdata_all[modelindex][tmid, feature.colname] = {
-                            "em_log10nne": np.array([]),
-                            "em_Te": np.array([]),
-                        }
-                    else:
-                        emdata_all[modelindex][tmid, feature.colname] = {
-                            "em_log10nne": dfpackets_selected["em_log10nne"].to_numpy(),
-                            "em_Te": dfpackets_selected["em_Te"].to_numpy(),
-                        }
+            # one collect gives all the time bins and features, then the loop filters the eager frame
+            dfpackets_collected = dfpackets.select("t_arrive_d", args.emtypecolumn, "em_log10nne", "em_Te").collect()
 
-            estimators = at.estimators.read_estimators(modelpath)
-            modeldata = at.inputmodel.get_modeldata(modelpath)[0].collect()
+            for tmid, tstart, tend in zip(times_days, args.timebins_tstart, args.timebins_tend, strict=False):
+                dfpackets_timebin = dfpackets_collected.filter(
+                    pl.col("t_arrive_d").is_between(tstart, tend, closed="both")
+                )
+                for feature in emfeatures:
+                    dfpackets_selected = dfpackets_timebin.filter(
+                        pl.col(args.emtypecolumn).is_in(feature.linelistindices)
+                    )
+                    emdata_all[modelindex][tmid, feature.colname] = {
+                        "em_log10nne": dfpackets_selected["em_log10nne"].to_numpy(),
+                        "em_Te": dfpackets_selected["em_Te"].to_numpy(),
+                    }
+
+            dfestimators_collected = dfestimators.select("em_timestep", "em_Te", "em_log10nne").collect()
+            tstartlist = at.get_timestep_times(modelpath, loc="start")
+            tendlist = at.get_timestep_times(modelpath, loc="end")
             Tedata_all[modelindex] = {}
             log10nnedata_all[modelindex] = {}
             for tmid, tstart, tend in zip(times_days, args.timebins_tstart, args.timebins_tend, strict=False):
-                Tedata_all[modelindex][tmid] = []
-                log10nnedata_all[modelindex][tmid] = []
-                tstartlist = at.get_timestep_times(modelpath, loc="start")
-                tendlist = at.get_timestep_times(modelpath, loc="end")
                 tslist = [ts for ts in range(len(tstartlist)) if tendlist[ts] >= tstart and tstartlist[ts] <= tend]
-                for timestep in tslist:
-                    for modelgridindex in range(modeldata.height):
-                        Te, log10nne = None, None
-                        with contextlib.suppress(KeyError):
-                            Te = estimators[timestep, modelgridindex]["Te"]
-                            log10nne = math.log10(estimators[timestep, modelgridindex]["nne"])
-
-                        if Te is not None and log10nne is not None:
-                            Tedata_all[modelindex][tmid].append(Te)
-                            log10nnedata_all[modelindex][tmid].append(log10nne)
+                dfestimators_timebin = dfestimators_collected.filter(pl.col("em_timestep").is_in(tslist))
+                Tedata_all[modelindex][tmid] = dfestimators_timebin["em_Te"].to_list()
+                log10nnedata_all[modelindex][tmid] = dfestimators_timebin["em_log10nne"].to_list()
 
         if modeltag != "all":
             continue

--- a/artistools/misc/general.py
+++ b/artistools/misc/general.py
@@ -45,7 +45,7 @@ def vec_len(vec: Sequence[float] | npt.NDArray[np.floating]) -> float:
 
 
 @functools.lru_cache
-def _savgol_coeffs(window_length: int, polyorder: int) -> npt.NDArray[np.float64]:
+def savgol_coeffs(window_length: int, polyorder: int) -> npt.NDArray[np.float64]:
     """Return the Savitzky-Golay smoothing coefficients for a centred window."""
     halflen = window_length // 2
     xwindow = np.arange(-halflen, halflen + 1, dtype=np.float64)
@@ -75,7 +75,7 @@ def savgol_filter(ylist: npt.ArrayLike, window_length: int, polyorder: int) -> n
         raise ValueError(msg)
 
     halflen = window_length // 2
-    filtered = np.correlate(y, _savgol_coeffs(window_length, polyorder), mode="same")
+    filtered = np.correlate(y, savgol_coeffs(window_length, polyorder), mode="same")
 
     # the outermost points have incomplete windows, so evaluate polynomial fits to the first and last full windows
     xedge = np.arange(window_length, dtype=np.float64)

--- a/artistools/misc/modelinfo.py
+++ b/artistools/misc/modelinfo.py
@@ -309,12 +309,15 @@ def get_mpiranklist(
 
 
 def read_rank_outputfiles(
-    modelpath: Path | str, filenameformat: str, timestep: int | None = None, modelgridindex: int | None = None
+    modelpath: Path | str,
+    filenameformat: str,
+    timestep: int | None = None,
+    modelgridindex: int | Sequence[int] | None = None,
 ) -> pl.DataFrame:
     """Read per-MPI-rank whitespace-separated output files (e.g. radfield_{mpirank:04d}.out) from the run folders into one DataFrame.
 
-    When a timestep or model grid cell is given, only the run folders and ranks that could contain it are read,
-    and the rows are filtered to that selection (negative values mean no filter).
+    When a timestep, a model grid cell, or a sequence of cells is given, only the run folders and ranks
+    that could contain them are read, and the rows are filtered to that selection (negative values mean no filter).
     """
     nonemptycounts = get_nonempty_cellcounts(modelpath)
     filepaths = []
@@ -351,8 +354,9 @@ def read_rank_outputfiles(
         .with_columns(pl.col("modelgridindex").cast(pl.Int64), pl.col("timestep").cast(pl.Int64))
     )
 
-    if modelgridindex is not None and modelgridindex >= 0:
-        dfout = dfout.filter(pl.col("modelgridindex") == modelgridindex)
+    matchcells = [modelgridindex] if isinstance(modelgridindex, int) else modelgridindex
+    if matchcells and all(mgi >= 0 for mgi in matchcells):
+        dfout = dfout.filter(pl.col("modelgridindex").is_in(matchcells))
     if timestep is not None and timestep >= 0:
         dfout = dfout.filter(pl.col("timestep") == timestep)
 

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -1434,6 +1434,21 @@ def test_read_rank_outputfiles_names_an_empty_cell(tmp_path: Path) -> None:
         read_rank_outputfiles(tmp_path, "nlte_{mpirank:04d}.out", modelgridindex=0)
 
 
+def test_read_rank_outputfiles_takes_a_cell_list() -> None:
+    """A sequence of cells must give the same rows as the single-cell call that it replaces."""
+    from artistools.misc.modelinfo import read_rank_outputfiles
+
+    modelpath = at.get_path("testdata") / "testmodel"
+    df_single = read_rank_outputfiles(modelpath, "nlte_{mpirank:04d}.out", timestep=40, modelgridindex=0)
+    df_list = read_rank_outputfiles(modelpath, "nlte_{mpirank:04d}.out", timestep=40, modelgridindex=[0])
+    pltest.assert_frame_equal(df_list, df_single)
+    assert not df_single.is_empty()
+
+    # a negative cell number means no filter, also inside a sequence
+    df_all = read_rank_outputfiles(modelpath, "nlte_{mpirank:04d}.out", timestep=40, modelgridindex=[0, -1])
+    pltest.assert_frame_equal(df_all, read_rank_outputfiles(modelpath, "nlte_{mpirank:04d}.out", timestep=40))
+
+
 def test_addarg_modelpath_positional_also_takes_the_option() -> None:
     """A command whose path is positional must also accept -modelpath.
 

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -28,7 +28,7 @@ from artistools.misc import dirbins
 from artistools.misc import fileio
 
 
-def _write_timesteps_out(modeldir: Path) -> None:
+def write_timesteps_out(modeldir: Path) -> None:
     """Write a minimal timesteps.out with 5 evenly spaced timesteps (mids 105..145)."""
     lines = ["#timestep tmid_days tstart_days twidth_days"]
     for ts in range(5):
@@ -1075,7 +1075,7 @@ def test_gaussian_filter_wrap() -> None:
 
 
 def test_get_timestep_of_timedays(tmp_path: Path) -> None:
-    _write_timesteps_out(tmp_path)
+    write_timesteps_out(tmp_path)
 
     # timesteps span [100,110), [110,120), ... [140,150)
     assert at.get_timestep_of_timedays(tmp_path, 125) == 2
@@ -1089,7 +1089,7 @@ def test_get_timestep_of_timedays(tmp_path: Path) -> None:
 
 
 def test_get_deposition(tmp_path: Path) -> None:
-    _write_timesteps_out(tmp_path)
+    write_timesteps_out(tmp_path)
     deplines = ["#tmid_days gammadep_Lsun positrondep_Lsun total_dep_Lsun"]
     for ts in range(5):
         tmid = 105 + ts * 10
@@ -1107,7 +1107,7 @@ def test_get_deposition(tmp_path: Path) -> None:
     # deposition times that don't line up with the timesteps are rejected
     baddir = tmp_path / "bad"
     baddir.mkdir()
-    _write_timesteps_out(baddir)
+    write_timesteps_out(baddir)
     badlines = ["#tmid_days gammadep_Lsun positrondep_Lsun total_dep_Lsun"]
     badlines.extend(f"{999 + ts} {ts + 1.0} {(ts + 1) * 0.1} {(ts + 1) * 1.1}" for ts in range(5))
     (baddir / "deposition.out").write_text("\n".join(badlines) + "\n")
@@ -1198,7 +1198,7 @@ def test_average_direction_bins_rejects_missing_bins(monkeypatch: pytest.MonkeyP
 
 def test_get_time_range_timesteps_without_clamping(tmp_path: Path) -> None:
     """A timestep range gives no times in days, so the timestep bounds must be used even when not clamping."""
-    _write_timesteps_out(tmp_path)
+    write_timesteps_out(tmp_path)
 
     for clamp in (True, False):
         timestepmin, timestepmax, tlow, thigh = at.get_time_range(

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -141,8 +141,10 @@ def add_lte_pops(
     return dfpop
 
 
-def read_files(modelpath: str | Path, timestep: int | None = None, modelgridindex: int | None = None) -> pl.DataFrame:
-    """Read in NLTE populations from a model for a particular timestep and grid cell."""
+def read_files(
+    modelpath: str | Path, timestep: int | None = None, modelgridindex: int | Sequence[int] | None = None
+) -> pl.DataFrame:
+    """Read in NLTE populations from a model for a particular timestep and one or more grid cells."""
     return at.read_rank_outputfiles(
         modelpath, "nlte_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
     )

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -612,8 +612,8 @@ def make_singletimestep_plot(
     time_days = at.get_timestep_time(modelpath, timestep)
     modelname = at.get_model_name(modelpath)
 
-    # one read of the rank files supplies the data for every cell in mgilist
-    dfpop_allcells = at.nltepops.read_files(modelpath, timestep=timestep)
+    # one read of the ranks that own the cells in mgilist supplies the data for every cell
+    dfpop_allcells = at.nltepops.read_files(modelpath, timestep=timestep, modelgridindex=list(mgilist))
     dfpop = dfpop_allcells.filter(pl.col("modelgridindex") == mgilist[0])
 
     if dfpop.is_empty():

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -541,8 +541,14 @@ def plot_populations_with_time_or_velocity(
     for modelnumber, modelpath in enumerate(modelpaths):
         populations = {}
 
+        # the loop changes only the cell or only the timestep, thus one read with that filter supplies the whole loop
+        dfpop_all = (
+            at.nltepops.read_files(modelpath, modelgridindex=modelgridindex_list[0])
+            if args.x == "time"
+            else at.nltepops.read_files(modelpath, timestep=timesteps[0])
+        )
         for timestep, mgi in zip(timesteps, modelgridindex_list, strict=False):
-            dfpop = at.nltepops.read_files(modelpath, timestep=timestep, modelgridindex=mgi)
+            dfpop = dfpop_all.filter((pl.col("timestep") == timestep) & (pl.col("modelgridindex") == mgi))
             if dfpop.is_empty():
                 continue
             timesteppops = dfpop.filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage))
@@ -606,7 +612,9 @@ def make_singletimestep_plot(
     time_days = at.get_timestep_time(modelpath, timestep)
     modelname = at.get_model_name(modelpath)
 
-    dfpop = at.nltepops.read_files(modelpath, timestep=timestep, modelgridindex=mgilist[0])
+    # one read of the rank files supplies the data for every cell in mgilist
+    dfpop_allcells = at.nltepops.read_files(modelpath, timestep=timestep)
+    dfpop = dfpop_allcells.filter(pl.col("modelgridindex") == mgilist[0])
 
     if dfpop.is_empty():
         print(f"No NLTE population data for modelgrid cell {mgilist[0]} timestep {timestep}")
@@ -671,7 +679,7 @@ def make_singletimestep_plot(
             W = math.nan
             nne = math.nan
 
-        dfpop = at.nltepops.read_files(modelpath, timestep=timestep, modelgridindex=modelgridindex)
+        dfpop = dfpop_allcells.filter(pl.col("modelgridindex") == modelgridindex)
 
         if dfpop.is_empty():
             print(f"No NLTE population data for modelgrid cell {modelgridindex} timestep {timestep}")

--- a/artistools/radfield.py
+++ b/artistools/radfield.py
@@ -175,8 +175,6 @@ def plot_line_estimators(
     **plotkwargs: t.Any,
 ) -> float:
     """Plot the Jblue_lu values from the detailed line estimators on a spectrum."""
-    ymax = -1
-
     # the detailed line estimators have bin_num < -1. Cell zero and timestep zero are falsy, so these filters must
     # test against None rather than truthiness
     radfielddataselected = select_radfield_subset(
@@ -194,14 +192,13 @@ def plot_line_estimators(
     ymax = radfielddataselected["Jb_lambda"].max()
     assert isinstance(ymax, float)
 
-    if not radfielddataselected.is_empty():
-        axis.scatter(
-            radfielddataselected["lambda_angstroms"],
-            radfielddataselected["Jb_lambda"],
-            label="Line estimators",
-            s=0.2,
-            **plotkwargs,
-        )
+    axis.scatter(
+        radfielddataselected["lambda_angstroms"],
+        radfielddataselected["Jb_lambda"],
+        label="Line estimators",
+        s=0.2,
+        **plotkwargs,
+    )
     return ymax
 
 

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -476,7 +476,11 @@ def get_spectrum_at_time(
 
 
 @lru_cache(maxsize=4)
-def _get_binned_lambda_frame_cached(lambda_bin_edges_bytes: bytes, count: int) -> pl.LazyFrame:
+def get_binned_lambda_frame_cached(lambda_bin_edges_bytes: bytes, count: int) -> pl.LazyFrame:
+    """Return the wavelength bin frame for the given packed bin edges.
+
+    The bytes key makes the arguments hashable for the lru_cache.
+    """
     lambda_bin_edges = np.frombuffer(lambda_bin_edges_bytes, dtype=np.float64, count=count)
     return (
         pl
@@ -498,7 +502,7 @@ def get_binned_lambda_frame(lambda_bin_edges: npt.NDArray[np.floating]) -> pl.La
     separately. Without the cache, the code makes this frame again for each contribution.
     """
     edges = np.ascontiguousarray(lambda_bin_edges, dtype=np.float64)
-    return _get_binned_lambda_frame_cached(edges.tobytes(), edges.size)
+    return get_binned_lambda_frame_cached(edges.tobytes(), edges.size)
 
 
 def select_dirbins(alldirbins: list[int], requested: Sequence[int] | None) -> list[int]:
@@ -958,8 +962,14 @@ def get_specpol_data(dirbin: int = -1, modelpath: Path | str | None = None) -> d
     return split_dataframe_stokesparams(specdata)
 
 
+# maxsize is small because this reads eagerly and every cached entry retains a whole vspecpol_total file.
+# Callers collect the frames once per timestep, so a cache miss on each call would parse the file again.
+@lru_cache(maxsize=2)
 def get_vspecpol_data(vspecindex: int, modelpath: Path | str) -> dict[str, pl.LazyFrame]:
-    """Return the I, Q, and U virtual packet spectra of one observer, summing the per-rank files if needed."""
+    """Return the I, Q, and U virtual packet spectra of one observer, summing the per-rank files if needed.
+
+    Callers must not mutate the returned dict, which is shared between calls.
+    """
     assert modelpath is not None
     # alternatively use f'vspecpol_averaged-{angle}.out' ?
 

--- a/artistools/spectra/writespectra.py
+++ b/artistools/spectra/writespectra.py
@@ -45,20 +45,23 @@ def write_flambda_spectra(modelpath: Path) -> None:
     assert tmax_d_valid is not None
     timesteps = [ts for ts in range(tslast + 1) if tmids[ts] >= tmin_d_valid and tmids[ts] <= tmax_d_valid]
 
-    for timestep in timesteps:
-        dfspectrum = get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep)[-1].collect()
-
+    # one collect_all call evaluates the queries of all the timesteps together
+    dfspectra_alltimesteps = pl.collect_all([
+        get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep)[-1] for timestep in timesteps
+    ])
+    for timestep, dfspectrum in zip(timesteps, dfspectra_alltimesteps, strict=True):
         write_spectrum(dfspectrum, outfilepath=outdirectory / f"spectrum_ts{timestep:02.0f}_{tmids[timestep]:.2f}d.txt")
 
-    for timestep in timesteps:
-        dfspectra = get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep, average_over_phi=True)
-        if 0 in dfspectra:
+    lzspectra_polar = [
+        get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep, average_over_phi=True)
+        for timestep in timesteps
+    ]
+    if lzspectra_polar and 0 in lzspectra_polar[0]:
+        dfspectra_polar = pl.collect_all([dirbin_spectra[0] for dirbin_spectra in lzspectra_polar])
+        for timestep, dfspectrum in zip(timesteps, dfspectra_polar, strict=True):
             write_spectrum(
-                dfspectra[0].collect(),
-                outfilepath=outdirectory / f"spectrum_polar00_ts{timestep:02.0f}_{tmids[timestep]:.2f}d.txt",
+                dfspectrum, outfilepath=outdirectory / f"spectrum_polar00_ts{timestep:02.0f}_{tmids[timestep]:.2f}d.txt"
             )
-        else:
-            break
 
 
 def addargs(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
## Summary

This change applies the confirmed findings of a full code review. It removes the per-timestep collect loops, deletes dead code, and removes the underscore prefixes from function names.

### Fewer collects and reads

- `make_emitting_regions_plot` collects the packets frame and the estimator frame one time, then filters per time bin and feature. The per-cell `read_estimators` loop now uses the lazy estimator frame that the join already built.
- A new function `get_bolometric_luminosities` integrates the spectra of one direction bin with one `collect_all` call. `bolometric_magnitude` and `get_bol_lc_from_spec` use it and only differ in the unit conversion.
- `write_flambda_spectra` collects the spectra of all timesteps with one `collect_all` call.
- `get_vspecpol_data` has an `lru_cache`, thus the callers do not parse the `vspecpol_total` file again for each timestep.
- `plot_viewanglebrightness_at_fixed_time` collects all direction bins with one `collect_all` call, thus it parses `light_curve_res.out` one time.
- `plotnltepops` reads the nlte rank files one time per model or per plot, then filters per timestep and cell.

### Dead code and duplication

- The `args.subplots` initialiser made the `or args.subplots` test dead. Both are gone.
- `plot_line_estimators` had an unused `ymax` initialiser and an always-true `is_empty` guard.
- `second_band_brightness_at_peak_first_band` finds the fit index with `argmin` in place of a float-equality scan.
- `save_viewing_angle_data_for_plotting` builds one `np.savetxt` call in place of two near-identical calls.
- `from_e2e_model` prints the element masses in a loop over an element list, and uses `range(ntraj)` for the particle loops. The printed text does not change.
- The commented-out blocks in `viewingangleanalysis.py`, `plotlightcurve.py`, and `from_e2e_model.py` are gone.
- The "All models" legend label now joins the model labels. Before, it interpolated the whole list and the legend showed a list repr.

### Renames

The repository rules forbid an underscore prefix on a function name. This change renames the fifteen prefixed functions and updates every caller. Examples: `_scan_artis_estimators` becomes `scan_artis_estimators`, and `_get_elements_df` becomes `get_elements_df`.

## Test plan

- `ruff format`, `ruff check`, `pyrefly check`, `ty check`, `refurb`, `vulture`, and the prek hooks all pass.
- The full pytest suite passes on the rebased branch: 543 passed, 1 skipped.
- A manual run against the test model checked the new emitting-regions queries, because no test covers that code path. It needs a `floers_te_nne.json` reference file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)