### PR TITLE
Give the reason for each rejection of a parquet cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ coverage.xml
 
 *.so
 
+# write_parquet_atomic() leaves the lock file of a cache in place, and a run that stops early can
+# leave a partial file. No cache directory is a source directory
+*.replace-lock
+*.partial
+
 # Distribution / packaging
 .Python
 .venv/

--- a/artistools/__init__.py
+++ b/artistools/__init__.py
@@ -160,6 +160,7 @@ from artistools.misc import print_detail as print_detail
 from artistools.misc import print_heading as print_heading
 from artistools.misc import print_saved as print_saved
 from artistools.misc import print_theta_phi_definitions as print_theta_phi_definitions
+from artistools.misc import read_parquet_cache_metadata as read_parquet_cache_metadata
 from artistools.misc import read_rank_outputfiles as read_rank_outputfiles
 from artistools.misc import read_wsv as read_wsv
 from artistools.misc import readnoncommentline as readnoncommentline

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -413,20 +413,24 @@ def get_batch_textsource_mtime(textsource_mtimes: Mapping[int, float], rankmin: 
     return max((mtime for rank, mtime in textsource_mtimes.items() if rankmin <= rank <= rankmax), default=None)
 
 
-def rankbatch_parquet_is_current(parquetfilepath: Path, textsource_mtime: float | None) -> bool:
-    """Return True when the parquet cache matches the cache format version and the text files.
+def rankbatch_parquet_staleness(parquetfilepath: Path, textsource_mtime: float | None) -> str | None:
+    """Return the reason why the parquet cache is stale, or None when the cache is current.
 
     The reader of a run and the writer of one batch both ask this, thus one rule decides whether a
-    conversion of the text files takes place. A cache in a folder that holds no text file stays
-    current, because no source remains for a new conversion.
+    conversion of the text files takes place. read_parquet_cache_metadata gives every other reason,
+    e.g. a cache that is absent, damaged, or written for a different cache format version.
     """
-    if not parquetfilepath.is_file():
-        return False
+    if textsource_mtime is None:
+        # a cache in a folder that holds no text file stays current, because no source remains for a
+        # new conversion. Only a cache that does not exist then needs one
+        return None if parquetfilepath.is_file() else "the file does not exist"
 
-    return (
-        textsource_mtime is None
-        or read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime) is not None
-    )
+    return read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)[1]
+
+
+def rankbatch_parquet_is_current(parquetfilepath: Path, textsource_mtime: float | None) -> bool:
+    """Return True when the parquet cache matches the cache format version and the text files."""
+    return rankbatch_parquet_staleness(parquetfilepath, textsource_mtime) is None
 
 
 def estimbatch_parquet_is_current(parquetfilepath: Path, folderpath: Path | str) -> bool:
@@ -470,7 +474,8 @@ def get_estimators_rankbatch_parquetfile(
     textsource_mtime = get_batch_textsource_mtime(textsource_mtimes, min(batch_mpiranks), max(batch_mpiranks))
 
     outdatedparquet: tuple[int, int] | None = None
-    if not rankbatch_parquet_is_current(parquetfilepath, textsource_mtime):
+    stalereason = rankbatch_parquet_staleness(parquetfilepath, textsource_mtime)
+    if stalereason is not None:
         # leave a stale file in place: write_parquet_atomic() puts the new one at the path in one step, so
         # the path always resolves to a complete parquet. Deleting it first opens a window in which a
         # concurrent reader finds it missing or half-swapped. The identity comes from the stat that showed
@@ -479,7 +484,7 @@ def get_estimators_rankbatch_parquetfile(
             outdatedparquet = at.get_file_identity(parquetfilepath.stat())
             print(
                 f"  {parquetfilepath.relative_to(modelpath.parent)} is not a current cache of the estimator"
-                " text files. File will be regenerated..."
+                f" text files, because {stalereason}. File will be regenerated..."
             )
 
         print(f"  generating {parquetfilepath.relative_to(modelpath.parent)}...")

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -752,12 +752,13 @@ def test_a_current_parquet_cache_starts_no_progress_bar(tmp_path: Path) -> None:
     from artistools.estimators.estimators import CACHEVERSION
     from artistools.estimators.estimators import get_rankbatch_parquetpath
     from artistools.estimators.estimators import rankbatch_parquet_is_current
+    from artistools.estimators.estimators import rankbatch_parquet_staleness
 
     parquetfilepath = get_rankbatch_parquetpath(tmp_path, [0, 1, 2], 0)
     assert parquetfilepath.name == "estimbatch00_0000_0002.out.parquet.tmp"
 
     # a cache that no run wrote yet needs the conversion
-    assert not rankbatch_parquet_is_current(parquetfilepath, None)
+    assert rankbatch_parquet_staleness(parquetfilepath, None) == "the file does not exist"
 
     mtime = 1000.0
     at.write_parquet_atomic(

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -352,9 +352,9 @@ def read_model_parquet_cache(
     if not parquetfilepath.is_file():
         return None
 
-    pqmetadata = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
+    pqmetadata, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
     if pqmetadata is None:
-        print(f"{parquetfilepath} is not a current cache of the text source. Will regenerate.")
+        print(f"{parquetfilepath} is not a current cache of the text source, because {stalereason}. Will regenerate.")
         return None
 
     # scan_parquet resolves its schema from the same footer that gave the metadata. Thus the check

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -1,6 +1,7 @@
 """File helpers: compressed text files, file searching, metadata, and atomic parquet writes."""
 
 import contextlib
+import datetime
 import io
 import os
 import re
@@ -783,26 +784,59 @@ def replace_outdated_file(newfilepath: Path, destpath: Path, outdatedfile: tuple
         os.close(lockfd)
 
 
+def format_mtime(mtime: float | str | None) -> str:
+    """Return a file modification time as a local time string with the raw number.
+
+    A cache that holds no stamp gives "absent". A stamp that no writer of this repository can
+    produce, e.g. a hand-edited one, comes back unchanged.
+    """
+    if mtime is None:
+        return "absent"
+    try:
+        localtime = datetime.datetime.fromtimestamp(float(mtime)).astimezone()
+    except (ValueError, OSError, OverflowError):
+        return str(mtime)
+    return f"{localtime.isoformat(sep=' ', timespec='seconds')} ({mtime})"
+
+
 def read_parquet_cache_metadata(
     parquetfilepath: Path, cacheversion: int, textsource_mtime: float
-) -> dict[str, str] | None:
-    """Return the metadata of a parquet cache, or None when the cache is stale or unreadable.
+) -> tuple[dict[str, str] | None, str | None]:
+    """Return the metadata of a parquet cache, and the reason why the cache is stale.
 
     The writer of a cache stamps the cache format version and the modification time of its text source
     into the parquet metadata. A cache from a different artistools version, or from different text
     files, fails the comparison. A new modification time of the cache does not make it current.
-    read_parquet_metadata is eager, thus a damaged file gives None here and not an error at a distant
+    read_parquet_metadata is eager, thus a damaged file gives a reason here and not an error at a distant
     collect().
+
+    A current cache gives its metadata and no reason. A stale cache gives no metadata and the reason
+    for the rejection, because a regeneration of a large cache costs minutes and the user must see
+    what caused it. Each reason reads as a lower-case clause after the word "because".
     """
     try:
         pqmetadata = pl.read_parquet_metadata(parquetfilepath)
