### PR TITLE
Fix twelve command-line defects from a full review of the codebase

### DIFF
--- a/.claude/hooks/verify-tree.sh
+++ b/.claude/hooks/verify-tree.sh
@@ -30,8 +30,14 @@ cd "$projectdir" || exit 0
 run() { uv run --no-sync -- "$@"; }
 
 lint="$(run ruff check --no-fix 2>&1)"; lintstatus=$?
-tycheck="$(run ty check 2>&1)"; tystatus=$?
-pyreflycheck="$(run pyrefly check 2>&1)"; pyreflystatus=$?
+
+# a personal ~/.config/ty/ty.toml can add extra search paths that shadow this checkout, e.g. the
+# main checkout shadows a worktree. CI reads no personal configuration, thus this check reads none
+tycheck="$(XDG_CONFIG_HOME="${TMPDIR:-/tmp}/artistools-hook-no-user-config" uv run --no-sync -- ty check 2>&1)"; tystatus=$?
+
+# the git ignore files hide every path below .claude/worktrees, thus a plain pyrefly check in a
+# worktree finds no files and checks nothing. The explicit file list makes pyrefly check the tree
+pyreflycheck="$(git ls-files -z -- '*.py' | xargs -0 uv run --no-sync -- pyrefly check 2>&1)"; pyreflystatus=$?
 pyreflycheck="$(printf '%s\n' "$pyreflycheck" | grep -v '^ *INFO ')"
 
 if [ "$lintstatus" -eq 0 ] && [ "$tystatus" -eq 0 ] && [ "$pyreflystatus" -eq 0 ]; then

