### PR TITLE
Add the deposition subcommand

### DIFF
--- a/artistools/commands.py
+++ b/artistools/commands.py
@@ -108,6 +108,7 @@ COMMANDGROUPS: Mapping[str, tuple[str, ...]] = MappingProxyType({
     ),
     "model commands": ("inputmodel", "makevpktinput"),
     "data commands": (
+        "deposition",
         "ejectaopacity",
         "exportmassfractions",
         "gsinetworkdecayproducts",
@@ -136,6 +137,14 @@ subcommandtree: CommandTree = {
     ),
     "completions": CommandSpec(
         "commands", funcname="setup_completions", helptext="Write a tab-completion script for a shell."
+    ),
+    "deposition": CommandSpec(
+        "estimators.deposition",
+        helptext="Give the deposition rate per unit volume, per ion, and per unit mass.",
+        note=(
+            "The deposition_ estimators of each cell give the rate, thus the command needs a run of a"
+            " recent ARTIS version. Every column covers the cells that hold matter."
+        ),
     ),
     # the help lists this name under "inputmodel describe", thus the top level hides it
     "describeinputmodel": dc.replace(DESCRIBEINPUTMODEL, aliases=(), hidden=True),
@@ -711,6 +720,8 @@ SINGLEDASHLONGFLAGS = frozenset({
     "-binwidth",
     "-cell",
     "-cell-is-optically-thick",
+    "-channel",
+    "-channels",
     "-cmap",
     "-color",
     "-colors",

--- a/artistools/estimators/__init__.py
+++ b/artistools/estimators/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = ["plot"]
 
+from artistools.estimators import deposition as deposition
 from artistools.estimators import estimators_classic as estimators_classic
 from artistools.estimators import exportmassfractions as exportmassfractions
 from artistools.estimators import plotestimators as plotestimators

--- a/artistools/estimators/deposition.py
+++ b/artistools/estimators/deposition.py
@@ -31,8 +31,12 @@ DEFAULTOUTPUTNAME = "deposition.txt"
 
 
 def get_deposition_channels(colnames: Sequence[str]) -> list[str]:
-    """Return the deposition channels that the estimators of a model give."""
-    return [name.removeprefix(DEPOSITIONPREFIX) for name in colnames if name.startswith(DEPOSITIONPREFIX)]
+    """Return the deposition channels that the estimators of a model give, in alphabetical order.
+
+    The reader of the estimator files keeps the columns in a hash map, thus the order of the columns
+    changes between runs. The sort gives one order to the listing and to each message.
+    """
+    return sorted(name.removeprefix(DEPOSITIONPREFIX) for name in colnames if name.startswith(DEPOSITIONPREFIX))
 
 
 def get_deposition_expression(colnames: Sequence[str], channels: Sequence[str] | None) -> pl.Expr:
@@ -88,8 +92,8 @@ def aggregate_deposition_rates(
         dep_erg_per_s=get_deposition_expression(colnames, channels) * pl.col("volume_prevtimestep"),
     )
 
-    # only a cell that holds matter has an ion. A NaN number density gives no count, and the
-    # comparison alone keeps such a cell, because polars reads a NaN as greater than zero
+    # only a cell that holds matter has an ion. The filter also names is_finite, because a NaN
+    # number density passes the comparison and gives no count
     dfcells = dfestim.filter(pl.col("nntot") > 0, pl.col("nntot").is_finite()).select(
         "timestep", "modelgridindex", "tmid_days", "mass_g", "volume", ioncount=pl.col("nntot") * pl.col("volume")
     )

--- a/artistools/estimators/deposition.py
+++ b/artistools/estimators/deposition.py
@@ -1,0 +1,268 @@
+# PYTHON_ARGCOMPLETE_OK
+"""Give the deposition rate of a model per unit volume, per ion, and per unit mass."""
+
+import argparse
+import typing as t
+from collections.abc import Sequence
+from pathlib import Path
+
+import polars as pl
+
+from artistools.constants import EV_to_erg
+from artistools.estimators.estimators import scan_estimators
+from artistools.misc import addarg_modelpath
+from artistools.misc import addarg_output
+from artistools.misc import addarg_timedays
+from artistools.misc import addarg_timestep
+from artistools.misc import addarg_verbose
+from artistools.misc import get_model_name
+from artistools.misc import get_time_range
+from artistools.misc import get_timestep_times
+from artistools.misc import normalize_path_list
+from artistools.misc import parse_cli_args
+from artistools.misc import print_product
+from artistools.misc import print_saved
+from artistools.misc import print_warning
+from artistools.misc import resolve_outputfile
+from artistools.misc.cliutils import CommaJoinAction
+
+DEPOSITIONPREFIX = "deposition_"
+DEFAULTOUTPUTNAME = "deposition.txt"
+
+
+def get_deposition_channels(colnames: Sequence[str]) -> list[str]:
+    """Return the deposition channels that the estimators of a model give."""
+    return [name.removeprefix(DEPOSITIONPREFIX) for name in colnames if name.startswith(DEPOSITIONPREFIX)]
+
+
+def get_deposition_expression(colnames: Sequence[str], channels: Sequence[str] | None) -> pl.Expr:
+    """Return the expression that gives the deposition rate of one cell in erg/s/cm3.
+
+    The command needs the rate of each cell, which the deposition_ columns hold. An older run holds
+    total_dep alone, and artistools derives that column from the heating rate. On the classic-mode
+    test model that total is 1400 times below the tally of deposition.out, thus such a model gets an
+    error and no number.
+    """
+    available = get_deposition_channels(colnames)
+    if not available:
+        msg = (
+            "The estimators of this model hold no deposition_ column, thus they give no deposition "
+            "rate of a cell. The file deposition.out holds the rate of the whole model, which "
+            "artistools plotlightcurves --plotdeposition draws"
+        )
+        raise ValueError(msg)
+
+    channels = [channel.removeprefix(DEPOSITIONPREFIX) for channel in channels] if channels else available
+    if unknown := [channel for channel in channels if channel not in available]:
+        msg = f"This model gives no deposition rate of {' and '.join(unknown)}. It holds {', '.join(available)}"
+        raise ValueError(msg)
+
+    # ignore_nulls=False keeps a null, thus a channel that one rank left out gives no partial total
+    return pl.sum_horizontal((pl.col(f"{DEPOSITIONPREFIX}{channel}") for channel in channels), ignore_nulls=False)
+
+
+def aggregate_deposition_rates(
+    dfestim: pl.LazyFrame, timesteps: Sequence[int] | None = None, channels: Sequence[str] | None = None
+) -> pl.DataFrame:
+    """Return the deposition rate per unit volume, per ion, and per unit mass of each timestep.
+
+    ARTIS writes the deposition rate of a timestep into the estimators of the next timestep. It
+    divides that rate by the volume of the timestep that took the energy. Thus the rate of timestep n
+    comes from the rows of timestep n + 1 and from the column volume_prevtimestep. The last timestep
+    gets no row, because only a later timestep holds that rate.
+
+    The join on the cell gives one row of one timestep to each cell. Thus the rate, the ion count,
+    the volume, and the mass of a row cover one set of cells.
+    """
+    colnames = dfestim.collect_schema().names()
+    if "nntot" not in colnames:
+        msg = (
+            "The estimators of this model hold no number density of the elements, "
+            "thus the command cannot count the ions"
+        )
+        raise ValueError(msg)
+
+    dfrates = dfestim.select(
+        timestep=pl.col("timestep") - 1,
+        modelgridindex=pl.col("modelgridindex"),
+        dep_erg_per_s=get_deposition_expression(colnames, channels) * pl.col("volume_prevtimestep"),
+    )
+
+    # only a cell that holds matter has an ion. A NaN number density gives no count, and the
+    # comparison alone keeps such a cell, because polars reads a NaN as greater than zero
+    dfcells = dfestim.filter(pl.col("nntot") > 0, pl.col("nntot").is_finite()).select(
+        "timestep", "modelgridindex", "tmid_days", "mass_g", "volume", ioncount=pl.col("nntot") * pl.col("volume")
+    )
+    if timesteps is not None:
+        dfcells = dfcells.filter(pl.col("timestep").is_in(list(timesteps)))
+
+    return (
+        dfcells
+        .join(dfrates, on=("timestep", "modelgridindex"), how="inner")
+        .group_by("timestep")
+        .agg(
+            tmid_days=pl.col("tmid_days").first(),
+            dep_erg_per_s=pl.col("dep_erg_per_s").sum(),
+            ioncount=pl.col("ioncount").sum(),
+            volume=pl.col("volume").sum(),
+            mass_g=pl.col("mass_g").sum(),
+            # the sum leaves a null out, thus the count of the cells that gave no rate goes beside it
+            cellswithnorate=pl.col("dep_erg_per_s").is_finite().fill_null(value=False).not_().sum(),
+        )
+        .with_columns(
+            # a rate in erg divided by erg per eV gives the rate in eV
+            dep_per_volume=pl.col("dep_erg_per_s") / EV_to_erg / pl.col("volume"),
+            dep_per_ion=pl.col("dep_erg_per_s") / EV_to_erg / pl.col("ioncount"),
+            dep_per_mass=pl.col("dep_erg_per_s") / EV_to_erg / pl.col("mass_g"),
+        )
+        .select(
+            "timestep",
+            # the table prints a number, thus a null arrives there as a NaN
+            *(
+                pl.col(name).fill_null(float("nan"))
+                for name in ("tmid_days", "dep_per_volume", "dep_per_ion", "dep_per_mass")
+            ),
+            "cellswithnorate",
+        )
+        .sort("timestep")
+        .collect(engine="streaming")
+    )
+
+
+def get_deposition_rates(
+    modelpath: Path | str,
+    timesteps: Sequence[int] | None = None,
+    channels: Sequence[str] | None = None,
+    verbose: bool = False,
+) -> pl.DataFrame:
+    """Read the estimators of a model, and return the deposition rate of each timestep.
+
+    A value of None for timesteps reads every timestep of the model.
+    """
+    readtimesteps = None if timesteps is None else tuple({*timesteps} | {timestep + 1 for timestep in timesteps})
+    dfestim = scan_estimators(modelpath, timestep=readtimesteps, join_modeldata=True, verbose=verbose)
+
+    return aggregate_deposition_rates(dfestim, timesteps, channels)
+
+
+def get_selected_timesteps(modelpath: Path | str, timedays: str | None, timestep: str | None) -> list[int] | None:
+    """Return the timesteps that -timedays or -timestep selects, or None if the caller gives no time.
+
+    Each argument also takes a list, e.g. 1,5,30. get_time_range reads one item of that list. Thus a
+    time, a range of times, a timestep, a range of timesteps, and "last" mean here what they mean on
+    every other command.
+    """
+    if timedays is timestep is None:
+        return None
+
+    selected: set[int] = set()
+    for token in str(timestep if timedays is None else timedays).split(","):
+        timestepmin, timestepmax, _, _ = (
+            get_time_range(modelpath, timestep_range_str=token)
+            if timedays is None
+            else get_time_range(modelpath, timedays_range_str=token)
+        )
+        selected.update(range(timestepmin, timestepmax + 1))
+
+    return sorted(selected)
+
+
+def format_channel_list(modelpath: Path | str, verbose: bool = False) -> str:
+    """Return the deposition channels that the estimators of a model hold.
+
+    The scan reads the files of one cell, thus the listing costs much less than the table.
+    """
+    channels = get_deposition_channels(
+        scan_estimators(modelpath, modelgridindex=0, verbose=verbose).collect_schema().names()
+    )
+
+    return f"{get_model_name(modelpath)} holds {', '.join(channels) if channels else 'no deposition channel'}"
+
+
+def format_deposition_table(modelpath: Path | str, dftable: pl.DataFrame, channels: Sequence[str] | None) -> str:
+    """Return the deposition rates of one model as a table of one row for each timestep."""
+    lines = [
+        f"{get_model_name(modelpath)}: deposition of {', '.join(channels) if channels else 'every channel'}",
+        f"{'timestep':>8s} {'t_days':>10s} {'dep_per_volume':>15s} {'dep_per_ion':>15s} {'dep_per_mass':>15s}",
+        f"{'':>8s} {'[d]':>10s} {'[eV/s/cm^3]':>15s} {'[eV/s]':>15s} {'[eV/s/g]':>15s}",
+    ]
+    lines.extend(
+        f"{timestep:8d} {tmid_days:10.3f} {dep_per_volume:15.3e} {dep_per_ion:15.3e} {dep_per_mass:15.3e}"
+        for timestep, tmid_days, dep_per_volume, dep_per_ion, dep_per_mass in dftable.select(
+            "timestep", "tmid_days", "dep_per_volume", "dep_per_ion", "dep_per_mass"
+        ).iter_rows()
+    )
+
+    return "\n".join(lines)
+
+
+def warn_about_gaps(
+    modelpath: Path | str, dftable: pl.DataFrame, timesteps: Sequence[int] | None, lasttimestep: int
+) -> None:
+    """Print a warning for each timestep that got no row, and for the cells that gave no rate."""
+    modelname = get_model_name(modelpath)
+    gotrows = set(dftable["timestep"].to_list())
+    # a run gives no rate for its last timestep, thus the default selection loses that one row
+    wanted = set(timesteps) if timesteps is not None else {lasttimestep}
+    if missing := sorted(wanted - gotrows):
+        print_warning(
+            f"{modelname}: no deposition rate for timestep {', '.join(str(timestep) for timestep in missing)}. "
+            "The rate of a timestep arrives in the file of the next timestep, "
+            "thus the last timestep of a run gives none"
+        )
+
+    if cellswithnorate := int(dftable["cellswithnorate"].sum()):
+        print_warning(f"{modelname}: {cellswithnorate} cells gave no deposition rate, thus a row can hold a NaN")
+
+
+def addargs(parser: argparse.ArgumentParser) -> None:
+    """Add arguments to an argparse parser object."""
+    addarg_modelpath(parser, positional=True, multiplepaths=True, default=[], helptext="Paths to ARTIS model folders")
+    addarg_timedays(
+        parser, kind="str", helptext="Times in days, e.g. 30, a range 10-30, or a list 1,5,30. Default: every timestep"
+    )
+    addarg_timestep(parser, helptext="Timesteps, e.g. 40, a range 45-65, a list 4,9, or last")
+    parser.add_argument(
+        "-channels",
+        "-channel",
+        dest="channels",
+        action=CommaJoinAction,
+        help=(
+            "Deposition channels to add, e.g. gamma,electron,alpha. "
+            "Default: every channel of the model. Give --listchannels to show the channels"
+        ),
+    )
+    parser.add_argument(
+        "--listchannels", action="store_true", help="Show the deposition channels of the model. The command then stops"
+    )
+    addarg_output(parser, kind="file", helptext="Path/filename for the output text file")
+    addarg_verbose(parser)
+
+
+def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
+    """Give the deposition rate of a model per unit volume, per ion, and per unit mass."""
+    args = parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
+
+    channels = str(args.channels).split(",") if args.channels else None
+    tables: list[str] = []
+    for modelpath in normalize_path_list(args.modelpath):
+        if args.listchannels:
+            tables.append(format_channel_list(modelpath, verbose=args.verbose))
+        else:
+            timesteps = get_selected_timesteps(modelpath, args.timedays, args.timestep)
+            dftable = get_deposition_rates(modelpath, timesteps, channels, verbose=args.verbose)
+            warn_about_gaps(modelpath, dftable, timesteps, len(get_timestep_times(modelpath, loc="mid")) - 1)
+            tables.append(format_deposition_table(modelpath, dftable, channels))
+
+        print_product(args, tables[-1])
+
+    if args.outputfile:
+        outputfile = resolve_outputfile(args.outputfile, DEFAULTOUTPUTNAME)
+        outputfile.write_text("\n\n".join(tables) + "\n", encoding="utf-8")
+        print_saved(outputfile)
+
+
+if __name__ == "__main__":
+    from artistools.commands import run_module_as_subcommand
+
+    run_module_as_subcommand(__spec__)

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 import typing as t
 from pathlib import Path
 from unittest import mock
@@ -1588,3 +1589,170 @@ def test_estimator_snapshot_classic_3d_cone(mockplot: mock.MagicMock) -> None:
 
     xvalues = np.concatenate([np.array(callargs[0][1], dtype=float) for callargs in mockplot.call_args_list])
     assert len(xvalues) > 0
+
+
+# the estimators of every test model of the repository hold no deposition_ column, thus a test that
+# needs one writes this line into a copy of the test model
+DEPOSITIONLINE = "deposition: gamma 2.0e-10 positron 1.0e-10 electron 5.0e-11 alpha 2.5e-11"
+
+
+def make_model_with_deposition(tmp_path: Path) -> Path:
+    """Return a copy of the test model whose estimators give the deposition rate of each channel.
+
+    The copy holds the four small input files that the reader needs, thus it costs no time and no
+    space. The atomic data of the test model stays where it is.
+    """
+    modeldir = tmp_path / "modelwithdeposition"
+    modeldir.mkdir()
+    for name in ("model.txt", "abundances.txt", "input.txt", "compositiondata.txt"):
+        shutil.copy(modelpath / name, modeldir / name)
+
+    lines = (modelpath / "estimators_0000.out").read_text(encoding="utf-8").splitlines()
+    withdeposition = [f"{line}\n{DEPOSITIONLINE}" if line.startswith("timestep ") else line for line in lines]
+    (modeldir / "estimators_0000.out").write_text("\n".join(withdeposition) + "\n", encoding="utf-8")
+
+    return modeldir
+
+
+def test_deposition_rates_read_the_next_timestep() -> None:
+    """The rate of timestep n comes from the rows of n + 1, weighted by the volume of n.
+
+    Every column of one row must cover one set of cells: a cell with no matter enters neither the
+    rate nor the volume, the ion count, or the mass. A cell that gives no rate is counted.
+    """
+    dfestim = pl.LazyFrame({
+        "timestep": [0, 0, 0, 0, 1, 1, 1, 1],
+        "modelgridindex": [0, 1, 2, 3, 0, 1, 2, 3],
+        "tmid_days": [10.0] * 4 + [11.0] * 4,
+        "nntot": [10.0, 20.0, 0.0, 5.0, 9.0, 19.0, 0.0, 4.0],
+        "volume": [2.0, 4.0, 8.0, 1.0, 2.2, 4.4, 8.8, 1.1],
+        "volume_prevtimestep": [None] * 4 + [2.0, 4.0, 8.0, 1.0],
+        "mass_g": [3.0, 5.0, 7.0, 2.0, 3.0, 5.0, 7.0, 2.0],
+        "deposition_gamma": [0.0] * 4 + [1.0e-9, 2.0e-9, 5.0e-9, None],
+        "deposition_alpha": [0.0] * 4 + [1.0e-10, 0.0, 1.0e-9, 1.0e-9],
+    })
+
+    dftable = at.estimators.deposition.aggregate_deposition_rates(dfestim)
+
+    # cell 2 holds no matter and cell 3 gives no rate, thus the rate covers cells 0 and 1 alone
+    rate_erg_per_s = 1.1e-9 * 2.0 + 2.0e-9 * 4.0
+    assert dftable["timestep"].to_list() == [0]
+    assert np.isclose(dftable["tmid_days"].item(), 10.0)
+    # cell 3 still holds matter, thus its volume, its ions, and its mass stay in the denominators
+    assert np.isclose(dftable["dep_per_volume"].item(), rate_erg_per_s / at.constants.EV_to_erg / 7.0, rtol=1e-12)
+    assert np.isclose(dftable["dep_per_ion"].item(), rate_erg_per_s / at.constants.EV_to_erg / 105.0, rtol=1e-12)
+    assert np.isclose(dftable["dep_per_mass"].item(), rate_erg_per_s / at.constants.EV_to_erg / 10.0, rtol=1e-12)
+    assert dftable["cellswithnorate"].item() == 1
+
+    # one channel gives its own rate, and the ion count and the mass do not change
+    dfgamma = at.estimators.deposition.aggregate_deposition_rates(dfestim, channels=["gamma"])
+    assert np.isclose(
+        dfgamma["dep_per_ion"].item(), (1.0e-9 * 2.0 + 2.0e-9 * 4.0) / at.constants.EV_to_erg / 105.0, rtol=1e-12
+    )
+
+
+def test_deposition_rates_from_the_estimator_files(tmp_path: Path) -> None:
+    """The rates of a model must match a calculation that reads the estimators on its own.
+
+    The volume of timestep 55 is 1.01 times the volume of 54, and the ion count of 55 is 0.99 times
+    the count of 54. Thus this test fails if the code reads a quantity at the wrong timestep.
+    """
+    modeldir = make_model_with_deposition(tmp_path)
+    dfestim = at.estimators.scan_estimators(modeldir, timestep=(54, 55), join_modeldata=True).collect()
+    row54 = dfestim.filter(pl.col("timestep") == 54)
+    # the four values of DEPOSITIONLINE, in erg/s/cm3
+    rate_erg_per_s = (2.0e-10 + 1.0e-10 + 5.0e-11 + 2.5e-11) * dfestim.filter(pl.col("timestep") == 55)[
+        "volume_prevtimestep"
+    ].item()
+
+    dftable = at.estimators.deposition.get_deposition_rates(modeldir, timesteps=[54])
+
+    assert dftable["timestep"].to_list() == [54]
+    assert np.isclose(
+        dftable["dep_per_volume"].item(), rate_erg_per_s / at.constants.EV_to_erg / row54["volume"].item(), rtol=1e-6
+    )
+    assert np.isclose(
+        dftable["dep_per_ion"].item(),
+        rate_erg_per_s / at.constants.EV_to_erg / (row54["nntot"].item() * row54["volume"].item()),
+        rtol=1e-6,
+    )
+    assert np.isclose(
+        dftable["dep_per_mass"].item(), rate_erg_per_s / at.constants.EV_to_erg / row54["mass_g"].item(), rtol=1e-6
+    )
+
+
+def test_deposition_needs_the_deposition_estimators() -> None:
+    """A model that gives no rate of a cell must give an error and no number.
+
+    artistools derives total_dep from the heating rate for such a model. On the classic-mode test
+    model that total is 1400 times below the tally of deposition.out, thus it is no deposition rate.
+    """
+    with pytest.raises(ValueError, match="hold no deposition_ column"):
+        at.estimators.deposition.main(argsraw=[], modelpath=modelpath, timestep="54")
+
+    assert at.estimators.deposition.format_channel_list(modelpath).endswith("holds no deposition channel")
+
+
+def test_deposition_names_the_channels_of_the_model() -> None:
+    """An unknown channel must give a message that names the channels of the model."""
+    colnames = ["total_dep", "deposition_gamma", "deposition_positron"]
+    dfcell = pl.LazyFrame({"deposition_gamma": [1.0], "deposition_positron": [2.0]})
+
+    # no channel of its own means every channel of the model
+    expr = at.estimators.deposition.get_deposition_expression(colnames, None)
+    assert np.isclose(dfcell.select(expr).collect().item(), 3.0)
+
+    expr = at.estimators.deposition.get_deposition_expression(colnames, ["deposition_gamma"])
+    assert np.isclose(dfcell.select(expr).collect().item(), 1.0)
+
+    with pytest.raises(ValueError, match=re.escape("no deposition rate of alpha. It holds gamma, positron")):
+        at.estimators.deposition.get_deposition_expression(colnames, ["alpha"])
+
+
+def test_deposition_timeselection_takes_a_list_and_a_range() -> None:
+    """-timedays and -timestep each take a list. Each item of the list means what it means elsewhere."""
+    tmids = at.get_timestep_times(modelpath, loc="mid")
+    timesteps = at.estimators.deposition.get_selected_timesteps(modelpath, "260,300-303", None)
+
+    inrange = [timestep for timestep, tmid in enumerate(tmids) if 300 <= tmid <= 303]
+    assert timesteps == sorted({at.get_timestep_of_timedays(modelpath, 260), *inrange})
+
+    assert at.estimators.deposition.get_selected_timesteps(modelpath, None, "4,9-11") == [4, 9, 10, 11]
+    assert at.estimators.deposition.get_selected_timesteps(modelpath, None, "last") == [len(tmids) - 1]
+    assert at.estimators.deposition.get_selected_timesteps(modelpath, None, None) is None
+
+    # a range that holds no timestep gives an error, and not a selection that quietly loses it
+    with pytest.raises(ValueError, match="does not include any full timesteps"):
+        at.estimators.deposition.get_selected_timesteps(modelpath, "303-300,260", None)
+
+
+def test_deposition_writes_a_table(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The command writes the table that it prints. It also reports each timestep with no rate."""
+    modeldir = make_model_with_deposition(tmp_path)
+    outfile = tmp_path / "deposition.txt"
+    at.estimators.deposition.main(argsraw=[], modelpath=modeldir, timestep="54,last", outputfile=outfile)
+
+    lines = outfile.read_text(encoding="utf-8").splitlines()
+    assert lines[0].startswith(at.get_model_name(modeldir))
+    assert lines[1].split() == ["timestep", "t_days", "dep_per_volume", "dep_per_ion", "dep_per_mass"]
+    assert lines[2].split() == ["[d]", "[eV/s/cm^3]", "[eV/s]", "[eV/s/g]"]
+
+    values = [float(value) for value in lines[3].split()]
+    assert len(lines) == 4, "the last timestep gets no rate, thus the table holds one row"
+    assert values[0] == pytest.approx(54)
+    # the table gives four digits, thus the value in the file has less precision
+    assert np.isclose(
+        values[3], at.estimators.deposition.get_deposition_rates(modeldir, [54])["dep_per_ion"].item(), rtol=1e-3
+    )
+
+    # the file of the next timestep holds the rate, thus the last timestep of the run gives none
+    assert "no deposition rate for timestep 99" in capsys.readouterr().err
+
+
+def test_deposition_lists_the_channels(tmp_path: Path) -> None:
+    """--listchannels must name the channels of the model, and write them when -o asks."""
+    modeldir = make_model_with_deposition(tmp_path)
+    outfile = tmp_path / "channels.txt"
+    at.estimators.deposition.main(argsraw=[], modelpath=modeldir, listchannels=True, outputfile=outfile)
+
+    assert outfile.read_text(encoding="utf-8").strip().endswith("holds alpha, electron, gamma, positron")


### PR DESCRIPTION
## What this adds

`artistools deposition` gives the deposition rate of a model per unit volume, per ion, and per unit mass. It grew out of a one-model, one-time analysis script.

```
artistools deposition <modelpath> -t 30
```

```
SFHo_long-radius-entropy_3D_...: deposition of every channel
timestep     t_days  dep_per_volume     dep_per_ion    dep_per_mass
                [d]     [eV/s/cm^3]          [eV/s]        [eV/s/g]
      45     30.031       4.719e+02       1.170e-03       1.248e+19
```

- takes several model paths, and gives one table for each;
- `-t 30`, `-t 1,5,30`, and `-t 10-30` select the times. `-ts 45`, `-ts 45-65`, and `-ts last` select the timesteps. Each item of a list goes to `get_time_range`, thus it means here what it means on every other command;
- `-channels gamma,electron,alpha` selects the channels, and `--listchannels` shows the channels of a model;
- `-o` writes the table, and `--quiet`, `--verbose`, and `-h` work as on every other command.

## How the rate reaches a timestep

ARTIS writes the deposition rate of a timestep into the estimators of the next timestep, and it divides that rate by the volume of the timestep that took the energy. Thus the sum reads the rows of timestep n + 1 and the column `volume_prevtimestep`. The last timestep of a run gets no row, and a warning says why.

A join on the cell gives the rate, the ion count, the volume, and the mass one set of cells. A cell that holds no matter enters no column.

## Why the command refuses an older run

artistools derives `total_dep` from the heating rate when a run holds no `deposition_` column. On `tests/data/test-classicmode_3d` that total sums to about 2e40 erg/s, and `deposition.out` of the same run reports about 3e43 erg/s. It is also NaN in every cell at the first timesteps. Thus it is no deposition rate, and a model that holds no `deposition_` column now gets an error that names `deposition.out` and `artistools plotlightcurves --plotdeposition`.

## Tests

No test model of the repository holds a `deposition_` column. Thus:

- one test makes a copy of the test model with a `deposition:` line in the estimators. The copy holds the four small input files that the reader needs, and it costs no space. The test compares each column with a calculation that reads the estimators on its own;
- a second test gives a synthetic frame to the aggregation. It pins the timestep shift, the volume weighting, the set of cells, and the conversion to eV;
- between timestep 54 and timestep 55 the volume differs by a factor 1.01 and the ion count by a factor 0.99. Thus a quantity that comes from the wrong timestep makes the tests fail.

## For the reviewer

- **The default sums every channel.** The script that this command replaces summed gamma, electron, and alpha, thus it left the positrons out. `-channels gamma,electron,alpha` gives that sum again.
- **Open question on the volume of a channel.** Under `PARTICLE_THERMALISATION_SCHEME == INSTANTFULLDEPOSITION` the positron, electron, and alpha estimators hold an analytic rate at the time of their own file, and `deposition_gamma` alone holds the Monte Carlo estimator of the previous timestep. If that is correct, the three other channels need `volume` and not `volume_prevtimestep`, and the total is low by `(t_n/t_n+1)^3`. That is about 1 % on a grid of 250 to 350 days and about 9 % on the timesteps of the classic 3D test model. This branch keeps one convention for every channel, as the script did. Please say which convention ARTIS gives.

`ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`, and `vulture` give no error. The full test suite gives 578 passed and 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
