### PR TITLE
Stamp a cache version and the text source time into each parquet cache

### DIFF
--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -25,9 +25,9 @@ import artistools as at
 from artistools.constants import K_B_ev_per_K
 from artistools.misc import path_is_codecomparison
 from artistools.misc import print_warning
+from artistools.misc import read_parquet_cache_metadata
 
 if t.TYPE_CHECKING:
-    import os
     from collections.abc import Iterable
 
 
@@ -381,25 +381,54 @@ def get_rankbatch_parquetpath(folderpath: Path | str, batch_mpiranks: Sequence[i
     return Path(folderpath) / filename
 
 
-def get_textsource_mtime(folderpath: Path | str) -> float | None:
-    """Return the time of the last change of an estimator text file, or None when the folder holds none."""
-    with contextlib.suppress(StopIteration):
-        return next(Path(folderpath).glob("estimators_????.out*")).stat().st_mtime
+# The version of the estimator parquet cache format. Increase it for a change that makes an older
+# cache file incorrect, e.g. a new column, a removed column, or a different data type.
+CACHEVERSION = 1
 
-    return None
+
+def get_textsource_mtimes(folderpath: Path | str) -> dict[int, float]:
+    """Return the time of the last change of each estimator text file in the folder, keyed by MPI rank."""
+    return {
+        int(textfile.name.split("_")[1].split(".")[0]): textfile.stat().st_mtime
+        for textfile in Path(folderpath).glob("estimators_????.out*")
+    }
+
+
+def get_batch_textsource_mtime(textsource_mtimes: Mapping[int, float], rankmin: int, rankmax: int) -> float | None:
+    """Return the newest change time of the text files of the ranks in the batch, or None when it has none.
+
+    Every file of the batch counts. One rank file that a restart rewrote makes the whole batch cache
+    stale, thus no single file can decide for the others.
+    """
+    return max((mtime for rank, mtime in textsource_mtimes.items() if rankmin <= rank <= rankmax), default=None)
 
 
 def rankbatch_parquet_is_current(parquetfilepath: Path, textsource_mtime: float | None) -> bool:
-    """Return True when the parquet cache exists and no estimator text file is newer than it.
+    """Return True when the parquet cache matches the cache format version and the text files.
 
     The reader of a run and the writer of one batch both ask this, thus one rule decides whether a
-    conversion of the text files takes place.
+    conversion of the text files takes place. A cache in a folder that holds no text file stays
+    current, because no source remains for a new conversion.
     """
-    parquetstat: os.stat_result | None = None
-    with contextlib.suppress(FileNotFoundError):
-        parquetstat = parquetfilepath.stat()
+    if not parquetfilepath.is_file():
+        return False
 
-    return parquetstat is not None and not (textsource_mtime and textsource_mtime > parquetstat.st_mtime)
+    return (
+        textsource_mtime is None
+        or read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime) is not None
+    )
+
+
+def estimbatch_parquet_is_current(parquetfilepath: Path, folderpath: Path | str) -> bool:
+    """Return True when a batch cache is current for the estimator text files of its own ranks.
+
+    The name of the cache gives the range of the MPI ranks, e.g. estimbatch00_0000_0099, thus a
+    caller such as get_runfolder_timesteps() needs no rank list.
+    """
+    nameparts = parquetfilepath.name.split("_")
+    rankmin, rankmax = int(nameparts[1]), int(nameparts[2].split(".")[0])
+    textsource_mtime = get_batch_textsource_mtime(get_textsource_mtimes(folderpath), rankmin, rankmax)
+    return rankbatch_parquet_is_current(parquetfilepath, textsource_mtime)
 
 
 def get_estimators_rankbatch_parquetfile(
@@ -408,7 +437,7 @@ def get_estimators_rankbatch_parquetfile(
     batchindex: int,
     modelpath: Path | str | None = None,
     verbose: bool = False,
-    textsource_mtime: float | None = None,
+    textsource_mtimes: Mapping[int, float] | None = None,
 ) -> Path:
     """Return the parquet cache for one batch of MPI ranks' estimator files, creating it if it is missing or stale."""
 
@@ -419,15 +448,16 @@ def get_estimators_rankbatch_parquetfile(
     modelpath = Path(folderpath).parent if modelpath is None else Path(modelpath)
     folderpath = Path(folderpath)
     parquetfilepath = get_rankbatch_parquetpath(folderpath, batch_mpiranks, batchindex)
-    # the caller reads this one time for the folder, because a glob of a folder that holds one file
-    # for each MPI rank is not cheap
-    if textsource_mtime is None:
-        textsource_mtime = get_textsource_mtime(folderpath)
+    # the caller globs the folder one time and passes the mtimes, because a glob of a folder that
+    # holds one file for each MPI rank is slow
+    if textsource_mtimes is None:
+        textsource_mtimes = get_textsource_mtimes(folderpath)
 
     assert len(batch_mpiranks) == max(batch_mpiranks) - min(batch_mpiranks) + 1, (
         "batch_mpiranks must be a contiguous range of ranks"
     )
     assert len(set(batch_mpiranks)) == len(batch_mpiranks), "batch_mpiranks must not contain duplicates"
+    textsource_mtime = get_batch_textsource_mtime(textsource_mtimes, min(batch_mpiranks), max(batch_mpiranks))
 
     outdatedparquet: tuple[int, int] | None = None
     if not rankbatch_parquet_is_current(parquetfilepath, textsource_mtime):
@@ -438,8 +468,8 @@ def get_estimators_rankbatch_parquetfile(
         with contextlib.suppress(FileNotFoundError):
             outdatedparquet = at.get_file_identity(parquetfilepath.stat())
             print(
-                f"  {parquetfilepath.relative_to(modelpath.parent)} is older than the estimator text files."
-                " File will be regenerated..."
+                f"  {parquetfilepath.relative_to(modelpath.parent)} is not a current cache of the estimator"
+                " text files. File will be regenerated..."
             )
 
         print(f"  generating {parquetfilepath.relative_to(modelpath.parent)}...")
@@ -469,6 +499,7 @@ def get_estimators_rankbatch_parquetfile(
             parquetfilepath,
             metadata={
                 "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
+                "cacheversion": str(CACHEVERSION),
                 "textsource_mtime": str(textsource_mtime),
                 "batch_rank_min": str(min(batch_mpiranks)),
                 "batch_rank_max": str(max(batch_mpiranks)),
@@ -646,10 +677,11 @@ def scan_artis_estimators(
 
         # a bar is worth its place only when a batch converts text files, which takes minutes. Current
         # parquet caches read no text, and their scan is lazy, thus a bar would show no work
-        mtimeoffolder = {runfolder: get_textsource_mtime(runfolder) for runfolder in runfolders}
+        mtimesoffolder = {runfolder: get_textsource_mtimes(runfolder) for runfolder in runfolders}
         anyconversion = any(
             not rankbatch_parquet_is_current(
-                get_rankbatch_parquetpath(runfolder, mpiranks, batchindex), mtimeoffolder[runfolder]
+                get_rankbatch_parquetpath(runfolder, mpiranks, batchindex),
+                get_batch_textsource_mtime(mtimesoffolder[runfolder], min(mpiranks), max(mpiranks)),
             )
             for runfolder, batchindex, mpiranks in pairs
         )
@@ -667,7 +699,7 @@ def scan_artis_estimators(
                 batch_mpiranks=mpiranks,
                 batchindex=batchindex,
                 verbose=verbose,
-                textsource_mtime=mtimeoffolder[runfolder],
+                textsource_mtimes=mtimesoffolder[runfolder],
             )
             for runfolder, batchindex, mpiranks in batches
         ]

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -387,11 +387,21 @@ CACHEVERSION = 1
 
 
 def get_textsource_mtimes(folderpath: Path | str) -> dict[int, float]:
-    """Return the time of the last change of each estimator text file in the folder, keyed by MPI rank."""
-    return {
-        int(textfile.name.split("_")[1].split(".")[0]): textfile.stat().st_mtime
-        for textfile in Path(folderpath).glob("estimators_????.out*")
-    }
+    """Return the time of the last change of each rank's estimator file, keyed by MPI rank.
+
+    The glob finds the ranks, and the suffix order then selects one file for each rank: the same
+    file that find_estimator_file() in rust/src/estimators.rs reads. A leftover sibling, e.g.
+    estimators_0000.out.bak beside estimators_0000.out, thus cannot decide the freshness.
+    """
+    folderpath = Path(folderpath)
+    ranks = {int(textfile.name.split("_")[1].split(".")[0]) for textfile in folderpath.glob("estimators_????.out*")}
+    mtimes: dict[int, float] = {}
+    for rank in sorted(ranks):
+        for suffix in ("", ".zst", ".gz", ".xz"):
+            with contextlib.suppress(FileNotFoundError):
+                mtimes[rank] = (folderpath / f"estimators_{rank:04d}.out{suffix}").stat().st_mtime
+                break
+    return mtimes
 
 
 def get_batch_textsource_mtime(textsource_mtimes: Mapping[int, float], rankmin: int, rankmax: int) -> float | None:

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -829,6 +829,28 @@ def test_one_rewritten_rank_file_makes_its_batch_stale(tmp_path: Path) -> None:
     assert get_batch_textsource_mtime(mtimes, 5, 9) is None
 
 
+def test_the_stamp_reads_the_file_that_the_parser_reads(tmp_path: Path) -> None:
+    """The mtime of a rank comes from the file that the Rust parser selects, and no sibling decides.
+
+    The glob kept an arbitrary candidate of each rank. Thus a leftover sibling such as
+    estimators_0000.out.bak could give the stamp while the parser read estimators_0000.out.
+    """
+    from artistools.estimators.estimators import get_textsource_mtimes
+
+    outfile = tmp_path / "estimators_0000.out"
+    outfile.write_text("timestep 0\n")
+    bakfile = tmp_path / "estimators_0000.out.bak"
+    bakfile.write_text("timestep 0\n")
+    os.utime(bakfile, (outfile.stat().st_mtime + 100.0, outfile.stat().st_mtime + 100.0))
+
+    assert get_textsource_mtimes(tmp_path) == {0: outfile.stat().st_mtime}
+
+    # a compressed file counts only when the plain name is absent, in the order of the parser
+    gzfile = tmp_path / "estimators_0001.out.gz"
+    gzfile.write_bytes(b"")
+    assert get_textsource_mtimes(tmp_path)[1] == gzfile.stat().st_mtime
+
+
 def test_a_cached_scan_asks_for_no_progress_class() -> None:
     """A scan that converts no text file must not build the progress class, which takes a lock."""
     import artistools.misc.general

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -1,3 +1,4 @@
+import os
 import re
 import typing as t
 from pathlib import Path
@@ -748,19 +749,84 @@ def test_a_current_parquet_cache_starts_no_progress_bar(tmp_path: Path) -> None:
     The scan of the parquet files is lazy, thus a run whose caches were current showed a bar that
     came and went with no work behind it.
     """
-    parquetfilepath = at.estimators.estimators.get_rankbatch_parquetpath(tmp_path, [0, 1, 2], 0)
+    from artistools.estimators.estimators import CACHEVERSION
+    from artistools.estimators.estimators import get_rankbatch_parquetpath
+    from artistools.estimators.estimators import rankbatch_parquet_is_current
+
+    parquetfilepath = get_rankbatch_parquetpath(tmp_path, [0, 1, 2], 0)
     assert parquetfilepath.name == "estimbatch00_0000_0002.out.parquet.tmp"
 
     # a cache that no run wrote yet needs the conversion
-    assert not at.estimators.estimators.rankbatch_parquet_is_current(parquetfilepath, None)
+    assert not rankbatch_parquet_is_current(parquetfilepath, None)
 
-    parquetfilepath.write_bytes(b"")
-    mtime = parquetfilepath.stat().st_mtime
-    assert at.estimators.estimators.rankbatch_parquet_is_current(parquetfilepath, None)
-    assert at.estimators.estimators.rankbatch_parquet_is_current(parquetfilepath, mtime - 10.0)
+    mtime = 1000.0
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}),
+        parquetfilepath,
+        metadata={"cacheversion": str(CACHEVERSION), "textsource_mtime": str(mtime)},
+    )
 
-    # an estimator text file that is newer than the cache needs the conversion again
-    assert not at.estimators.estimators.rankbatch_parquet_is_current(parquetfilepath, mtime + 10.0)
+    # a folder with no text files keeps the cache, and a matching stamp also keeps it
+    assert rankbatch_parquet_is_current(parquetfilepath, None)
+    assert rankbatch_parquet_is_current(parquetfilepath, mtime)
+
+    # a text source time other than the stamped one needs the conversion again
+    assert not rankbatch_parquet_is_current(parquetfilepath, mtime + 10.0)
+
+
+def test_a_cache_without_a_current_stamp_is_stale(tmp_path: Path) -> None:
+    """A cache must hold the current cache version and the time of its text source, or a scan rejects it.
+
+    The freshness rule compared only modification times. Thus a scan accepted a cache that an older
+    artistools wrote with different columns, and the diagonal concat filled the difference with
+    nulls.
+    """
+    from artistools.estimators.estimators import rankbatch_parquet_is_current
+
+    mtime = 1000.0
+
+    # no metadata stamp, e.g. a cache from before the stamp existed
+    unstamped = tmp_path / "estimbatch00_0000_0002.out.parquet.tmp"
+    at.write_parquet_atomic(pl.DataFrame({"timestep": [0]}), unstamped)
+    assert not rankbatch_parquet_is_current(unstamped, mtime)
+
+    # a matching text source time but a different cache version
+    oldversion = tmp_path / "estimbatch01_0003_0005.out.parquet.tmp"
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}), oldversion, metadata={"cacheversion": "0", "textsource_mtime": str(mtime)}
+    )
+    assert not rankbatch_parquet_is_current(oldversion, mtime)
+
+    # a file that is not parquet
+    unreadable = tmp_path / "estimbatch02_0006_0008.out.parquet.tmp"
+    unreadable.write_bytes(b"not parquet")
+    assert not rankbatch_parquet_is_current(unreadable, mtime)
+
+
+def test_one_rewritten_rank_file_makes_its_batch_stale(tmp_path: Path) -> None:
+    """The newest text file of the batch decides its freshness, and no other file hides it.
+
+    One file, in the unspecified order of a glob, decided for the whole folder. Thus a restart that
+    rewrote the file of a later rank kept the stale caches current.
+    """
+    from artistools.estimators.estimators import get_batch_textsource_mtime
+    from artistools.estimators.estimators import get_textsource_mtimes
+
+    for rank in range(3):
+        (tmp_path / f"estimators_{rank:04d}.out").write_text("timestep 0\n")
+
+    mtimes = get_textsource_mtimes(tmp_path)
+    assert sorted(mtimes.keys()) == [0, 1, 2]
+
+    newest = max(mtimes.values())
+    os.utime(tmp_path / "estimators_0002.out", (newest + 100.0, newest + 100.0))
+    mtimes = get_textsource_mtimes(tmp_path)
+
+    assert get_batch_textsource_mtime(mtimes, 0, 2) == newest + 100.0
+    # a batch that does not hold the rewritten rank keeps its own time
+    assert get_batch_textsource_mtime(mtimes, 0, 1) == max(mtimes[0], mtimes[1])
+    # a batch with no text file gives None
+    assert get_batch_textsource_mtime(mtimes, 5, 9) is None
 
 
 def test_a_cached_scan_asks_for_no_progress_class() -> None:

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -1,6 +1,5 @@
 """Read, write, and derive columns for ARTIS model.txt and abundance input files."""
 
-import calendar
 import contextlib
 import datetime
 import errno
@@ -30,6 +29,7 @@ from artistools.misc import get_file_identity
 from artistools.misc import path_is_codecomparison
 from artistools.misc import polars_source
 from artistools.misc import print_warning
+from artistools.misc import read_parquet_cache_metadata
 from artistools.misc import read_wsv
 from artistools.misc import resolve_outputfile
 from artistools.misc import stripallsuffixes
@@ -335,44 +335,35 @@ def read_modelfile_text(
     return dfmodel, modelmeta
 
 
+# The version of the model parquet cache format. Increase it for a change that makes an older cache
+# file incorrect, e.g. a new column or a different data type.
+CACHEVERSION = 1
+
+
 def read_model_parquet_cache(
     parquetfilepath: Path, textsource_mtime: float, printwarningsonly: bool = False
 ) -> tuple[pl.LazyFrame, dict[t.Any, t.Any]] | None:
     """Return the cached model table and its metadata, or None if the cache is absent, stale, or unreadable.
 
-    An unreadable cache file is deleted, so that it is rebuilt from the text source rather than
-    rediscovered as broken on every run.
+    A rejected cache stays in place: get_modeldata() rewrites it through write_parquet_atomic(), which
+    replaces only the exact file that this check saw. A deletion here could remove the fresh cache
+    that a rival process installed after this check.
     """
     if not parquetfilepath.is_file():
         return None
 
-    cache_mtime = parquetfilepath.stat().st_mtime
-    if cache_mtime < textsource_mtime:
-        print(f"{parquetfilepath} is older than its text source. Will regenerate.")
+    pqmetadata = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
+    if pqmetadata is None:
+        print(f"{parquetfilepath} is not a current cache of the text source. Will regenerate.")
         return None
 
-    t_lastschemachange = calendar.timegm((2025, 8, 5, 9, 0, 0))
-    if cache_mtime < t_lastschemachange:
-        print(f"{parquetfilepath} was generated before the last schema change. Will regenerate.")
-        return None
-
-    # read_parquet_metadata is eager, so a damaged file raises here instead of at some distant
-    # collect(). scan_parquet resolves its schema from the same footer, so no further check is needed
+    # scan_parquet resolves its schema from the same footer that gave the metadata. Thus the check
+    # above already rejects a damaged file, and this code needs no further check
     try:
-        pqmetadata = pl.read_parquet_metadata(parquetfilepath)
-        cached_source_mtime = pqmetadata["textsource_mtime"]
         modelmeta = json.loads(pqmetadata["modelmeta_json"])
         dfmodel = pl.scan_parquet(parquetfilepath)
     except (pl.exceptions.PolarsError, KeyError, json.JSONDecodeError, OSError) as exc:
-        print(f"Could not read {parquetfilepath} ({type(exc).__name__}: {exc}). Will delete and regenerate.")
-        parquetfilepath.unlink(missing_ok=True)
-        return None
-
-    if cached_source_mtime != str(textsource_mtime):
-        print(
-            f"Modification time of text source ({textsource_mtime}) does not match parquet metadata "
-            f"({cached_source_mtime}). Will regenerate."
-        )
+        print(f"Could not read {parquetfilepath} ({type(exc).__name__}: {exc}). Will regenerate.")
         return None
 
     if not printwarningsonly:
@@ -451,6 +442,7 @@ def get_modeldata(
                 replaces=outdatedparquet,
                 metadata={
                     "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
+                    "cacheversion": str(CACHEVERSION),
                     "textsource_mtime": str(textsource_mtime),
                     "modelmeta_json": json.dumps(modelmeta),
                 },

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2205,3 +2205,18 @@ def test_maketardismodel_maxatomicnumber_from_command_line(tmp_path: Path) -> No
     assert "Fe" in csvytext
     assert "Co" not in csvytext
     assert "Ni" not in csvytext
+
+
+def test_an_unreadable_model_cache_is_not_deleted(tmp_path: Path) -> None:
+    """A rejected cache must stay in place, because a rival process possibly replaced it.
+
+    The reader deleted an unreadable file with a bare unlink, outside the identity rule of
+    write_parquet_atomic. That unlink can remove the fresh cache that a rival process installed.
+    """
+    from artistools.inputmodel.inputmodel_misc import read_model_parquet_cache
+
+    parquetfilepath = tmp_path / "model.txt.parquet.tmp"
+    parquetfilepath.write_bytes(b"not parquet")
+
+    assert read_model_parquet_cache(parquetfilepath, textsource_mtime=1.0) is None
+    assert parquetfilepath.is_file(), "the unreadable cache must stay for the identity-checked rewrite"

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -81,6 +81,7 @@ from artistools.misc.fileio import path_is_codecomparison as path_is_codecompari
 from artistools.misc.fileio import path_is_reference_data as path_is_reference_data
 from artistools.misc.fileio import polars_source as polars_source
 from artistools.misc.fileio import print_saved as print_saved
+from artistools.misc.fileio import read_parquet_cache_metadata as read_parquet_cache_metadata
 from artistools.misc.fileio import read_wsv as read_wsv
 from artistools.misc.fileio import readnoncommentline as readnoncommentline
 from artistools.misc.fileio import stripallsuffixes as stripallsuffixes

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -485,20 +485,30 @@ def firstexisting_or_none(
 
 
 @cache
+def find_bundled_data_file(filename: Path | str, bundledsubfolder: str) -> Path | None:
+    """Return the path of a file in the named data folder of the package, or None when the folder holds none."""
+    from artistools.commands import get_path
+
+    return firstexisting_or_none(
+        filename, folder=Path(get_path("artistools_dir"), bundledsubfolder), tryzipped=True, search_subfolders=False
+    )
+
+
 def find_reference_data_file(filename: Path | str, bundledsubfolder: str) -> Path | None:
     """Return the path of a file of reference data, or None when no such file exists.
 
     The file is either at the given path or in the named folder of the data that the package holds,
     and a compressed file of the same name is also accepted. The light curves and the spectra each
     hold reference data of their own, thus the caller names the folder that holds its kind.
+
+    The search of the working folder runs on every call, because the working folder can change while
+    the process runs. A cache holds only the search of the package data, because that folder is
+    constant.
     """
-    from artistools.commands import get_path
+    if found := firstexisting_or_none(filename, folder=Path(), tryzipped=True, search_subfolders=False):
+        return found
 
-    for folder in (Path(), Path(get_path("artistools_dir"), bundledsubfolder)):
-        if found := firstexisting_or_none(filename, folder=folder, tryzipped=True, search_subfolders=False):
-            return found
-
-    return None
+    return find_bundled_data_file(filename, bundledsubfolder)
 
 
 def path_is_reference_data(filepath: Path | str, bundledsubfolder: str) -> bool:
@@ -771,6 +781,28 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
             newfilepath.replace(destpath)
     finally:
         os.close(lockfd)
+
+
+def read_parquet_cache_metadata(
+    parquetfilepath: Path, cacheversion: int, textsource_mtime: float
+) -> dict[str, str] | None:
+    """Return the metadata of a parquet cache, or None when the cache is stale or unreadable.
+
+    The writer of a cache stamps the cache format version and the modification time of its text source
+    into the parquet metadata. A cache from a different artistools version, or from different text
+    files, fails the comparison. A new modification time of the cache does not make it current.
+    read_parquet_metadata is eager, thus a damaged file gives None here and not an error at a distant
+    collect().
+    """
+    try:
+        pqmetadata = pl.read_parquet_metadata(parquetfilepath)
+    except (pl.exceptions.PolarsError, OSError):
+        return None
+
+    iscurrent = pqmetadata.get("cacheversion") == str(cacheversion) and pqmetadata.get("textsource_mtime") == str(
+        textsource_mtime
+    )
+    return pqmetadata if iscurrent else None
 
 
 def write_parquet_atomic(

--- a/artistools/misc/modelinfo.py
+++ b/artistools/misc/modelinfo.py
@@ -224,14 +224,19 @@ def get_inputparams(modelpath: Path) -> dict[str, t.Any]:
 def get_runfolder_timesteps(folderpath: Path | str) -> tuple[int, ...]:
     """Get the set of timesteps covered by the output files in an ARTIS run folder."""
     if estimparquetfiles := sorted(Path(folderpath).glob("estimbatch*.out.parquet*")):
-        # if there are estimators in parquet format, read the timesteps from there
-        dfestfile = pl.scan_parquet(estimparquetfiles[0])
-        timesteps_contained = (
-            dfestfile.select(pl.col("timestep")).unique().sort("timestep").collect().to_series().to_list()
-        )
-        # the first timestep of a restarted run is duplicate and should be ignored
-        restart_timestep = None if 0 in timesteps_contained else timesteps_contained[0]
-        return tuple(ts for ts in timesteps_contained if ts != restart_timestep)
+        # this import runs at call time, because artistools.estimators imports artistools.misc
+        from artistools.estimators.estimators import estimbatch_parquet_is_current
+
+        # a stale cache can hold fewer timesteps than the text files, e.g. while ARTIS still runs.
+        # Thus only a current cache answers. For a stale cache, the text files answer instead
+        if estimbatch_parquet_is_current(estimparquetfiles[0], folderpath):
+            dfestfile = pl.scan_parquet(estimparquetfiles[0])
+            timesteps_contained = (
+                dfestfile.select(pl.col("timestep")).unique().sort("timestep").collect().to_series().to_list()
+            )
+            # the first timestep of a restarted run is duplicate and should be ignored
+            restart_timestep = None if 0 in timesteps_contained else timesteps_contained[0]
+            return tuple(ts for ts in timesteps_contained if ts != restart_timestep)
     if estimfiles := sorted(Path(folderpath).glob("estimators_*.out*")):
         with zopen(estimfiles[0]) as estfile:
             timesteps_contained = sorted({int(line.split()[1]) for line in estfile if line.startswith("timestep ")})

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -202,6 +202,60 @@ def test_one_rule_finds_the_reference_data_of_each_kind(tmp_path: Path) -> None:
     assert not at.path_is_reference_data(tmp_path / "nosuchfile.txt", "data/refspectra")
 
 
+def test_reference_data_search_follows_the_working_folder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A relative name must not match after a change of the working folder.
+
+    A cache held the full result. Thus the first answer kept a working folder that no longer
+    applied, and a miss stayed None after the file appeared.
+    """
+    folder_with_file = tmp_path / "a"
+    folder_with_file.mkdir()
+    (folder_with_file / "myref.txt").write_bytes(b"")
+    empty_folder = tmp_path / "b"
+    empty_folder.mkdir()
+
+    monkeypatch.chdir(empty_folder)
+    assert at.find_reference_data_file("myref.txt", "data/refspectra") is None
+
+    monkeypatch.chdir(folder_with_file)
+    assert at.find_reference_data_file("myref.txt", "data/refspectra") == Path("myref.txt")
+
+    monkeypatch.chdir(empty_folder)
+    assert at.find_reference_data_file("myref.txt", "data/refspectra") is None
+
+
+def test_a_stale_estimator_cache_does_not_hide_new_timesteps(tmp_path: Path) -> None:
+    """A run that appends timesteps makes the batch cache stale, thus the text files answer.
+
+    get_runfolder_timesteps read the first batch cache with no freshness check. Thus a plot during
+    a run excluded the new timesteps of the folder.
+    """
+    from artistools.estimators.estimators import CACHEVERSION
+    from artistools.misc.modelinfo import get_runfolder_timesteps
+
+    stale_folder = tmp_path / "stale"
+    stale_folder.mkdir()
+    (stale_folder / "estimators_0000.out").write_text("timestep 0 header\ntimestep 1 header\n")
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}),
+        stale_folder / "estimbatch00_0000_0000.out.parquet.tmp",
+        metadata={"cacheversion": str(CACHEVERSION), "textsource_mtime": "1.0"},
+    )
+    assert get_runfolder_timesteps(stale_folder) == (0, 1)
+
+    current_folder = tmp_path / "current"
+    current_folder.mkdir()
+    textfile = current_folder / "estimators_0000.out"
+    textfile.write_text("timestep 0 header\ntimestep 1 header\n")
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}),
+        current_folder / "estimbatch00_0000_0000.out.parquet.tmp",
+        metadata={"cacheversion": str(CACHEVERSION), "textsource_mtime": str(textfile.stat().st_mtime)},
+    )
+    # the current cache answers, thus the extra timestep of the text file stays unread
+    assert get_runfolder_timesteps(current_folder) == (0,)
+
+
 def test_add_cli_arg_helpers() -> None:
     """The shared argument helpers must define the standard flags, types, and defaults."""
     parser = argparse.ArgumentParser()

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -1,6 +1,6 @@
 """Read ARTIS packets and virtual packets files, caching them as parquet, and bin them by viewing direction."""
 