--- a/artistools/commands.py
+++ b/artistools/commands.py
@@ -695,6 +695,7 @@ SINGLEDASHLONGFLAGS = frozenset({
     "-colors",
     "-colour_evolution",
     "-composition",
+    "-coneangle",
     "-dashes",
     "-deltalambda",
     "-deltalogx",

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -1366,6 +1366,13 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Choose an axis for use with args.readonlymgi. Hint: for negative use e.g. -axis=-z",
     )
 
+    parser.add_argument(
+        "-coneangle",
+        type=float,
+        default=30.0,
+        help="The full angle of the cone in degrees for -readonlymgi cone. The half angle is coneangle/2",
+    )
+
 
 def set_x_and_timesteps(args: argparse.Namespace, modelpath: Path) -> tuple[int, int]:
     """Apply the default x variable and the default time range, and return the first and last timestep.

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -401,30 +401,32 @@ def test_estimator_snapshot_classic_3d_x_axis(mockplot: mock.MagicMock) -> None:
     # order of keys is important
     # the values changed when select_cells_along_axis started to give the estimators the zero-based
     # modelgridindex. The one-based inputcellid selected the neighbour of each intended cell before.
+    # They changed again when the axis profile started to keep the innermost cell, whose pos_min is
+    # zero on the positive axis. The old filter pos_min > 0 dropped that cell from every mean.
     expectedvals = {
-        "init_fe": 0.04393352801044238,
-        "init_nistable": 0.018982497938848007,
-        "init_ni56": 0.2077651788649079,
-        "nne": 53758218157.34207,
-        "TR": 27507.6203125,
-        "Te": 47433.08046875,
-        "averageionisation_Fe": 3.425372314453125,
-        "populations_FeI": 3.0725831040676213e-24,
-        "populations_FeII": 1.5928779125425183e-13,
-        "populations_FeIII": 8.581985725514274e-05,
-        "populations_FeIV": 0.5742737034335732,
-        "populations_FeV": 0.42559488230617715,
-        "populations_CoII": 0.20000008376639494,
-        "populations_CoIII": 0.018350993919011672,
-        "populations_CoIV": 0.7816059589385986,
-        "heating_dep": 2.7398957951083184e-14,
+        "init_fe": 0.030691306495330833,
+        "init_nistable": 0.03129141867854237,
+        "init_ni56": 0.3625203213639654,
+        "nne": 138785511355.11838,
+        "TR": 32679.133463541668,
+        "Te": 49283.68359375,
+        "averageionisation_Fe": 3.5216503938039145,
+        "populations_FeI": 2.5604762125407237e-24,
+        "populations_FeII": 1.3273970472709221e-13,
+        "populations_FeIII": 7.15164795263741e-05,
+        "populations_FeIV": 0.47807180327557336,
+        "populations_FeV": 0.5218229725433048,
+        "populations_CoII": 0.166666736471993,
+        "populations_CoIII": 0.015291374246013826,
+        "populations_CoIV": 0.8180049657821655,
+        "heating_dep": 2.2832464959235988e-14,
         "heating_coll": 0.0,
-        "heating_bf": 8.98808005561809e-16,
-        "heating_ff": 4.492620069717229e-18,
-        "cooling_adiabatic": 1.940665408033783e-14,
-        "cooling_coll": 2.1374800532917157e-14,
-        "cooling_fb": 3.3767601071335755e-17,
-        "cooling_ff": 1.3946639675067307e-17,
+        "heating_bf": 7.490066713015075e-16,
+        "heating_ff": 3.7438500580976916e-18,
+        "cooling_adiabatic": 1.617221173361486e-14,
+        "cooling_coll": 1.7812333777430962e-14,
+        "cooling_fb": 2.8139667559446467e-17,
+        "cooling_ff": 1.1622199729222756e-17,
     }
 
     assert len(expectedvals) == len(mockplot.call_args_list)
@@ -1475,3 +1477,25 @@ def test_a_compact_ion_name_reads_the_ion_stage_in_upper_case() -> None:
     # a roman numeral in lower case names no ion stage, thus these names hold no ion
     for ionstr in ("Feii", "FeIi", "feii", "Sii"):
         assert not is_valid_ion(ionstr), f"{ionstr} must name no ion"
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_estimator_snapshot_classic_3d_cone(mockplot: mock.MagicMock) -> None:
+    """-readonlymgi cone selects the cells within -coneangle of the axis.
+
+    The parser did not define -coneangle, which make_cone reads, thus the cone path stopped with
+    AttributeError before this test existed.
+    """
+    at.estimators.plot(
+        argsraw=[],
+        modelpath=modelpath_classic_3d,
+        plotlist=[["Te"]],
+        outputfile=outputpath / "test_estimator_snapshot_classic_3d_cone.pdf",
+        timedays=4,
+        readonlymgi="cone",
+        axis="+z",
+        coneangle=60.0,
+    )
+
+    xvalues = np.concatenate([np.array(callargs[0][1], dtype=float) for callargs in mockplot.call_args_list])
+    assert len(xvalues) > 0

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -253,6 +253,12 @@ def get_grid(
             for _n_z in range(nvz)
         ]).reshape(nvr, nvz)
     elif model_dim == 3:
+        # an odd count in x or y puts a cell centre on the symmetry axis, where the mapping divides
+        # by the cylindrical radius
+        if numb_cells_ARTIS_x % 2 or numb_cells_ARTIS_y % 2:
+            msg = f"-ngridx and -ngridy must be even, got {numb_cells_ARTIS_x} and {numb_cells_ARTIS_y}"
+            raise ValueError(msg)
+
         vminr, vmaxr = -vmax_on_c, vmax_on_c
 
         def axis_grid(ncells: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -253,15 +253,17 @@ def get_grid(
             for _n_z in range(nvz)
         ]).reshape(nvr, nvz)
     elif model_dim == 3:
-        nvz = (
-            numb_cells_ARTIS_z // eqsymfac
-        )  # number of mapping grid cells in z direction depends on equatorial symmetry
-        vminr, vmaxr, nvr = -0.5, 0.5, 50
-        vxgridl = np.array([vminr + i * (vmaxr - vminr) / nvr for i in np.arange(numb_cells_ARTIS_x)])
-        vxgridr = np.flip(np.array([vmaxr - i * (vmaxr - vminr) / nvr for i in np.arange(numb_cells_ARTIS_x)]))
-        vxgridc = 0.5 * (vxgridl + vxgridr)
-        vygridl, vygridc, vygridr = vxgridl, vxgridc, vxgridr
-        vzgridl, vzgridc, vzgridr = vxgridl, vxgridc, vxgridr
+        vminr, vmaxr = -vmax_on_c, vmax_on_c
+
+        def axis_grid(ncells: int) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+            """Return the left edges, the centres, and the right edges of one axis of the velocity grid."""
+            gridl = np.array([vminr + i * (vmaxr - vminr) / ncells for i in range(ncells)])
+            gridr = gridl + (vmaxr - vminr) / ncells
+            return gridl, 0.5 * (gridl + gridr), gridr
+
+        vxgridl, vxgridc, vxgridr = axis_grid(numb_cells_ARTIS_x)
+        vygridl, vygridc, vygridr = axis_grid(numb_cells_ARTIS_y)
+        vzgridl, vzgridc, vzgridr = axis_grid(numb_cells_ARTIS_z)
 
         x3d = op(op(vxgridc, np.ones(numb_cells_ARTIS_y)), np.ones(numb_cells_ARTIS_z)) * (CLIGHT * t_model_init_s)
         y3d = op(op(np.ones(numb_cells_ARTIS_x), vygridc), np.ones(numb_cells_ARTIS_z)) * (CLIGHT * t_model_init_s)
@@ -330,7 +332,7 @@ def get_grid(
         hall = np.multiply.outer(np.ones((nvr, nvz)), hsmooth)
     elif model_dim == 3:
         distall = np.sqrt(oa(R3d, -rcyltraj) ** 2 + oa(z3d, -zcyltraj) ** 2)
-        hall = np.multiply.outer(np.ones((nvr, nvr, nvr)), hsmooth)
+        hall = np.multiply.outer(np.ones((numb_cells_ARTIS_x, numb_cells_ARTIS_y, numb_cells_ARTIS_z)), hsmooth)
     wall = sphkernel(distall, hall, nu)
     weight = wall * (mtraj / rho2dhat)
     weinor = (weight.T / (np.sum(weight, axis=interpol_axis) + 1.0e-100).T).T

--- a/artistools/inputmodel/slice1dfromconein3dmodel.py
+++ b/artistools/inputmodel/slice1dfromconein3dmodel.py
@@ -198,10 +198,10 @@ def make_1d_profile(args: argparse.Namespace, logprint: Callable[..., None]) -> 
         logprint("from along the axis")
         slice1d = get_profile_along_axis(args)
         # pos_min is the inner edge of a cell. On the positive axis, the outer edge is pos_min plus the
-        # cell width. On the negative axis, pos_min is already the outer edge, and the reverse and
-        # negate step below makes the velocities positive.
+        # cell width of the slice axis. On the negative axis, pos_min is already the outer edge, and
+        # the reverse and negate step below makes the velocities positive.
         pos_outer = (
-            pl.col(f"pos_{args.sliceaxis}_min") + modelmeta["wid_init"]
+            pl.col(f"pos_{args.sliceaxis}_min") + modelmeta[f"wid_init_{args.sliceaxis}"]
             if args.positive_axis
             else pl.col(f"pos_{args.sliceaxis}_min")
         )

--- a/artistools/inputmodel/slice1dfromconein3dmodel.py
+++ b/artistools/inputmodel/slice1dfromconein3dmodel.py
@@ -31,7 +31,7 @@ def make_cone(args: argparse.Namespace, logprint: Callable[..., None]) -> pl.Dat
     theta = np.radians([angle_of_cone / 2])  # angle between line of sight and edge is half angle of cone
 
     pldfmodel, modelmeta = at.get_modeldata(
-        modelpath=args.modelpath[0],
+        modelpath=at.normalize_path_list(args.modelpath)[0],
         get_elemabundances=True,
         derived_cols=[
             "volume",
@@ -68,16 +68,17 @@ def get_profile_along_axis(
     print("Getting profile along axis")
 
     if modeldata is None:
-        modeldata = at.inputmodel.get_modeldata(args.modelpath, get_elemabundances=True, derived_cols=derived_cols)[
-            0
-        ].collect()
+        modeldata = at.inputmodel.get_modeldata(
+            at.normalize_path_list(args.modelpath)[0], get_elemabundances=True, derived_cols=derived_cols
+        )[0].collect()
 
     argmin = modeldata[f"pos_{args.other_axis2}_min"].abs().arg_min()
     assert argmin is not None
     position_closest_to_axis = modeldata[f"pos_{args.other_axis2}_min"].item(argmin)
 
+    # the innermost cell on the positive axis has pos_min == 0, thus the condition must keep it
     sliceaxis_cond = (
-        (pl.col(f"pos_{args.sliceaxis}_min") > 0) if args.positive_axis else (pl.col(f"pos_{args.sliceaxis}_min") < 0)
+        (pl.col(f"pos_{args.sliceaxis}_min") >= 0) if args.positive_axis else (pl.col(f"pos_{args.sliceaxis}_min") < 0)
     )
 
     return modeldata.filter(
@@ -89,8 +90,10 @@ def get_profile_along_axis(
 
 def make_1d_profile(args: argparse.Namespace, logprint: Callable[..., None]) -> pl.DataFrame:
     """Make 1D model from 3D model."""
-    logprint("Making 1D model from 3D model:", at.get_model_name(args.modelpath[0]))
-    _, modelmeta = at.get_modeldata(modelpath=args.modelpath[0])
+    modelpath = at.normalize_path_list(args.modelpath)[0]
+    logprint("Making 1D model from 3D model:", at.get_model_name(modelpath))
+    _, modelmeta = at.get_modeldata(modelpath=modelpath)
+    args.t_model = modelmeta["t_model_init_days"]
     if args.makefromcone:
         logprint("from a cone")
         cone = make_cone(args, logprint)
@@ -194,10 +197,18 @@ def make_1d_profile(args: argparse.Namespace, logprint: Callable[..., None]) -> 
     else:  # make from along chosen axis
         logprint("from along the axis")
         slice1d = get_profile_along_axis(args)
+        # pos_min is the inner edge of a cell. On the positive axis, the outer edge is pos_min plus the
+        # cell width. On the negative axis, pos_min is already the outer edge, and the reverse and
+        # negate step below makes the velocities positive.
+        pos_outer = (
+            pl.col(f"pos_{args.sliceaxis}_min") + modelmeta["wid_init"]
+            if args.positive_axis
+            else pl.col(f"pos_{args.sliceaxis}_min")
+        )
         slice1d = (
             # Convert positions to velocities
             slice1d
-            .with_columns(pl.col(f"pos_{args.sliceaxis}_min") / (args.t_model * day_to_s * km_to_cm))
+            .with_columns((pos_outer / (args.t_model * day_to_s * km_to_cm)).alias(f"pos_{args.sliceaxis}_min"))
             .rename({f"pos_{args.sliceaxis}_min": "vel_r_max_kmps"})
             # Remove columns we don't need
             .drop("inputcellid", f"pos_{args.other_axis1}_min", f"pos_{args.other_axis2}_min")

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2175,6 +2175,21 @@ def test_from_e2e_model_3d_grid_takes_the_arguments(tmp_path: Path) -> None:
     assert np.isclose(z3d_min.min(), -xmax_cm, rtol=1e-10)
     assert np.amax(rhoint) > 0.0
 
+    # an odd count in x or y puts a cell centre on the symmetry axis, where the mapping divides by
+    # the cylindrical radius. The command must reject such a grid with a message
+    with pytest.raises(ValueError, match="must be even"):
+        get_grid(
+            datpath,
+            isopath,
+            vmax_on_c,
+            model_dim=3,
+            grid_dims=np.array([5, 6, 6]),
+            nodynej=False,
+            nohmns=False,
+            notorus=False,
+            no_nu_trapping=False,
+        )
+
 
 def test_maketardismodel_maxatomicnumber_from_command_line(tmp_path: Path) -> None:
     """-maxatomicnumber reads an integer from the command line.

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2086,3 +2086,107 @@ def test_energyfiles_plotrate_makes_the_output_folder(tmp_path: Path) -> None:
 
     assert outfolder.is_dir(), "the command must make the folder that -o names"
     assert (outfolder / "energyfiles_plotrate.pdf").is_file(), f"no plot in {list(outfolder.iterdir())}"
+
+
+def test_make1dmodelfromaxis(tmp_path: Path) -> None:
+    """--no-makefromcone samples the cells along the axis, and both axis directions agree.
+
+    The positive-axis branch renamed the inner cell edge to vel_r_max_kmps and dropped the cell
+    with pos_min == 0. Thus the velocity of each shell was low by one cell width. The branch also
+    read args.t_model, which only the cone branch set, and passed a list of paths to get_modeldata.
+    """
+    _, modelmeta3d = at.inputmodel.get_modeldata(modelpath_3d)
+    outdirs = {}
+    for axis in ("+z", "-z"):
+        outdir = tmp_path / f"axis_{axis[1]}_{'pos' if axis[0] == '+' else 'neg'}"
+        outdir.mkdir()
+        at.inputmodel.slice1dfromconein3dmodel.main(
+            argsraw=[], modelpath=[modelpath_3d], outputpath=outdir, axis=axis, makefromcone=False
+        )
+        outdirs[axis] = outdir
+
+    dfpos = at.inputmodel.get_modeldata(outdirs["+z"] / "model_1d.txt")[0].collect()
+    dfneg = at.inputmodel.get_modeldata(outdirs["-z"] / "model_1d.txt")[0].collect()
+
+    ncells_along_axis = int(modelmeta3d["ncoordgrid"]) // 2
+    assert dfpos.height == ncells_along_axis
+    assert dfneg.height == ncells_along_axis
+
+    # the outer velocity of the outermost shell is the maximum velocity of the model
+    vmax_kmps = modelmeta3d["vmax_cmps"] / 1.0e5
+    assert np.isclose(dfpos["vel_r_max_kmps"].item(-1), vmax_kmps, rtol=1e-4)
+
+    assert np.allclose(dfpos["vel_r_max_kmps"], dfneg["vel_r_max_kmps"], rtol=1e-6)
+
+
+def test_from_e2e_model_3d_grid_takes_the_arguments(tmp_path: Path) -> None:
+    """The 3D mapping grid comes from -vmax_on_c and -ngridx/y/z.
+
+    The 3D branch held vminr, vmaxr, nvr = -0.5, 0.5, 50, thus the arguments had no effect, and a
+    grid size other than 50 stopped with a broadcast error.
+    """
+    from artistools.constants import C_cm_per_s
+    from artistools.inputmodel.from_e2e_model import get_grid
+    from artistools.inputmodel.from_e2e_model import t_model_init_s
+
+    rng = np.random.default_rng(seed=1)
+    ntraj = 4
+    ntimes = 8
+    datpath = tmp_path / "e2emodel.npz"
+    isopath = tmp_path / "iso_table.npy"
+    np.savez(
+        datpath,
+        pos=np.column_stack([np.array([0.10, 0.15, 0.20, 0.25]), np.array([0.5, 1.0, 2.0, 2.5])]),
+        idx=np.arange(1, ntraj + 1, dtype=float),
+        state=np.array([-1.0, 0.0, 0.0, 1.0]),
+        mass=np.full(ntraj, 1e-3),
+        qdot=np.full((ntraj, ntimes), 1e10),
+        hnuloss=np.zeros((ntraj, ntimes)),
+        time=np.linspace(0.0, 2.0 * t_model_init_s, ntimes),
+        nz=rng.uniform(0.01, 0.2, size=(ntraj, 2)),
+        t5out=np.column_stack([np.zeros((ntraj, 4)), np.full(ntraj, 0.3)]),
+    )
+    np.save(isopath, np.array([[2.0, 2.0], [30.0, 26.0]]))
+
+    vmax_on_c = 0.4
+    ncells = 6
+    x3d_min, _y3d_min, z3d_min, rhoint, xint, _iso, _q, _ye, _bs, eqsymfac, _dfcontribs = get_grid(
+        datpath,
+        isopath,
+        vmax_on_c,
+        model_dim=3,
+        grid_dims=np.array([ncells, ncells, ncells]),
+        nodynej=False,
+        nohmns=False,
+        notorus=False,
+        no_nu_trapping=False,
+    )
+
+    assert eqsymfac == 1
+    assert rhoint.shape == (ncells, ncells, ncells)
+    assert xint.shape == (2, ncells, ncells, ncells)
+
+    # the cell edges span -vmax to +vmax, thus the smallest left edge is -vmax and the largest is
+    # one cell width below +vmax
+    xmax_cm = vmax_on_c * C_cm_per_s * t_model_init_s
+    wid_cm = 2.0 * xmax_cm / ncells
+    assert np.isclose(x3d_min.min(), -xmax_cm, rtol=1e-10)
+    assert np.isclose(x3d_min.max(), xmax_cm - wid_cm, rtol=1e-10)
+    assert np.isclose(z3d_min.min(), -xmax_cm, rtol=1e-10)
+    assert np.amax(rhoint) > 0.0
+
+
+def test_maketardismodel_maxatomicnumber_from_command_line(tmp_path: Path) -> None:
+    """-maxatomicnumber reads an integer from the command line.
+
+    The argument had no type, thus the command compared a string with an integer and stopped with
+    TypeError before this test existed.
+    """
+    at.inputmodel.to_tardis.main(argsraw=["-inputpath", str(modelpath), "-o", str(tmp_path), "-maxatomicnumber", "26"])
+
+    csvypath = tmp_path / f"{at.get_model_name(modelpath)}.csvy"
+    assert csvypath.is_file()
+    csvytext = csvypath.read_text(encoding="utf-8")
+    assert "Fe" in csvytext
+    assert "Co" not in csvytext
+    assert "Ni" not in csvytext

--- a/artistools/inputmodel/to_tardis.py
+++ b/artistools/inputmodel/to_tardis.py
@@ -26,7 +26,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         help="Output nuclear or elemental abundances",
     )
 