-    except (pl.exceptions.PolarsError, OSError):
-        return None
+    except FileNotFoundError:
+        return None, "the file does not exist"
+    except (pl.exceptions.PolarsError, OSError) as exc:
+        return None, f"the file is not a readable parquet file ({type(exc).__name__}: {exc})"
 
-    iscurrent = pqmetadata.get("cacheversion") == str(cacheversion) and pqmetadata.get("textsource_mtime") == str(
-        textsource_mtime
-    )
-    return pqmetadata if iscurrent else None
+    foundversion = pqmetadata.get("cacheversion")
+    if foundversion != str(cacheversion):
+        return None, (
+            f"the cache format version is {foundversion}, but this artistools version writes {cacheversion}"
+            if foundversion is not None
+            else "the file has no cacheversion stamp, thus an artistools version before the stamp wrote it"
+        )
+
+    foundmtime = pqmetadata.get("textsource_mtime")
+    if foundmtime != str(textsource_mtime):
+        return None, (
+            f"the text source changed: the cache stamp is {format_mtime(foundmtime)},"
+            f" but the text file now has {format_mtime(textsource_mtime)}"
+        )
+
+    return pqmetadata, None
 
 
 def write_parquet_atomic(

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -224,6 +224,54 @@ def test_reference_data_search_follows_the_working_folder(tmp_path: Path, monkey
     assert at.find_reference_data_file("myref.txt", "data/refspectra") is None
 
 
+def test_a_rejected_parquet_cache_gives_the_reason(tmp_path: Path) -> None:
+    """A rejected cache must say which check failed, because a regeneration costs minutes.
+
+    The message said only that the cache was not current. Thus a user could not see whether a new
+    cache format version, a rewritten text file, or a damaged file caused the conversion.
+    """
+    cacheversion = 3
+    mtime = 1000.0
+
+    current = tmp_path / "current.parquet"
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}),
+        current,
+        metadata={"cacheversion": str(cacheversion), "textsource_mtime": str(mtime)},
+    )
+    pqmetadata, stalereason = at.read_parquet_cache_metadata(current, cacheversion, mtime)
+    assert stalereason is None
+    assert pqmetadata is not None
+
+    def get_reason(parquetfilepath: Path, textsource_mtime: float) -> str:
+        pqmetadata, stalereason = at.read_parquet_cache_metadata(parquetfilepath, cacheversion, textsource_mtime)
+        assert pqmetadata is None
+        assert stalereason is not None
+        return stalereason
+
+    # the text file changed after the run wrote the cache, thus the reason names both times
+    changedsource = get_reason(current, mtime + 10.0)
+    assert "the text source changed" in changedsource
+    assert str(mtime) in changedsource
+    assert str(mtime + 10.0) in changedsource
+
+    unstamped = tmp_path / "unstamped.parquet"
+    at.write_parquet_atomic(pl.DataFrame({"timestep": [0]}), unstamped)
+    assert "no cacheversion stamp" in get_reason(unstamped, mtime)
+
+    oldversion = tmp_path / "oldversion.parquet"
+    at.write_parquet_atomic(
+        pl.DataFrame({"timestep": [0]}), oldversion, metadata={"cacheversion": "0", "textsource_mtime": str(mtime)}
+    )
+    assert f"version is 0, but this artistools version writes {cacheversion}" in get_reason(oldversion, mtime)
+
+    unreadable = tmp_path / "unreadable.parquet"
+    unreadable.write_bytes(b"not parquet")
+    assert "not a readable parquet file" in get_reason(unreadable, mtime)
+
+    assert get_reason(tmp_path / "nosuchfile.parquet", mtime) == "the file does not exist"
+
+
 def test_a_stale_estimator_cache_does_not_hide_new_timesteps(tmp_path: Path) -> None:
     """A run that appends timesteps makes the batch cache stale, thus the text files answer.
 

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -408,7 +408,8 @@ def get_packets_rankbatch_parquetfile(
         ):
             last_textfile_mtime = text_filepath.stat().st_mtime
 
-            if read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, last_textfile_mtime) is not None:
+            _, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, last_textfile_mtime)
+            if stalereason is None:
                 conversion_needed = False
             else:
                 # the identity comes from the stat that showed the file is outdated, so only that exact
@@ -420,7 +421,8 @@ def get_packets_rankbatch_parquetfile(
                 # it missing or half-swapped
                 print(
                     f"  {parquetfilepath.relative_to(modelpath)} is not a current cache of"
-                    f" {text_filepath.relative_to(modelpath)}. File will be regenerated..."
+                    f" {text_filepath.relative_to(modelpath)}, because {stalereason}."
+                    " File will be regenerated..."
                 )
         else:
             conversion_needed = False


### PR DESCRIPTION
## What changed

A run showed only that a cache file was not current:

```
packets/packetsbatch01_0100_0199.out.parquet.tmp is not a current cache of
packets/packets00_0199.out.zst. File will be regenerated...
```

The user could not see which check failed. Thus a regeneration that costs minutes had no visible cause.

`read_parquet_cache_metadata` now returns the metadata and the reason for the rejection. The reason names the check that failed:

- the file does not exist;
- the file is not a readable parquet file, with the type and the text of the exception;
- the file has no `cacheversion` stamp;
- the cache format version differs from the version that this artistools version writes;
- the text source changed, with the stamped time and the current time of the text file.

The three callers show the reason. The message now reads:

```
packets/packetsbatch01_0100_0199.out.parquet.tmp is not a current cache of
packets/packets00_0199.out.zst, because the file has no cacheversion stamp, thus an
artistools version before the stamp wrote it. File will be regenerated...
```

```
... because the text source changed: the cache stamp is 2025-09-16 06:20:00+01:00
(1758000000.123456), but the text file now has 2026-02-25 06:15:23+00:00 (1772000123.5).
```

## Why

PR #611 added the `cacheversion` stamp and the `textsource_mtime` stamp. Each cache that an earlier artistools version wrote thus fails the check one time. A user who saw the message could not tell that cause from a rewritten text file or from a damaged file.

## Notes for the reviewer

- The reason is `None` when the cache is current, thus one value shows the state. The caller no longer holds two conventions.
- The new function `format_mtime` gives a local time and the raw number, thus the user can compare the two times.
- The estimators module gets `rankbatch_parquet_staleness`. `rankbatch_parquet_is_current` becomes a wrapper of it, because two callers want only a boolean.
- `read_parquet_cache_metadata` now reports a file that does not exist. The estimator check thus does one `stat` call less for each rank batch, which counts on a network file system.
- Each of the three call sites keeps its own sentence, because each one names a different source and a different base path. The docstring states the rule that every reason reads as a clause after the word "because".
- The tests of the shared reasons are in `artistools/misc/test_misc.py`, beside the code that writes them. `test_estimators.py` keeps only the rules that the estimators layer adds.

## Checks

`ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`, and `vulture` give no new report. The full test suite passes: 559 passed, 1 skipped. No Rust file changed, thus this branch did not need `cargo clippy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)