-import calendar
+import datetime
 import math
 import time
 import typing as t
@@ -17,6 +17,7 @@ import artistools as at
 from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
+from artistools.misc import read_parquet_cache_metadata
 
 type_ids = {"TYPE_GAMMA": 10, "TYPE_RPKT": 11, "TYPE_NTLEPTON": 20, "TYPE_ESCAPE": 32}
 
@@ -372,9 +373,10 @@ def get_vpackets_text_columns(vpacketsfiletext: Path) -> list[str]:
     return firstline.lstrip("#").split()
 
 
-def format_timestamp(timestamp: float) -> str:
-    """Return a UTC time as a string. Log messages use it to compare the modification times of files."""
-    return time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(timestamp))
+# The version of the packets parquet cache format. Increase it for a change that makes an older
+# cache file incorrect, e.g. a new column, a removed column, or a different data type.
+# version 1: the stokes1/2/3 columns became stokes_q/stokes_u, and the schema omits the redundant stokes I
+CACHEVERSION = 1
 
 
 def get_packets_rankbatch_parquetfile(
@@ -391,13 +393,6 @@ def get_packets_rankbatch_parquetfile(
     )
     parquetfilepath = packetdir / parquetfilename
 
-    # The time of the last change to the parquet schema. A schema change adds a column or changes a data type.
-    # The code makes a new cache file if the cache is older than this time.
-    # Increase this time only for a change that makes an older cache file incorrect.
-    # 2026-05-21: the stokes1/2/3 columns became stokes_q/stokes_u, and the new schema omits the redundant stokes I
-    time_parquetschemachange = (2026, 5, 21, 10, 0, 0)
-    t_lastschemachange = calendar.timegm(time_parquetschemachange)
-
     text_filenames = [
         (f"vpackets_{rank:04d}.out" if virtual else f"packets00_{rank:04d}.out") for rank in batch_mpiranks
     ]
@@ -406,7 +401,6 @@ def get_packets_rankbatch_parquetfile(
     outdatedparquet: tuple[int, int] | None = None
     if parquetfilepath.is_file():
         parquetstat = parquetfilepath.stat()
-        parquet_mtime = parquetstat.st_mtime
         # only the last rank's file is checked, on the assumption that a run writes all of its ranks together. An
         # individually-updated earlier file will not invalidate the cached parquet
         if text_filepath := at.firstexisting_or_none(
@@ -414,7 +408,7 @@ def get_packets_rankbatch_parquetfile(
         ):
             last_textfile_mtime = text_filepath.stat().st_mtime
 
-            if parquet_mtime > last_textfile_mtime and parquet_mtime > t_lastschemachange:
+            if read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, last_textfile_mtime) is not None:
                 conversion_needed = False
             else:
                 # the identity comes from the stat that showed the file is outdated, so only that exact
@@ -424,19 +418,9 @@ def get_packets_rankbatch_parquetfile(
                 # one step, so the path always resolves to a complete parquet. Deleting it first opens a
                 # window in which a concurrent reader (another rank, or another pytest-xdist worker) finds
                 # it missing or half-swapped
-                reasons = []
-                if parquet_mtime <= last_textfile_mtime:
-                    reasons.append(
-                        f"{text_filepath.relative_to(modelpath)} was modified later"
-                        f" ({format_timestamp(last_textfile_mtime)})"
-                    )
-                if parquet_mtime <= t_lastschemachange:
-                    reasons.append(f"the parquet schema changed later ({format_timestamp(t_lastschemachange)})")
-
                 print(
-                    f"  {parquetfilepath.relative_to(modelpath)} was written"
-                    f" {format_timestamp(parquet_mtime)} but {' and '.join(reasons)}."
-                    " File will be regenerated..."
+                    f"  {parquetfilepath.relative_to(modelpath)} is not a current cache of"
+                    f" {text_filepath.relative_to(modelpath)}. File will be regenerated..."
                 )
         else:
             conversion_needed = False
@@ -449,6 +433,9 @@ def get_packets_rankbatch_parquetfile(
             at.firstexisting(filename, folder=modelpath, tryzipped=True, search_subfolders=True)
             for filename in text_filenames
         ]
+
+        # the stamp uses the same file that the freshness check reads: the text file of the last rank
+        textsource_mtime = text_file_paths[-1].stat().st_mtime
 
         column_names = (
             get_vpackets_text_columns(text_file_paths[0])
@@ -503,7 +490,17 @@ def get_packets_rankbatch_parquetfile(
             f"   took {time.perf_counter() - time_start_load:.1f} seconds. Writing parquet file...", end="", flush=True
         )
         time_start_write = time.perf_counter()
-        at.write_parquet_atomic(pldf_batch, parquetfilepath, compression_level=12, replaces=outdatedparquet)
+        at.write_parquet_atomic(
+            pldf_batch,
+            parquetfilepath,
+            metadata={
+                "creationtimeutc": str(datetime.datetime.now(datetime.UTC)),
+                "cacheversion": str(CACHEVERSION),
+                "textsource_mtime": str(textsource_mtime),
+            },
+            compression_level=12,
+            replaces=outdatedparquet,
+        )
         print(f"took {time.perf_counter() - time_start_write:.1f} seconds")
 
     return parquetfilepath


### PR DESCRIPTION
## Summary

A parquet cache was fresh when its modification time was newer than one text file. That rule accepted a cache that an older artistools wrote with different columns, and the diagonal concat filled the difference with nulls. One glob entry in unspecified order also decided the freshness of a whole estimator folder.

This change closes six cache-invalidation gaps with one mechanism. The writer of each cache stamps a cache format version and the modification time of its text source into the parquet metadata. The reader compares both values and regenerates the cache on a mismatch. `read_parquet_cache_metadata()` in `artistools/misc/fileio.py` holds the one rule, and each cache kind holds its own `CACHEVERSION` constant to increase on a schema change.

- **Estimators**: `rankbatch_parquet_is_current()` reads the stamp back instead of a comparison of file mtimes. `get_textsource_mtimes()` gives the mtime of each rank file, and the newest file of the batch's own ranks decides for that batch.
- **Packets**: the fixed schema-change date (2026-05-21) is gone. An old-format cache regenerates whatever its modification time is.
- **Model**: `read_model_parquet_cache()` uses the shared rule, drops its date stamp, and keeps an unreadable cache file in place. `get_modeldata()` replaces it under the identity rule of `write_parquet_atomic()`, thus no bare unlink can remove the fresh cache of a rival process.
- **Timesteps**: `get_runfolder_timesteps()` reads the timestep list only from a current batch cache. For a stale cache, the text files answer, thus a plot during a run sees an appended timestep.
- **Reference data**: `find_reference_data_file()` searches the working folder on every call and caches only the search of the package data. The old cache pinned a result from a working folder that no longer applied.

Every existing cache regenerates one time, because it holds no version stamp.

## Test plan

- Five new regression tests: the stamp rule (missing stamp, wrong version, unreadable file), the per-batch mtimes, the stale-timesteps fallback, the keep-unreadable-cache rule, and the working-folder reference lookup.
- The full suite passes: 557 passed, 1 skipped.
- ruff, ty, pyrefly, refurb, and the prek hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)