-    parser.add_argument("-maxatomicnumber", default=92, help="Maximum atomic number for elemental abundances")
+    parser.add_argument("-maxatomicnumber", type=int, default=92, help="Maximum atomic number for elemental abundances")
 
     at.addarg_output(parser, kind="folder", helptext="Path of output TARDIS model file", default=Path())
 

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1631,3 +1631,28 @@ def test_angle_averaged_peakmag_without_filter_reads_the_averaged_file(
     )
 
     assert list(tmp_path.glob("*angle_averaged_all_models_data.txt"))
+
+
+def test_viewing_angle_peakmag_export_without_filter_fits_each_direction_bin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--save_viewing_angle_peakmag_risetime_delta_m15_to_file without -filter fits each selected bin.
+
+    Only the angle-averaged modes force dirbin -1. This export must keep the parsed direction bins
+    and read the direction-resolved light curve file.
+    """
+    monkeypatch.chdir(tmp_path)
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotviewingangle=[0, 1],
+        save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
+        timemin=3.2,
+        timemax=7.5,
+        outputfile=tmp_path,
+    )
+
+    datafiles = list(tmp_path.glob("*_viewing_angle_data.txt"))
+    assert len(datafiles) == 1
+    peakmag_risetime_deltam15 = np.loadtxt(datafiles[0], skiprows=1)
+    assert peakmag_risetime_deltam15.shape == (2, 3), "the export holds one row per selected direction bin"

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1609,3 +1609,25 @@ def test_lightcurve_timestep_takes_a_path_that_names_a_file(tmp_path: Path) -> N
     at.lightcurve.plot(argsraw=[str(modelpath / "light_curve.out"), "-timestep", "20", "-o", str(outputfile)])
 
     assert outputfile.is_file(), "the command must draw the light curve of the file"
+
+
+def test_angle_averaged_peakmag_without_filter_reads_the_averaged_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--save_angle_averaged_peakmag_risetime_delta_m15_to_file without -filter fits dirbin -1.
+
+    The branch forced dirbins to [-1] after it read the direction-resolved file, whose keys are
+    0 to 99. Thus the command stopped with KeyError before this test existed.
+    """
+    monkeypatch.chdir(tmp_path)
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath_classic_3d],
+        plotviewingangle=-2,
+        save_angle_averaged_peakmag_risetime_delta_m15_to_file=True,
+        timemin=3.2,
+        timemax=7.5,
+        outputfile=tmp_path,
+    )
+
+    assert list(tmp_path.glob("*angle_averaged_all_models_data.txt"))

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -552,13 +552,16 @@ def peakmag_risetime_declinerate_init(
 
         # check if doing viewing angle stuff, and if so define which data to use
         dirbins, _ = parse_directionbin_args(modelpath, args)
-        if not args.filter and args.plotviewingangle:
-            # without a filter, this branch fits the bolometric light curve of dirbin -1 alone
+        if not args.filter and args.plotviewingangle and wants_angle_averaged_data(args):
+            # without a filter, the angle-averaged modes fit the bolometric light curve of dirbin -1
+            # alone. The per-direction-bin export keeps the parsed direction bins
             dirbins = [-1]
 
         if not args.filter:
-            # dirbin -1 is the angle-averaged light curve, which only light_curve.out holds
-            lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=False)
+            # dirbin -1 is the angle-averaged light curve, which only light_curve.out holds. The
+            # direction-resolved bins come from light_curve_res.out
+            directionresolved = list(dirbins) != [-1]
+            lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=directionresolved)
             lcdataframes = at.lightcurve.readfile(lcpath)
 
         for dirbin in dirbins:
