### PR TITLE
Add a Ye range option to the deposition subcommand

### DIFF
--- a/artistools/commands.py
+++ b/artistools/commands.py
@@ -906,6 +906,7 @@ SINGLEDASHLONGFLAGS = frozenset({
     "-xunit",
     "-xunits",
     "-yaxis",
+    "-ye",
     "-yemax",
     "-ymax",
     "-ymin",

--- a/artistools/estimators/deposition.py
+++ b/artistools/estimators/deposition.py
@@ -10,6 +10,7 @@ import polars as pl
 
 from artistools.constants import EV_to_erg
 from artistools.estimators.estimators import scan_estimators
+from artistools.inputmodel import get_modeldata
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
 from artistools.misc import addarg_timedays
@@ -20,6 +21,7 @@ from artistools.misc import get_time_range
 from artistools.misc import get_timestep_times
 from artistools.misc import normalize_path_list
 from artistools.misc import parse_cli_args
+from artistools.misc import parse_float_range
 from artistools.misc import print_product
 from artistools.misc import print_saved
 from artistools.misc import print_warning
@@ -65,8 +67,75 @@ def get_deposition_expression(colnames: Sequence[str], channels: Sequence[str] |
     return pl.sum_horizontal((pl.col(f"{DEPOSITIONPREFIX}{channel}") for channel in channels), ignore_nulls=False)
 
 
+def parse_ye_range(text: str) -> tuple[float, float]:
+    """Return the lower end and the upper end of a Ye range such as 0-0.2.
+
+    A Ye is the number of electrons per nucleon, thus each end must be 0 to 1. That comparison also
+    refuses a nan and an infinity, because each comparison with a nan gives false.
+    """
+    yemin, yemax = sorted(parse_float_range(text, "a Ye range, such as 0-0.2"))
+    if not 0.0 <= yemin <= yemax <= 1.0:
+        msg = f"{text!r} names a Ye outside 0 to 1"
+        raise ValueError(msg)
+
+    return yemin, yemax
+
+
+def check_ye_range(modelpath: Path | str, yerange: tuple[float, float], verbose: bool = False) -> tuple[int, int]:
+    """Return how many cells a Ye range selects and how many hold matter, and print those counts.
+
+    A range that selects no cell gives an error.
+
+    A cell with no matter gives no deposition rate, and artistools writes a Ye of 0 for such a cell.
+    Thus the count covers the cells that hold matter, and a range of a low Ye gets the number of
+    cells that the table sums.
+
+    The check reads the model alone, and it gives the arguments that the reader of the estimators
+    gives. Thus a range that selects no cell stops the command before the much slower read of the
+    estimator files, and the two calls see the same cells.
+    """
+    modelname = get_model_name(modelpath)
+    dfmodel, _ = get_modeldata(modelpath, derived_cols=["ALL"], get_elemabundances=True, printwarningsonly=not verbose)
+    if "Ye" not in dfmodel.collect_schema().names():
+        msg = f"{modelname} gives no Ye of a cell. The model file must hold a Ye column"
+        raise ValueError(msg)
+
+    yemin, yemax = yerange
+    modelyemin, modelyemax, cellsinrange, cellswithmatter = (
+        dfmodel
+        .filter(pl.col("rho") > 0)
+        .select(
+            modelyemin=pl.col("Ye").min(),
+            modelyemax=pl.col("Ye").max(),
+            cellsinrange=pl.col("Ye").is_between(yemin, yemax).sum(),
+            cellswithmatter=pl.len(),
+        )
+        .collect()
+        .row(0)
+    )
+    if not cellsinrange:
+        # a model with no cell of matter, and a model of null Ye values, both give no minimum
+        yeofmodel = (
+            "It gives no Ye of a cell that holds matter"
+            if modelyemin is None
+            else f"Its cells with matter have a Ye of {modelyemin:g} to {modelyemax:g}"
+        )
+        msg = f"{modelname} has no cell with matter and a Ye of {yemin:g} to {yemax:g}. {yeofmodel}"
+        raise ValueError(msg)
+
+    print(
+        f"{modelname}: {cellsinrange} of {cellswithmatter} cells with matter "
+        f"({cellsinrange / cellswithmatter:.1%}) have a Ye of {yemin:g} to {yemax:g}"
+    )
+
+    return cellsinrange, cellswithmatter
+
+
 def aggregate_deposition_rates(
-    dfestim: pl.LazyFrame, timesteps: Sequence[int] | None = None, channels: Sequence[str] | None = None
+    dfestim: pl.LazyFrame,
+    timesteps: Sequence[int] | None = None,
+    channels: Sequence[str] | None = None,
+    yerange: tuple[float, float] | None = None,
 ) -> pl.DataFrame:
     """Return the deposition rate per unit volume, per ion, and per unit mass of each timestep.
 
@@ -77,6 +146,8 @@ def aggregate_deposition_rates(
 
     The join on the cell gives one row of one timestep to each cell. Thus the rate, the ion count,
     the volume, and the mass of a row cover one set of cells.
+
+    A Ye range keeps the cells of the model whose Ye is inside it. Both ends of the range count.
     """
     colnames = dfestim.collect_schema().names()
     if "nntot" not in colnames:
@@ -85,6 +156,14 @@ def aggregate_deposition_rates(
             "thus the command cannot count the ions"
         )
         raise ValueError(msg)
+
+    if yerange is not None:
+        # join_cell_modeldata puts an init_ prefix on each column of the model snapshot
+        if "init_Ye" not in colnames:
+            msg = "The model of this run gives no Ye of a cell, thus a Ye range selects nothing"
+            raise ValueError(msg)
+
+        dfestim = dfestim.filter(pl.col("init_Ye").is_between(yerange[0], yerange[1]))
 
     dfrates = dfestim.select(
         timestep=pl.col("timestep") - 1,
@@ -137,16 +216,19 @@ def get_deposition_rates(
     modelpath: Path | str,
     timesteps: Sequence[int] | None = None,
     channels: Sequence[str] | None = None,
+    yerange: tuple[float, float] | None = None,
     verbose: bool = False,
 ) -> pl.DataFrame:
     """Read the estimators of a model, and return the deposition rate of each timestep.
 
-    A value of None for timesteps reads every timestep of the model.
+    A value of None for timesteps reads every timestep of the model. A value of None for yerange
+    keeps every cell. Call check_ye_range in front of this function, which gives a message for a
+    range that selects no cell.
     """
     readtimesteps = None if timesteps is None else tuple({*timesteps} | {timestep + 1 for timestep in timesteps})
     dfestim = scan_estimators(modelpath, timestep=readtimesteps, join_modeldata=True, verbose=verbose)
 
-    return aggregate_deposition_rates(dfestim, timesteps, channels)
+    return aggregate_deposition_rates(dfestim, timesteps, channels, yerange)
 
 
 def get_selected_timesteps(modelpath: Path | str, timedays: str | None, timestep: str | None) -> list[int] | None:
@@ -183,10 +265,26 @@ def format_channel_list(modelpath: Path | str, verbose: bool = False) -> str:
     return f"{get_model_name(modelpath)} holds {', '.join(channels) if channels else 'no deposition channel'}"
 
 
-def format_deposition_table(modelpath: Path | str, dftable: pl.DataFrame, channels: Sequence[str] | None) -> str:
-    """Return the deposition rates of one model as a table of one row for each timestep."""
+def format_deposition_table(
+    modelpath: Path | str,
+    dftable: pl.DataFrame,
+    channels: Sequence[str] | None,
+    yerange: tuple[float, float] | None = None,
+    yecells: tuple[int, int] | None = None,
+) -> str:
+    """Return the deposition rates of one model as a table of one row for each timestep.
+
+    The counts that check_ye_range gives go in the title. Thus the file that -o writes says how many
+    cells the Ye range selected, and --quiet takes no part of that away.
+    """
+    channeltext = ", ".join(channels) if channels else "every channel"
+    yetext = (
+        f" in {yecells[0]} of {yecells[1]} cells with matter, with a Ye of {yerange[0]:g} to {yerange[1]:g}"
+        if yerange is not None and yecells is not None
+        else ""
+    )
     lines = [
-        f"{get_model_name(modelpath)}: deposition of {', '.join(channels) if channels else 'every channel'}",
+        f"{get_model_name(modelpath)}: deposition of {channeltext}{yetext}",
         f"{'timestep':>8s} {'t_days':>10s} {'dep_per_volume':>15s} {'dep_per_ion':>15s} {'dep_per_mass':>15s}",
         f"{'':>8s} {'[d]':>10s} {'[eV/s/cm^3]':>15s} {'[eV/s]':>15s} {'[eV/s/g]':>15s}",
     ]
@@ -203,17 +301,30 @@ def format_deposition_table(modelpath: Path | str, dftable: pl.DataFrame, channe
 def warn_about_gaps(
     modelpath: Path | str, dftable: pl.DataFrame, timesteps: Sequence[int] | None, lasttimestep: int
 ) -> None:
-    """Print a warning for each timestep that got no row, and for the cells that gave no rate."""
+    """Print a warning for each timestep that got no row, and for the cells that gave no rate.
+
+    A run always gives no rate for its last timestep, thus a selection of every timestep asks for the
+    timesteps in front of that one alone. A complete run then gives no warning, and a run that
+    stopped early still gives one.
+    """
     modelname = get_model_name(modelpath)
     gotrows = set(dftable["timestep"].to_list())
-    # a run gives no rate for its last timestep, thus the default selection loses that one row
-    wanted = set(timesteps) if timesteps is not None else {lasttimestep}
+    wanted = set(timesteps) if timesteps is not None else set(range(lasttimestep))
     if missing := sorted(wanted - gotrows):
-        print_warning(
-            f"{modelname}: no deposition rate for timestep {', '.join(str(timestep) for timestep in missing)}. "
-            "The rate of a timestep arrives in the file of the next timestep, "
-            "thus the last timestep of a run gives none"
+        # a long list of timesteps hides the message, thus many of them give the count and the ends
+        missingtext = (
+            f"timestep {', '.join(str(timestep) for timestep in missing)}"
+            if len(missing) <= 6
+            else f"{len(missing)} timesteps, from {missing[0]} to {missing[-1]}"
         )
+        # that rule explains the last timestep alone, thus a gap of a different cause gets no reason
+        reason = (
+            " The rate of a timestep arrives in the file of the next timestep, "
+            "thus the last timestep of a run gives none."
+            if lasttimestep in missing
+            else ""
+        )
+        print_warning(f"{modelname}: no deposition rate for {missingtext}.{reason}")
 
     if cellswithnorate := int(dftable["cellswithnorate"].sum()):
         print_warning(f"{modelname}: {cellswithnorate} cells gave no deposition rate, thus a row can hold a NaN")
@@ -236,7 +347,17 @@ def addargs(parser: argparse.ArgumentParser) -> None:
             "Default: every channel of the model. Give --listchannels to show the channels"
         ),
     )
-    parser.add_argument(
+    # --listchannels stops before it reads a cell, thus a Ye range with it selects nothing
+    listgroup = parser.add_mutually_exclusive_group()
+    listgroup.add_argument(
+        "-ye",
+        help=(
+            "Select the cells whose Ye (electrons per nucleon) of the model file is in a range, "
+            "e.g. 0-0.2. Both ends of the range count. Default: every cell. "
+            "The model file must hold a Ye column"
+        ),
+    )
+    listgroup.add_argument(
         "--listchannels", action="store_true", help="Show the deposition channels of the model. The command then stops"
     )
     addarg_output(parser, kind="file", helptext="Path/filename for the output text file")
@@ -248,15 +369,24 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     args = parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
 
     channels = str(args.channels).split(",") if args.channels else None
+    yerange = parse_ye_range(str(args.ye)) if args.ye is not None else None
+    modelpaths = normalize_path_list(args.modelpath)
+
+    # each model gets its check in front of the first slow read, thus a bad path wastes no work
+    yecellcounts = [
+        check_ye_range(modelpath, yerange, verbose=args.verbose) if yerange is not None else None
+        for modelpath in modelpaths
+    ]
+
     tables: list[str] = []
-    for modelpath in normalize_path_list(args.modelpath):
+    for modelpath, yecells in zip(modelpaths, yecellcounts, strict=True):
         if args.listchannels:
             tables.append(format_channel_list(modelpath, verbose=args.verbose))
         else:
             timesteps = get_selected_timesteps(modelpath, args.timedays, args.timestep)
-            dftable = get_deposition_rates(modelpath, timesteps, channels, verbose=args.verbose)
+            dftable = get_deposition_rates(modelpath, timesteps, channels, yerange, verbose=args.verbose)
             warn_about_gaps(modelpath, dftable, timesteps, len(get_timestep_times(modelpath, loc="mid")) - 1)
-            tables.append(format_deposition_table(modelpath, dftable, channels))
+            tables.append(format_deposition_table(modelpath, dftable, channels, yerange, yecells))
 
         print_product(args, tables[-1])
 

--- a/artistools/estimators/deposition.py
+++ b/artistools/estimators/deposition.py
@@ -90,12 +90,12 @@ def check_ye_range(modelpath: Path | str, yerange: tuple[float, float], verbose:
     Thus the count covers the cells that hold matter, and a range of a low Ye gets the number of
     cells that the table sums.
 
-    The check reads the model alone, and it gives the arguments that the reader of the estimators
-    gives. Thus a range that selects no cell stops the command before the much slower read of the
-    estimator files, and the two calls see the same cells.
+    The read asks for the density and for no other derived column, and it reads no abundance. Thus a
+    range that selects no cell stops the command before the much slower read of the estimator files,
+    and the check itself costs little on a model of many cells.
     """
     modelname = get_model_name(modelpath)
-    dfmodel, _ = get_modeldata(modelpath, derived_cols=["ALL"], get_elemabundances=True, printwarningsonly=not verbose)
+    dfmodel, _ = get_modeldata(modelpath, derived_cols=["rho"], printwarningsonly=not verbose)
     if "Ye" not in dfmodel.collect_schema().names():
         msg = f"{modelname} gives no Ye of a cell. The model file must hold a Ye column"
         raise ValueError(msg)

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -2,6 +2,7 @@ import os
 import re
 import shutil
 import typing as t
+from collections.abc import Sequence
 from pathlib import Path
 from unittest import mock
 
@@ -9,6 +10,7 @@ import matplotlib.axes as mplax
 import numpy as np
 import numpy.typing as npt
 import polars as pl
+import polars.testing as pltest
 import pytest
 
 import artistools as at
@@ -1596,20 +1598,59 @@ def test_estimator_snapshot_classic_3d_cone(mockplot: mock.MagicMock) -> None:
 DEPOSITIONLINE = "deposition: gamma 2.0e-10 positron 1.0e-10 electron 5.0e-11 alpha 2.5e-11"
 
 
-def make_model_with_deposition(tmp_path: Path) -> Path:
+def make_model_with_deposition(tmp_path: Path, cellye: Sequence[float] | None = None) -> Path:
     """Return a copy of the test model whose estimators give the deposition rate of each channel.
 
     The copy holds the four small input files that the reader needs, thus it costs no time and no
     space. The atomic data of the test model stays where it is.
+
+    The model of the repository holds one cell and no Ye column. Thus cellye gives one Ye to each
+    cell, and it makes one copy of that cell for each value that it holds. A test of a selection of
+    the cells then has a model that the selection can divide.
     """
     modeldir = tmp_path / "modelwithdeposition"
     modeldir.mkdir()
     for name in ("model.txt", "abundances.txt", "input.txt", "compositiondata.txt"):
         shutil.copy(modelpath / name, modeldir / name)
 
-    lines = (modelpath / "estimators_0000.out").read_text(encoding="utf-8").splitlines()
-    withdeposition = [f"{line}\n{DEPOSITIONLINE}" if line.startswith("timestep ") else line for line in lines]
-    (modeldir / "estimators_0000.out").write_text("\n".join(withdeposition) + "\n", encoding="utf-8")
+    ncells = 1 if cellye is None else len(cellye)
+    if cellye is not None:
+        dfmodel, modelmeta = at.inputmodel.get_modeldata(modelpath, printwarningsonly=True)
+        cellnumber = pl.int_range(1, ncells + 1, dtype=pl.Int32)
+        dfcells = pl.concat([dfmodel.collect()] * ncells).with_columns(
+            inputcellid=cellnumber,
+            # each shell must end above the one in front of it, thus the outer speed grows with the id
+            vel_r_max_kmps=pl.col("vel_r_max_kmps") * cellnumber,
+            # each cell holds a density of its own, thus a selection of the cells changes the mass
+            logrho=pl.col("logrho") - (cellnumber - 1),
+            Ye=pl.Series(cellye),
+        )
+        modelmeta["npts_model"] = ncells
+        (modeldir / "model.txt").unlink()
+        at.inputmodel.save_modeldata(dfcells, outpath=modeldir, modelmeta=modelmeta)
+
+        abundfields = (modelpath / "abundances.txt").read_text(encoding="utf-8").split()
+        (modeldir / "abundances.txt").write_text(
+            "".join(" ".join([str(mgi + 1), *abundfields[1:]]) + "\n" for mgi in range(ncells)), encoding="utf-8"
+        )
+
+    # ARTIS writes one block for each cell of a timestep, thus each copy of the cell needs its block
+    blocks: list[list[str]] = []
+    for line in (modelpath / "estimators_0000.out").read_text(encoding="utf-8").splitlines():
+        if line.startswith("timestep "):
+            blocks.append([line, DEPOSITIONLINE])
+        else:
+            blocks[-1].append(line)
+
+    (modeldir / "estimators_0000.out").write_text(
+        "".join(
+            line.replace("modelgridindex 0", f"modelgridindex {mgi}") + "\n"
+            for block in blocks
+            for mgi in range(ncells)
+            for line in block
+        ),
+        encoding="utf-8",
+    )
 
     return modeldir
 
@@ -1681,6 +1722,108 @@ def test_deposition_rates_from_the_estimator_files(tmp_path: Path) -> None:
     )
 
 
+def test_deposition_reads_a_ye_range() -> None:
+    """-ye takes a range such as 0-0.2. A single number is no range, thus it gives an error."""
+    assert at.estimators.deposition.parse_ye_range("0-0.2") == pytest.approx((0.0, 0.2))
+
+    # a hyphen inside an exponent does not split the range, and a reversed range gives the same range
+    assert at.estimators.deposition.parse_ye_range("0.35-1e-3") == pytest.approx((0.001, 0.35))
+
+    for text in ("0.2", "0-0.1-0.2", "low-high"):
+        with pytest.raises(ValueError, match="as a Ye range"):
+            at.estimators.deposition.parse_ye_range(text)
+
+    # a Ye is 0 to 1, thus a value outside that range, a nan, and an infinity each give an error
+    for text in ("0-2", "0--1", "0-nan", "0.5-nan", "0-inf"):
+        with pytest.raises(ValueError, match="names a Ye outside 0 to 1"):
+            at.estimators.deposition.parse_ye_range(text)
+
+
+def test_deposition_selects_the_cells_of_a_ye_range() -> None:
+    """A Ye range keeps the cells inside it. The rate, the ions, the volume, and the mass follow it."""
+    dfestim = pl.LazyFrame({
+        "timestep": [0, 0, 1, 1],
+        "modelgridindex": [0, 1, 0, 1],
+        "tmid_days": [10.0, 10.0, 11.0, 11.0],
+        "init_Ye": [0.15, 0.35, 0.15, 0.35],
+        "nntot": [10.0, 20.0, 9.0, 19.0],
+        "volume": [2.0, 4.0, 2.2, 4.4],
+        "volume_prevtimestep": [None, None, 2.0, 4.0],
+        "mass_g": [3.0, 5.0, 3.0, 5.0],
+        "deposition_gamma": [0.0, 0.0, 1.0e-9, 2.0e-9],
+    })
+
+    dflowye = at.estimators.deposition.aggregate_deposition_rates(dfestim, yerange=(0.0, 0.2))
+    rate_erg_per_s = 1.0e-9 * 2.0
+    assert dflowye["timestep"].to_list() == [0]
+    assert np.isclose(dflowye["dep_per_volume"].item(), rate_erg_per_s / at.constants.EV_to_erg / 2.0, rtol=1e-12)
+    assert np.isclose(dflowye["dep_per_ion"].item(), rate_erg_per_s / at.constants.EV_to_erg / 20.0, rtol=1e-12)
+    assert np.isclose(dflowye["dep_per_mass"].item(), rate_erg_per_s / at.constants.EV_to_erg / 3.0, rtol=1e-12)
+
+    # a range that holds both cells gives the same rates as a selection of every cell
+    dfbothcells = at.estimators.deposition.aggregate_deposition_rates(dfestim, yerange=(0.0, 0.4))
+    pltest.assert_frame_equal(dfbothcells, at.estimators.deposition.aggregate_deposition_rates(dfestim))
+    assert np.isclose(
+        dfbothcells["dep_per_mass"].item(), (1.0e-9 * 2.0 + 2.0e-9 * 4.0) / at.constants.EV_to_erg / 8.0, rtol=1e-12
+    )
+
+    # a frame of a run that gives no Ye must give a message, and not the error of the query engine
+    with pytest.raises(ValueError, match="gives no Ye of a cell"):
+        at.estimators.deposition.aggregate_deposition_rates(dfestim.drop("init_Ye"), yerange=(0.0, 0.2))
+
+
+def test_deposition_ye_range_needs_a_model_with_ye(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A Ye range that no cell holds must stop the command, and the message must name the Ye of the model."""
+    with pytest.raises(ValueError, match="gives no Ye of a cell"):
+        at.estimators.deposition.check_ye_range(modelpath, (0.0, 0.2))
+
+    modeldir = make_model_with_deposition(tmp_path, cellye=[0.3])
+    outfile = tmp_path / "deposition.txt"
+    at.estimators.deposition.main(argsraw=[], modelpath=modeldir, timestep="54", ye="0.25-0.35", outputfile=outfile)
+
+    # the one cell of the model is inside the range, thus the table gives the rate of that cell
+    lines = outfile.read_text(encoding="utf-8").splitlines()
+    assert lines[0].endswith("in 1 of 1 cells with matter, with a Ye of 0.25 to 0.35")
+    assert float(lines[3].split()[3]) == pytest.approx(
+        at.estimators.deposition.get_deposition_rates(modeldir, [54])["dep_per_ion"].item(), rel=1e-3
+    )
+    assert "1 of 1 cells with matter (100.0%) have a Ye of 0.25 to 0.35" in capsys.readouterr().out
+
+    # the one cell of the model holds matter and a Ye of 0.3, thus a range below that gets no cell
+    with pytest.raises(
+        ValueError, match=re.escape("has no cell with matter and a Ye of 0 to 0.2. Its cells with matter have a Ye")
+    ):
+        at.estimators.deposition.main(argsraw=[], modelpath=modeldir, timestep="54", ye="0-0.2")
+
+
+def test_deposition_ye_range_drops_a_cell_of_a_model(tmp_path: Path) -> None:
+    """A Ye range must divide the cells of a model that the reader of the estimators gives.
+
+    The model holds two cells of a different Ye, thus a range that takes one of them must give a rate
+    that is different from the rate of both cells.
+    """
+    modeldir = make_model_with_deposition(tmp_path, cellye=[0.15, 0.35])
+
+    dfbothcells = at.estimators.deposition.get_deposition_rates(modeldir, [54])
+    dflowye = at.estimators.deposition.get_deposition_rates(modeldir, [54], yerange=(0.1, 0.2))
+
+    assert at.estimators.deposition.check_ye_range(modeldir, (0.1, 0.2)) == (1, 2)
+    assert at.estimators.deposition.check_ye_range(modeldir, (0.1, 0.4)) == (2, 2)
+
+    # the outer cell of a low density holds most of the volume and little of the mass. Thus the inner
+    # cell alone gives a rate per unit mass that is far below the rate of both cells.
+    assert dflowye["dep_per_mass"].item() < dfbothcells["dep_per_mass"].item() / 2.0
+
+    # each cell gives the same rate per unit volume and holds the same ions, thus those two do not move
+    for name in ("dep_per_volume", "dep_per_ion"):
+        assert np.isclose(dflowye[name].item(), dfbothcells[name].item(), rtol=1e-6)
+
+    # a range that holds every cell must give the rates of every cell
+    pltest.assert_frame_equal(
+        at.estimators.deposition.get_deposition_rates(modeldir, [54], yerange=(0.1, 0.4)), dfbothcells
+    )
+
+
 def test_deposition_needs_the_deposition_estimators() -> None:
     """A model that gives no rate of a cell must give an error and no number.
 
@@ -1745,8 +1888,12 @@ def test_deposition_writes_a_table(tmp_path: Path, capsys: pytest.CaptureFixture
         values[3], at.estimators.deposition.get_deposition_rates(modeldir, [54])["dep_per_ion"].item(), rtol=1e-3
     )
 
-    # the file of the next timestep holds the rate, thus the last timestep of the run gives none
+    # the file of the next timestep holds the rate, thus the timestep that -timestep last names gives none
     assert "no deposition rate for timestep 99" in capsys.readouterr().err
+
+    # a selection of every timestep always loses that one row, thus it must give no warning
+    at.estimators.deposition.main(argsraw=[], modelpath=modeldir)
+    assert "no deposition rate for" not in capsys.readouterr().err
 
 
 def test_deposition_lists_the_channels(tmp_path: Path) -> None:

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -37,6 +37,7 @@ from artistools.misc.cliutils import KeepGivenPaths as KeepGivenPaths
 from artistools.misc.cliutils import makelist as makelist
 from artistools.misc.cliutils import normalize_path_list as normalize_path_list
 from artistools.misc.cliutils import parse_cli_args as parse_cli_args
+from artistools.misc.cliutils import parse_float_range as parse_float_range
 from artistools.misc.cliutils import parse_range as parse_range
 from artistools.misc.cliutils import parse_range_list as parse_range_list
 from artistools.misc.cliutils import print_detail as print_detail

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -3,6 +3,7 @@
 import argparse
 import dataclasses as dc
 import itertools
+import re
 import sys
 import typing as t
 from collections.abc import Callable
@@ -925,14 +926,28 @@ def set_args_from_dict(parser: argparse.ArgumentParser, kwargs: dict[str, t.Any]
         raise ValueError(msg)
 
 
+def parse_float_range(text: str, description: str) -> tuple[float, float]:
+    """Return the two numbers of a range such as 2.2-2.8, in the order that the text gives them.
+
+    A hyphen also appears inside an exponent, e.g. 1e-2, and in front of a negative number. Thus only
+    a hyphen that comes after a digit or after a decimal point separates the two ends of the range.
+    The description names what the caller expects, and the message of an error gives that name.
+    """
+    try:
+        first, second = (float(part) for part in re.split(r"(?<=[0-9.])-", text.strip()))
+    except ValueError as exc:
+        msg = f"Cannot read {text!r} as {description}"
+        raise ValueError(msg) from exc
+
+    return first, second
+
+
 def parse_range(rng: str, dictvars: dict[str, int]) -> Iterable[int]:
     """Parse a string with an integer range and return a list of numbers, replacing special variables in dictvars.
 
     A hyphen also stands in front of a negative number, thus only a hyphen that follows a digit or a
     letter separates the two ends of the range. "-1" then names one number, which the caller refuses.
     """
-    import re
-
     strparts = re.split(r"(?<=[0-9a-zA-Z])-", rng.strip())
 
     if len(strparts) not in {1, 2}:

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -12,6 +12,7 @@ import numpy as np
 import polars as pl
 
 from artistools.constants import C_cm_per_s
+from artistools.misc.cliutils import parse_float_range
 from artistools.misc.cliutils import print_warning
 from artistools.misc.fileio import firstexisting
 from artistools.misc.fileio import firstexisting_or_none
@@ -180,25 +181,15 @@ def get_timestep_of_timedays(modelpath: Path | str, timedays: str | float) -> in
 def parse_timedays_range(timedays_range_str: str | float) -> tuple[float, float] | None:
     """Return the two ends of a time range like 2.2-2.8, or None when the text names a single time.
 
-    A hyphen also appears inside an exponent, e.g. 1e-2, and in front of a negative time. The text is
-    read as one number first, thus only a hyphen that separates two numbers splits the range.
+    This function reads the text as one number first, thus a hyphen in front of a negative time
+    splits no range.
     """
     text = str(timedays_range_str).strip()
     with contextlib.suppress(ValueError):
         float(text)
         return None
 
-    # a digit or a decimal point in front of the hyphen means it separates two numbers
-    parts = re.split(r"(?<=[0-9.])-", text)
-    if len(parts) != 2:
-        msg = f"Cannot read {text!r} as a time in days or as a range such as 2.2-2.8"
-        raise ValueError(msg)
-
-    try:
-        return float(parts[0]), float(parts[1])
-    except ValueError as exc:
-        msg = f"Cannot read {text!r} as a time in days or as a range such as 2.2-2.8"
-        raise ValueError(msg) from exc
+    return parse_float_range(text, "a time in days or as a range such as 2.2-2.8")
 
 
 def get_bad_timestep_message(modelpath: Path | str, timestep: int) -> str:


### PR DESCRIPTION
## What this does

`artistools deposition -ye 0-0.2` keeps the cells whose Ye is inside the range. Both ends of the range count. The rate, the ion count, the volume, and the mass of each row then cover those cells alone.

```
modelname: 41523 of 250047 cells with matter (16.6%) have a Ye of 0 to 0.2
modelname: deposition of every channel in 41523 of 250047 cells with matter, with a Ye of 0 to 0.2
timestep     t_days  dep_per_volume     dep_per_ion    dep_per_mass
                [d]     [eV/s/cm^3]          [eV/s]        [eV/s/g]
```

The command reads the model before it reads the estimator files. Thus a range that selects no cell stops the command in front of the slow read, and the message names the Ye of the cells that hold matter.

A cell with no matter gives no deposition rate, and artistools writes a Ye of 0 for such a cell. Thus the count covers the cells that hold matter. Without that rule, a low Ye range on a 3D model reports a large part of an empty grid and then gives a table of no rows.

The title of the table holds the count. Thus the file that `-o` writes says how many cells the range selected, and `--quiet` takes no part of that away.

## Two other changes

- `parse_float_range` in `artistools/misc/cliutils.py` reads a range of two numbers. `parse_timedays_range` and the new `parse_ye_range` both call it, thus one place holds the rule of the hyphen and the exponent.
- A run always gives no rate for its last timestep, thus a selection of every timestep asked for one row that no run gives, and each run gave a warning about it. That selection now asks for the timesteps in front of the last one. A complete run gives no warning, and a run that stopped early still gives one. The warning also gives the reason of the last timestep for that timestep alone.

## Errors

| Command | Message |
| --- | --- |
| `-ye 0-0.1` on a model whose cells with matter have a Ye of 0.3 | has no cell with matter and a Ye of 0 to 0.1. Its cells with matter have a Ye of 0.3 to 0.3 |
| `-ye 0-nan`, `-ye 0-2` | names a Ye outside 0 to 1 |
| `-ye 0.2` | Cannot read '0.2' as a Ye range, such as 0-0.2 |
| `-ye 0-0.2 --listchannels` | argument --listchannels: not allowed with argument -ye |

## Tests

Five new tests in `artistools/estimators/test_estimators.py` cover the parser, the filter, the two error paths, and the CLI. The helper `make_model_with_deposition` now takes a list of Ye values and builds one cell for each, with a velocity, a density, an abundance row, and an estimator block of its own. Thus a test can prove that a range takes one of two cells away, which the model of the repository could not show with its one cell.

## Checks

`ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`, `vulture`, and `pytest -n auto` (582 passed, 1 skipped). I did not run `cargo clippy`, because the change touches no Rust code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)