@@ -581,17 +584,14 @@ def peakmag_risetime_declinerate_init(
                         lcdataframes[dirbin]
                         .filter(pl.col("time_days").is_between(args.timemin, args.timemax))
                         .fill_nan(0.0)
+                        # a time with no luminosity has no magnitude, thus drop the zero and the
+                        # non-finite values before the fit
+                        .filter(pl.col("mag").is_finite() & (pl.col("mag") != 0.0))
                         .select("time_days", "mag")
                         .collect()
                     )
-                    brightness = np.array(
-                        [mag for mag in lightcurve_data["mag"] if mag != 0], dtype=np.float64
-                    )  # drop times with 0 brightness
-                    time = [
-                        t
-                        for t, mag in zip(lightcurve_data["time_days"], lightcurve_data["mag"], strict=False)
-                        if mag != 0
-                    ]
+                    brightness = lightcurve_data["mag"].to_numpy()
+                    time = lightcurve_data["time_days"].to_list()
 
                 # Calculating band peak time, peak magnitude and delta m15
                 calculate_peak_time_mag_deltam15(time, brightness, modelname, dirbin, band_name, args)

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -550,14 +550,16 @@ def peakmag_risetime_declinerate_init(
         modelnames.append(modelname)
         lcdataframes: dict[int, pl.LazyFrame] = {}
 
-        if not args.filter:
-            lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=args.plotviewingangle)
-            lcdataframes = at.lightcurve.readfile(lcpath)
-
         # check if doing viewing angle stuff, and if so define which data to use
         dirbins, _ = parse_directionbin_args(modelpath, args)
         if not args.filter and args.plotviewingangle:
+            # without a filter, this branch fits the bolometric light curve of dirbin -1 alone
             dirbins = [-1]
+
+        if not args.filter:
+            # dirbin -1 is the angle-averaged light curve, which only light_curve.out holds
+            lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=False)
+            lcdataframes = at.lightcurve.readfile(lcpath)
 
         for dirbin in dirbins:
             if args.verbose:

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -821,6 +821,10 @@ def format_frame_path(frametemplate: Path | str, **fields: t.Any) -> str:
         given = ", ".join(f"{{{name}}}" for name in fields)
         msg = f"the name of the output holds the field {exc}, and this command gives {given}"
         raise ValueError(msg) from exc
+    except IndexError as exc:
+        given = ", ".join(f"{{{name}}}" for name in fields)
+        msg = f"the name of the output holds a field with no name, and each field needs one of: {given}"
+        raise ValueError(msg) from exc
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -1024,10 +1028,13 @@ def get_filterfunc(args: argparse.Namespace) -> "Callable[[npt.ArrayLike], npt.N
             arr_padded = np.pad(ylist, (n // 2, n - 1 - n // 2), mode="edge")
             return np.convolve(arr_padded, np.ones((n,)) / n, mode="valid")
 
-        assert filterfunc is None
         filterfunc = movavgfilterfunc
 
     if dictargs.get("filtersavgol", False):
+        if filterfunc is not None:
+            msg = "Give only one of -filtermovingavg and -filtersavgol"
+            raise ValueError(msg)
+
         from artistools.misc.general import savgol_filter
 
         window_length, polyorder = (int(x) for x in args.filtersavgol)
@@ -1035,7 +1042,6 @@ def get_filterfunc(args: argparse.Namespace) -> "Callable[[npt.ArrayLike], npt.N
         def savgolfilterfunc(ylist: "npt.ArrayLike") -> "npt.NDArray[np.float64]":
             return savgol_filter(ylist, window_length=window_length, polyorder=polyorder)
 
-        assert filterfunc is None
         filterfunc = savgolfilterfunc
 
         print("Applying Savitzky-Golay filter")

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -994,6 +994,11 @@ def test_get_filterfunc() -> None:
 
     # the Savitzky-Golay filter matches scipy.signal.savgol_filter(y, window_length=5, polyorder=3, mode="interp"),
     # which it replaced
+    # each filter argument selects one filter, thus a command line that gives both is a user error
+    # and not an internal fault
+    with pytest.raises(ValueError, match="only one of -filtermovingavg and -filtersavgol"):
+        at.get_filterfunc(argparse.Namespace(filtermovingavg=3, filtersavgol=["5", "3"]))
+
     filterfunc = at.get_filterfunc(argparse.Namespace(filtersavgol=["5", "3"]))
     assert filterfunc is not None
     yvalues = np.sin(np.linspace(0.0, 3.0, num=12)) + np.linspace(0.0, 0.5, num=12) ** 2
@@ -1083,6 +1088,9 @@ def test_get_timestep_of_timedays(tmp_path: Path) -> None:
     assert at.get_timestep_of_timedays(tmp_path, 149) == 4
     assert at.get_timestep_of_timedays(tmp_path, "125d") == 2  # accepts a "<days>d" string
 
+    # the message says the model covers up to 150 days, thus exactly 150 names the last timestep
+    assert at.get_timestep_of_timedays(tmp_path, 150) == 4
+
     # the message names the range that the run covers, so that the user can correct the value
     with pytest.raises(ValueError, match=r"No timestep of this model covers 500 days.*100\.00 to 150\.00 days"):
         at.get_timestep_of_timedays(tmp_path, 500)
@@ -1114,6 +1122,16 @@ def test_get_deposition(tmp_path: Path) -> None:
 
     with pytest.raises(AssertionError, match="Deposition times do not match"):
         at.get_deposition(baddir).collect()
+
+    # a file with more rows than the model has timesteps gets the same message, not a broadcast error
+    longdir = tmp_path / "long"
+    longdir.mkdir()
+    _write_timesteps_out(longdir)
+    longlines = deplines + [f"{155 + ts * 10} 1.0 0.1 1.1" for ts in range(2)]
+    (longdir / "deposition.out").write_text("\n".join(longlines) + "\n")
+
+    with pytest.raises(AssertionError, match="Deposition times do not match"):
+        at.get_deposition(longdir).collect()
 
 
 def test_average_direction_bins_unequal_bincounts(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -1126,7 +1126,7 @@ def test_get_deposition(tmp_path: Path) -> None:
     # a file with more rows than the model has timesteps gets the same message, not a broadcast error
     longdir = tmp_path / "long"
     longdir.mkdir()
-    _write_timesteps_out(longdir)
+    write_timesteps_out(longdir)
     longlines = deplines + [f"{155 + ts * 10} 1.0 0.1 1.1" for ts in range(2)]
     (longdir / "deposition.out").write_text("\n".join(longlines) + "\n")
 

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -70,7 +70,9 @@ def get_deposition(modelpath: Path | str = ".") -> pl.LazyFrame:
     # no timesteps are given in the old format of deposition.out, so ensure that
     # the times in days match up with the times of our assumed timesteps
     t_mid_days = depdata.select("tmid_days").collect().to_series().to_numpy()
-    if not np.allclose(t_mid_days, ts_mids[: len(t_mid_days)], rtol=0.01):
+    # a file with more rows than the model has timesteps is a mismatch. The slice comparison
+    # below raises a broadcast error for such a file instead of the message
+    if len(t_mid_days) > len(ts_mids) or not np.allclose(t_mid_days, ts_mids[: len(t_mid_days)], rtol=0.01):
         msg = "Deposition times do not match the timesteps"
         raise AssertionError(msg)
 
@@ -162,6 +164,10 @@ def get_timestep_of_timedays(modelpath: Path | str, timedays: str | float) -> in
     for ts, (tstart, tend) in enumerate(zip(arr_tstart, arr_tend, strict=False)):
         if tstart <= timedays_float < tend:
             return ts
+
+    # the message below says the model covers up to the last tend, thus that exact time must match
+    if arr_tstart and timedays_float == arr_tend[-1]:
+        return len(arr_tstart) - 1
 
     msg = (
         f"No timestep of this model covers {timedays_float:g} days. It has {len(arr_tstart)} timesteps, "

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -462,6 +462,11 @@ def make_plot_populations_with_time_or_velocity(modelpaths: Sequence[Path | str]
         timedayslist = [at.get_timestep_time(modelpaths[0], ts) for ts in range(args.timestepmin, args.timestepmax + 1)]
         args.subplots = False
 
+    if args.x == "time" and not args.subplots:
+        # the time branch of plot_populations_with_time_or_velocity draws the full time series in
+        # one call, thus one call fills the single axes
+        timedayslist = timedayslist[:1]
+
     cols = 1
     fig, axesgrid = make_frame_figure(args, rows=rows, cols=cols, aspect=0.847, sharey=True)
     ax = axesgrid.flatten() if args.subplots else axesgrid[0][0]

--- a/artistools/nltepops/test_nltepops.py
+++ b/artistools/nltepops/test_nltepops.py
@@ -134,7 +134,9 @@ def test_nltepops_versus_time(mockplot: mock.MagicMock, tmp_path: Path, monkeypa
         argsraw=[], modelpath=modelpath, cell=0, x="time", timedays="270-275", ion_stages=[1, 2], levels=[0, 1]
     )
 
-    assert len(mockplot.call_args_list) == 10
+    # one call draws the full time series of each level. The command called the plot function once
+    # per timestep on the same axes, thus it drew each series five times before this assertion
+    assert len(mockplot.call_args_list) == 2
     expected_series = [
         ([271.48221094182054, 273.31529638210384], [7.40594, 6.39568]),
         ([271.48221094182054, 273.31529638210384], [4.71888, 3.89199]),

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -285,9 +285,16 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
             sf.analyse_ntspectrum()
 
             if args.makeplot:
-                outputfilename = str(args.outputfile).format(
-                    cell=args.modelgridindex, timestep=args.timestep, timedays=args.timedays
-                )
+                if args.timestep is not None and args.timedays is not None:
+                    outputfilename = str(args.outputfile).format(
+                        cell=args.modelgridindex, timestep=args.timestep, timedays=args.timedays
+                    )
+                else:
+                    # a non-ARTIS composition has no cell and no timestep, thus the default template
+                    # does not apply, and the element names the file instead
+                    outputfilename = str(args.outputfile).replace(
+                        defaultoutputfile, f"spencerfano_{args.composition}.pdf"
+                    )
                 sf.plot_spec_channels(outputfilename=outputfilename)
 
             if args.ostat:

--- a/artistools/nonthermal/test_nonthermal.py
+++ b/artistools/nonthermal/test_nonthermal.py
@@ -95,3 +95,16 @@ def test_leptontransport_rejects_nonpositive_energy(energy: float) -> None:
     """Both stopping-power helpers require a positive energy, and reach a division by zero without it."""
     with pytest.raises(ValueError, match="energy must be positive"):
         at.nonthermal.leptontransport.main(argsraw=[], energy=energy)
+
+
+def test_spencerfano_makeplot_with_element_composition(tmp_path: Path) -> None:
+    """--makeplot with a non-ARTIS -composition names the plot file after the element.
+
+    The default file name holds a timestep field and a time field, which stay None without an
+    ARTIS model. Thus the format stopped with TypeError before this test existed.
+    """
+    at.nonthermal.solvespencerfanocmd.main(
+        argsraw=[], composition="He", x_e=0.5, makeplot=True, npts=200, noexcitation=True, outputfile=tmp_path
+    )
+
+    assert (tmp_path / "spencerfano_He.pdf").is_file()

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1724,7 +1724,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         return
 
     if args.averagevspecpolfiles:
-        atspectra.make_averaged_vspecfiles(args)
+        atspectra.make_averaged_vspecfiles(args.specpath)
         return
 
     if "/" in args.stokesparam:

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -916,12 +916,10 @@ def make_virtual_spectra_summed_file(modelpath: Path | str) -> None:
         print_saved(outfile)
 
 
-def make_averaged_vspecfiles(args: argparse.Namespace) -> None:
+def make_averaged_vspecfiles(modelpaths: Sequence[Path]) -> None:
     """Average the vspecpol_total files of several models into one vspecpol_averaged file per observer direction."""
     filenames = [
-        vspecfile.name
-        for vspecfile in Path(args.modelpath[0]).iterdir()
-        if vspecfile.name.startswith("vspecpol_total-")
+        vspecfile.name for vspecfile in Path(modelpaths[0]).iterdir() if vspecfile.name.startswith("vspecpol_total-")
     ]
 
     def sorted_by_number(lst: list[str]) -> list[str]:
@@ -936,12 +934,12 @@ def make_averaged_vspecfiles(args: argparse.Namespace) -> None:
     filenames = sorted_by_number(filenames)
 
     for spec_index, filename in enumerate(filenames):  # vspecpol-total files
-        vspecarrays = [read_wsv(modelpath / filename, has_header=False).to_numpy() for modelpath in args.modelpath]
+        vspecarrays = [read_wsv(modelpath / filename, has_header=False).to_numpy() for modelpath in modelpaths]
         averaged = vspecarrays[0].copy()
         # the first row (times) and first column (frequencies) are labels shared by all models, so average the rest
         averaged[1:, 1:] = np.mean([arr[1:, 1:] for arr in vspecarrays], axis=0)
         pl.DataFrame(averaged).write_csv(
-            args.modelpath[0] / f"vspecpol_averaged-{spec_index}.out", separator=" ", include_header=False
+            Path(modelpaths[0]) / f"vspecpol_averaged-{spec_index}.out", separator=" ", include_header=False
         )
 
 

--- a/artistools/spectra/test_vspectra.py
+++ b/artistools/spectra/test_vspectra.py
@@ -1,3 +1,5 @@
+import shutil
+from pathlib import Path
 from unittest import mock
 
 import matplotlib.axes as mplax
@@ -114,3 +116,26 @@ def test_vpkt_frompackets_spectrum_plot(mockplot: mock.MagicMock) -> None:
         rtol=0.001,
         atol=0.0,
     )
+
+
+def test_average_vspecpol_files(tmp_path: Path) -> None:
+    """--averagevspecpolfiles averages the vspecpol_total files of every -specpath model.
+
+    make_averaged_vspecfiles read args.modelpath, and plotspectra stores every path under
+    args.specpath, thus the command stopped with AttributeError before this test existed.
+    """
+    modeldirs = [tmp_path / "model_a", tmp_path / "model_b"]
+    for modeldir in modeldirs:
+        modeldir.mkdir()
+        for filename in ("vspecpol_total-0.out", "vspecpol_total-1.out"):
+            shutil.copy(at.get_path("testdata") / "vspecpolmodel" / filename, modeldir / filename)
+
+    at.spectra.plot(argsraw=[], specpath=[str(modeldir) for modeldir in modeldirs], averagevspecpolfiles=True)
+
+    for specindex in (0, 1):
+        averagedpath = modeldirs[0] / f"vspecpol_averaged-{specindex}.out"
+        assert averagedpath.is_file()
+        # the two models hold the same data, thus the average equals the source
+        averaged = np.loadtxt(averagedpath)
+        source = np.loadtxt(modeldirs[0] / f"vspecpol_total-{specindex}.out")
+        assert np.allclose(averaged, source, rtol=1e-6)

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1958,6 +1958,10 @@ def test_an_output_template_takes_the_older_name_of_a_field() -> None:
     with pytest.raises(ValueError, match=r"gives \{cell\}, \{timedays\}"):
         at.format_frame_path("p_{nosuch}.pdf", cell=1, timedays=2.0)
 
+    # a field with no name gets a message as well, not a raw IndexError
+    with pytest.raises(ValueError, match=r"field with no name.*\{cell\}, \{timedays\}"):
+        at.format_frame_path("p_{}.pdf", cell=1, timedays=2.0)
+
 
 def test_a_wavelength_range_takes_both_spellings() -> None:
     """-xmin and -lambdamin name one argument on every command that reads a range of wavelengths.


### PR DESCRIPTION
## Summary

A full review of the codebase confirmed twelve command-line defects. This PR fixes each one and adds a regression test for each fix.

- **plotspectra**: `--averagevspecpolfiles` read `args.modelpath`, but the parser stores every path under `args.specpath`, thus the command stopped with AttributeError. `make_averaged_vspecfiles` now takes the list of paths.
- **plotestimators**: the `-readonlymgi cone` path read `args.coneangle`, which the parser did not define. The parser now defines `-coneangle` (default 30.0). `make_cone` and `get_profile_along_axis` normalise the model path, thus a scalar path and a list of paths both work.
- **slice1dfromconein3dmodel**: the `--no-makefromcone` path read `args.t_model`, which only the cone branch set, and passed a list of paths to `get_modeldata`. On the positive axis, the code renamed the inner cell edge to `vel_r_max_kmps` and dropped the cell with `pos_min == 0`, thus the velocity of each shell was low by one cell width. The outer edge is now `pos_min` plus the cell width, and the filter keeps the innermost cell. The `+z` and `-z` slices now give the same velocity grid, which ends at vmax.
- **from_e2e_model**: the 3D branch held `vminr, vmaxr, nvr = -0.5, 0.5, 50`, thus `-vmax_on_c` and `-ngridx/y/z` had no effect, and a grid size other than 50 stopped with a broadcast error. The grid now comes from the arguments.
- **to_tardis**: `-maxatomicnumber` had no `type=`, thus a command-line value was a string and the comparison with an integer stopped with TypeError. The argument now has `type=int`.
- **viewingangleanalysis**: `--save_angle_averaged_peakmag_risetime_delta_m15_to_file` with `-plotviewingangle -2` and no `-filter` forced dirbins to `[-1]` after it read the direction-resolved file, whose keys are 0 to 99, thus the command stopped with KeyError. The branch now reads `light_curve.out`, which holds dirbin -1.
- **plotnltepops**: `-x time` called the plot function once per timestep on the same axes, and the time branch draws the full series in each call. This gave N duplicated lines and N^2 file reads. The command now calls the function one time.
- **get_deposition**: a `deposition.out` with more rows than the model has timesteps stopped with a broadcast ValueError. It now gets the mismatch message.
- **get_timestep_of_timedays**: `-timedays` equal to the exact end of the last timestep was rejected by a message that says the model covers up to that time. The exact end now names the last timestep.
- **get_filterfunc**: `-filtermovingavg` with `-filtersavgol` failed a bare assert, which `python -O` strips. It now raises ValueError with a message that names both flags.
- **format_frame_path**: an output template with a positional `{}` field stopped with a raw IndexError. It now gets a message that says the fields need names.
- **solvespencerfanocmd**: `--makeplot` with a non-ARTIS `-composition` formatted the default file name with `args.timestep` and `args.timedays` still None, thus it stopped with TypeError. The element now names the file.

The PR also makes the `verify-tree` stop hook check the tree of the current checkout. In a git worktree, a personal `~/.config/ty/ty.toml` made ty check the main checkout, and pyrefly found no files. The hook now hides the personal configuration, as CI does, and gives pyrefly the tracked files.

## Deliberate result change

The along-axis fix also applies to `plotestimators -readonlymgi alongaxis`, which now includes the innermost cell. The expected means in `test_estimator_snapshot_classic_3d_x_axis` changed for that reason.

## Test plan

- ruff format, ruff check, pyrefly, ty, refurb, and the prek hooks give no errors.
- The full pytest suite passes: 551 passed, 1 skipped.
- Each fix has a regression test in the test file of its area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)