### PR TITLE
Correct the defects that the codebase review found

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,5 @@
 ---
 name: Benchmark with CodSpeed
-permissions:
-    contents: read
 on:
     push:
         branches:
@@ -25,6 +23,9 @@ jobs:
             != 'dependabot[bot]')
         timeout-minutes: 180
         runs-on: ubuntu-24.04
+        permissions:
+            contents: read # required for actions/checkout
+            id-token: write # required for OIDC authentication with CodSpeed
         env:
             PYO3_USE_ABI3_FORWARD_COMPATIBILITY: 1
             UV_FROZEN: 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,5 +68,4 @@ jobs:
               uses: CodSpeedHQ/action@373d6868929f444bc08d901fd0eb0ad52a8875ea # v5.2.1
               with:
                   mode: simulation
-                  token: ${{ secrets.CODSPEED_TOKEN }}
                   run: pytest --codspeed

--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -821,7 +821,8 @@ def read_linestatfile(
 
     print(f"Reading {filepath}")
 
-    data = np.loadtxt(zopen(filepath))
+    with zopen(filepath) as linestatfile:
+        data = np.loadtxt(linestatfile)
     lambda_angstroms = data[0] * 1e8
     nlines = len(lambda_angstroms)
 

--- a/artistools/estimators/deposition.py
+++ b/artistools/estimators/deposition.py
@@ -63,8 +63,8 @@ def get_deposition_expression(colnames: Sequence[str], channels: Sequence[str] |
         msg = f"This model gives no deposition rate of {' and '.join(unknown)}. It holds {', '.join(available)}"
         raise ValueError(msg)
 
-    # ignore_nulls=False keeps a null, thus a channel that one rank left out gives no partial total
-    return pl.sum_horizontal((pl.col(f"{DEPOSITIONPREFIX}{channel}") for channel in channels), ignore_nulls=False)
+    # a cell that reports no channel deposited nothing in it, thus the sum reads a null as zero
+    return pl.sum_horizontal(pl.col(f"{DEPOSITIONPREFIX}{channel}") for channel in channels)
 
 
 def parse_ye_range(text: str) -> tuple[float, float]:
@@ -189,7 +189,7 @@ def aggregate_deposition_rates(
             ioncount=pl.col("ioncount").sum(),
             volume=pl.col("volume").sum(),
             mass_g=pl.col("mass_g").sum(),
-            # the sum leaves a null out, thus the count of the cells that gave no rate goes beside it
+            # a NaN rate makes the sum a NaN, thus the count of the cells with a NaN rate goes beside it
             cellswithnorate=pl.col("dep_erg_per_s").is_finite().fill_null(value=False).not_().sum(),
         )
         .with_columns(
@@ -327,7 +327,7 @@ def warn_about_gaps(
         print_warning(f"{modelname}: no deposition rate for {missingtext}.{reason}")
 
     if cellswithnorate := int(dftable["cellswithnorate"].sum()):
-        print_warning(f"{modelname}: {cellswithnorate} cells gave no deposition rate, thus a row can hold a NaN")
+        print_warning(f"{modelname}: {cellswithnorate} cells gave no finite deposition rate, thus a row holds a NaN")
 
 
 def addargs(parser: argparse.ArgumentParser) -> None:

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -586,12 +586,13 @@ def add_derived_estimator_columns(pldflazy: pl.LazyFrame) -> pl.LazyFrame:
         # for older files with no deposition data, take heating part of deposition and heating fraction
         pldflazy = pldflazy.with_columns(total_dep=pl.col("heating_dep") / pl.col("heating_heating_dep/total_dep"))
 
-    # only fill the number density columns: ARTIS omits zero-abundance ions and isotopes from the estimator files,
-    # so a missing number density means zero. The file reader already fills these with zero for cells that skip them
-    # within one file, and this makes the columns that a whole rank omitted agree. Every other column (Te, TR, nne,
-    # ...) must keep its nulls so that missing data isn't silently read as a real zero
+    # ARTIS omits a zero-abundance ion and an absent channel of a process from the estimator files, thus a null
+    # in these columns means zero. This fill makes a column that a whole rank omitted agree with the file reader.
+    # The heating ratios stay out, because a ratio of zero makes gamma_dep and total_dep a division by zero.
+    # Every other column (Te, TR, nne, ...) keeps its nulls, because a null there is missing data and not a zero
     # a selector that matches nothing makes this a no-op, so no guard is needed here
-    pldflazy = pldflazy.with_columns(cs.starts_with("nnelement_", "nnion_", "nniso_").fill_null(0))
+    zerowhenabsent = cs.starts_with("nnelement_", "nnion_", "nniso_", "deposition_", "heating_", "cooling_")
+    pldflazy = pldflazy.with_columns((zerowhenabsent - cs.contains("/")).fill_null(0))
 
     # a back-end that read a real total number density from file keeps it. Deriving nntot there would
     # replace it with a sum over only the elements that the back-end happened to supply.
@@ -775,19 +776,22 @@ def read_estimators(
 
 
 def get_averageexcitation(
-    modelpath: Path | str, atomic_number: int, ion_stage: int, dftexc: pl.LazyFrame
+    modelpath: Path | str,
+    atomic_number: int,
+    ion_stage: int,
+    dftexc: pl.LazyFrame,
+    dfnltepops: pl.DataFrame | None = None,
 ) -> pl.LazyFrame:
     """Return the population-weighted mean level excitation energy [eV] of an ion per timestep and cell.
 
     dftexc gives the excitation temperature (columns timestep, modelgridindex, T_exc) used to spread
-    the superlevel population over the levels it stands in for.
+    the superlevel population over the levels that it replaces. dfnltepops holds the NLTE populations
+    of every ion, which a caller that asks for several ions reads one time.
     """
-    dfpops = (
-        at.nltepops
-        .read_files(modelpath)
-        .lazy()
-        .filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))
-    )
+    if dfnltepops is None:
+        dfnltepops = at.nltepops.read_files(modelpath)
+
+    dfpops = dfnltepops.lazy().filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))
 
     adata = at.atomic.get_levels(modelpath)
     dfionlevels = adata.filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))["levels"].item()

--- a/artistools/estimators/exportmassfractions.py
+++ b/artistools/estimators/exportmassfractions.py
@@ -16,7 +16,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     at.addarg_modelpath(parser, default=Path())
     at.addarg_timestep(parser, default=14, helptext="Timestep number to export")
-    at.addarg_modelgridindex(parser, default="0-9", helptext="Range of cell numbers to export")
+    at.addarg_modelgridindex(parser, default="0", helptext="Range of cell numbers to export")
     at.addarg_output(
         parser, kind="file", defaultname=DEFAULTOUTPUTNAME, helptext="Path to output file of mass fractions"
     )

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -181,6 +181,8 @@ def get_line_points(dfseries: pl.LazyFrame, args: argparse.Namespace) -> pl.Lazy
     """Return the average line of a series in each x bin, with the minimum and the maximum of the bin."""
     dflinepoints = (
         dfseries
+        # a null value is a cell that reported none, thus its weight must not pull the average to zero
+        .filter(pl.col("yvalue").is_not_null())
         .group_by("xvalue_binned")
         .agg(
             yvalue_binned=(pl.col("yvalue") * pl.col("celltsweight")).sum() / pl.col("celltsweight").sum(),
@@ -395,6 +397,9 @@ def plot_average_excitation(
     # the superlevel population is spread over the levels it stands in for at the electron temperature
     dftexc = estimators.select("timestep", "modelgridindex", T_exc=pl.col("Te"))
 
+    # read_files has no cache, thus one read of the NLTE output of every rank serves every ion
+    dfnltepops_allions = at.nltepops.read_files(modelpath)
+
     plans = []
     for paramvalue in params:
         print(f"  plotting averageexcitation {paramvalue}")
@@ -404,7 +409,9 @@ def plot_average_excitation(
             raise TypeError(msg)
         atomic_number, ion_stage = iontuple
 
-        dfavgexc = at.estimators.get_averageexcitation(modelpath, atomic_number, ion_stage, dftexc)
+        dfavgexc = at.estimators.get_averageexcitation(
+            modelpath, atomic_number, ion_stage, dftexc, dfnltepops=dfnltepops_allions
+        )
 
         # weight the average by the ion population where it is available, as plot_average_ionisation
         # weights by the element population
@@ -457,7 +464,7 @@ def plot_levelpop(
 
     arr_tdelta = at.get_timestep_times(modelpath, loc="delta")
 
-    # read_files is uncached, so read every rank's nlte output once rather than once per param
+    # read_files has no cache, thus one read of the NLTE output of every rank serves every param
     dfnltepops_allions = at.nltepops.read_files(modelpath)
 
     plans = []
@@ -1572,6 +1579,9 @@ def write_snapshot_figures(
         args.format = "png"
 
     frames = [[timestep] for timestep in timesteps_included] if args.multiplot else [timesteps_included]
+    if len(frames) > 1:
+        # each frame collects the estimators several times, thus many frames read the parquet files one time
+        estimators = estimators.collect().lazy()
 
     # a gif or a merged pdf holds every frame, thus one product comes out of many figures
     firstts, lastts = timesteps_included[0], timesteps_included[-1]

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -8,6 +8,7 @@ import argparse
 import contextlib
 import math
 import string
+import tempfile
 import typing as t
 from collections.abc import Callable
 from collections.abc import Collection
@@ -1579,35 +1580,40 @@ def write_snapshot_figures(
         args.format = "png"
 
     frames = [[timestep] for timestep in timesteps_included] if args.multiplot else [timesteps_included]
-    if len(frames) > 1:
-        # each frame collects the estimators several times, thus many frames read the parquet files one time
-        estimators = estimators.collect().lazy()
 
-    # a gif or a merged pdf holds every frame, thus one product comes out of many figures
-    firstts, lastts = timesteps_included[0], timesteps_included[-1]
-    frameset = at.resolve_frameset_paths(
-        args.outputfile,
-        framecount=len(frames),
-        framename=SNAPSHOTFRAMENAME,
-        productname=f"plotestimators_evolution_ts{firstts:03d}-ts{lastts:03d}.gif" if args.makegif else None,
-        combines=len(frames) > 1 and (args.makegif or args.format == "pdf"),
-        gifduration=1000.0 if args.makegif else None,
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        if len(frames) > 1:
+            # each frame collects a few columns of the estimators several times. A streamed copy of the selected
+            # timesteps reads the source files one time, and a scan of it keeps the column selection of each frame
+            estimatorsfile = Path(tmpdir, "estimators.parquet")
+            estimators.sink_parquet(estimatorsfile)
+            estimators = pl.scan_parquet(estimatorsfile)
 
-    outputfiles = [
-        make_figure(
-            frameset=frameset,
-            modelpath=modelpath,
-            timestepslist=frame,
-            estimators=estimators,
-            xvariable=args.x,
-            plotlist=plotlist,
-            args=args,
+        # a gif or a merged pdf holds every frame, thus one product comes out of many figures
+        firstts, lastts = timesteps_included[0], timesteps_included[-1]
+        frameset = at.resolve_frameset_paths(
+            args.outputfile,
+            framecount=len(frames),
+            framename=SNAPSHOTFRAMENAME,
+            productname=f"plotestimators_evolution_ts{firstts:03d}-ts{lastts:03d}.gif" if args.makegif else None,
+            combines=len(frames) > 1 and (args.makegif or args.format == "pdf"),
+            gifduration=1000.0 if args.makegif else None,
         )
-        for frame in frames
-    ]
 
-    frameset.finish(outputfiles, args)
+        outputfiles = [
+            make_figure(
+                frameset=frameset,
+                modelpath=modelpath,
+                timestepslist=frame,
+                estimators=estimators,
+                xvariable=args.x,
+                plotlist=plotlist,
+                args=args,
+            )
+            for frame in frames
+        ]
+
+        frameset.finish(outputfiles, args)
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -1920,3 +1920,26 @@ def test_line_points_leave_a_cell_with_no_value_out_of_the_average() -> None:
     dflinepoints = get_line_points(dfseries, argparse.Namespace()).collect()
 
     assert np.isclose(dflinepoints["yvalue_binned"].item(), 10.0)
+
+
+def test_add_derived_estimator_columns_fills_absent_channels_with_zero() -> None:
+    """A deposition, heating, or cooling channel that a rank omitted is zero, and a heating ratio keeps its null."""
+    pldf = pl.LazyFrame({
+        "timestep": [0, 1],
+        "modelgridindex": [0, 1],
+        "deposition_gamma": [1.0, None],
+        "heating_gamma": [1.0, 2.0],
+        "heating_dep": [None, 2.0],
+        "cooling_ff": [None, 1.0],
+        "heating_gamma/gamma_dep": [0.5, None],
+        "Te": [5000.0, None],
+    })
+
+    dfout = at.estimators.add_derived_estimator_columns(pldf).collect()
+
+    assert dfout["deposition_gamma"].to_list() == [1.0, 0.0]
+    assert dfout["heating_dep"].to_list() == [0.0, 2.0]
+    assert dfout["cooling_ff"].to_list() == [0.0, 1.0]
+    # a ratio of zero makes gamma_dep a division by zero, thus a ratio keeps its null
+    assert dfout["heating_gamma/gamma_dep"].to_list() == [0.5, None]
+    assert dfout["Te"].to_list() == [5000.0, None]

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -1659,7 +1659,8 @@ def test_deposition_rates_read_the_next_timestep() -> None:
     """The rate of timestep n comes from the rows of n + 1, weighted by the volume of n.
 
     Every column of one row must cover one set of cells: a cell with no matter enters neither the
-    rate nor the volume, the ion count, or the mass. A cell that gives no rate is counted.
+    rate nor the volume, the ion count, or the mass. A cell with no value for a channel received no
+    energy in that channel. Its other channels enter the rate, and its volume stays in the denominators.
     """
     dfestim = pl.LazyFrame({
         "timestep": [0, 0, 0, 0, 1, 1, 1, 1],
@@ -1675,15 +1676,14 @@ def test_deposition_rates_read_the_next_timestep() -> None:
 
     dftable = at.estimators.deposition.aggregate_deposition_rates(dfestim)
 
-    # cell 2 holds no matter and cell 3 gives no rate, thus the rate covers cells 0 and 1 alone
-    rate_erg_per_s = 1.1e-9 * 2.0 + 2.0e-9 * 4.0
+    # cell 2 holds no matter, and cell 3 has no gamma value, thus only its alpha channel enters the rate
+    rate_erg_per_s = 1.1e-9 * 2.0 + 2.0e-9 * 4.0 + 1.0e-9 * 1.0
     assert dftable["timestep"].to_list() == [0]
     assert np.isclose(dftable["tmid_days"].item(), 10.0)
-    # cell 3 still holds matter, thus its volume, its ions, and its mass stay in the denominators
     assert np.isclose(dftable["dep_per_volume"].item(), rate_erg_per_s / at.constants.EV_to_erg / 7.0, rtol=1e-12)
     assert np.isclose(dftable["dep_per_ion"].item(), rate_erg_per_s / at.constants.EV_to_erg / 105.0, rtol=1e-12)
     assert np.isclose(dftable["dep_per_mass"].item(), rate_erg_per_s / at.constants.EV_to_erg / 10.0, rtol=1e-12)
-    assert dftable["cellswithnorate"].item() == 1
+    assert dftable["cellswithnorate"].item() == 0
 
     # one channel gives its own rate, and the ion count and the mass do not change
     dfgamma = at.estimators.deposition.aggregate_deposition_rates(dfestim, channels=["gamma"])
@@ -1903,3 +1903,20 @@ def test_deposition_lists_the_channels(tmp_path: Path) -> None:
     at.estimators.deposition.main(argsraw=[], modelpath=modeldir, listchannels=True, outputfile=outfile)
 
     assert outfile.read_text(encoding="utf-8").strip().endswith("holds alpha, electron, gamma, positron")
+
+
+def test_line_points_leave_a_cell_with_no_value_out_of_the_average() -> None:
+    """A null value shows that the cell reported no value, thus its weight must not decrease the average."""
+    import argparse
+
+    from artistools.estimators.plotestimators import get_line_points
+
+    dfseries = pl.LazyFrame({
+        "xvalue_binned": [1.0, 1.0, 1.0],
+        "yvalue": [10.0, None, 10.0],
+        "celltsweight": [1.0, 8.0, 1.0],
+    })
+
+    dflinepoints = get_line_points(dfseries, argparse.Namespace()).collect()
+
+    assert np.isclose(dflinepoints["yvalue_binned"].item(), 10.0)

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -142,7 +142,10 @@ def get_nuc_data(nuc_dataset: str) -> pl.DataFrame:
             if dfnuc.height > 0:
                 dfnuc = dfnuc.filter(pl.col("p_energy") == 0)
                 if dfnuc.is_empty():
-                    print(f"No beta decay found for Z={atomic_number} A={A}")
+                    # a nuclide with no row must stay in the table, because the inner join in
+                    # process_trajectory gives no decay power to a nuclide that the table does not hold
+                    print(f"ENSDF gives no ground-state beta decay for Z={atomic_number} A={A}")
+                    rows.append(hrow | {"source": "Hotokezaka"})
                     continue
                 # a missing value poisons the derived quantities to NaN (visible in the written file)
                 # instead of crashing on None or being silently skipped by the sums

--- a/artistools/inputmodel/describeinputmodel.py
+++ b/artistools/inputmodel/describeinputmodel.py
@@ -105,7 +105,7 @@ def describe_model(modelpath: Path | str, args: argparse.Namespace) -> None:
             print(f"Selected single cell mgi {mgi}:")
             dfmodel = dfmodel.filter(pl.col("inputcellid") == (mgi + 1))
 
-            print(dfmodel)
+            print(dfmodel.collect())
 
     try:
         assoc_cells, mgi_of_propcells, direct_model_propgrid_map = at.get_grid_mapping(modelpath)

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -182,6 +182,7 @@ def read_modelfile_text(
 
         dfmodel = dfmodel.head(npts_model).with_columns(pl.exclude("inputcellid").cast(pl.Float32)).lazy()
 
+    # an old model.txt names the electron fraction cellYe, and Ye is the name everywhere after this point
     dfmodel = dfmodel.sort("inputcellid").rename({"velocity_outer": "vel_r_max_kmps", "cellYe": "Ye"}, strict=False)
 
     if modelmeta["dimensions"] == 1:
@@ -506,9 +507,6 @@ def get_modeldata(
         dfmodel = dfmodel.join(abundancedata, how="inner", on="inputcellid", maintain_order="left")
 
     dfmodel = dfmodel.with_columns(pl.col("inputcellid").sub(1).alias("modelgridindex"))
-
-    if "cellYe" in dfmodel.collect_schema().names() and "Ye" not in dfmodel.collect_schema().names():
-        dfmodel = dfmodel.rename({"cellYe": "Ye"}, strict=False)
 
     if derived_cols:
         dfmodel = add_derived_cols_to_modeldata(
@@ -1230,7 +1228,7 @@ def dimension_reduce_model(
             pl
             .when(pl.col("mass_g").sum() > 0)
             .then(
-                (cs.starts_with("X_") | cs.by_name(["Ye", "cellYe"], require_all=False)).dot(pl.col("mass_g"))
+                (cs.starts_with("X_") | cs.by_name("Ye", require_all=False)).dot(pl.col("mass_g"))
                 / pl.col("mass_g").sum()
             )
             .otherwise(0.0),
@@ -1244,10 +1242,7 @@ def dimension_reduce_model(
             pl.col("mass_g").implode().alias("mass_g_list"),
             (
                 ~(
-                    cs.by_name(
-                        ["mass_g", "inputcellid", "modelgridindex", "Ye", "cellYe", "q", "tracercount"],
-                        require_all=False,
-                    )
+                    cs.by_name(["mass_g", "inputcellid", "modelgridindex", "Ye", "q", "tracercount"], require_all=False)
                     | cs.starts_with("X_")
                     | cs.starts_with("pos_")
                     | cs.starts_with("vel_")
@@ -1268,8 +1263,7 @@ def dimension_reduce_model(
             out_n_z=((pl.col("inputcellid") - 1) // ncoordgridr).cast(pl.Int32),
         )
         .with_columns(
-            cs.starts_with("X_").fill_null(0.0),
-            cs.by_name("Ye", "cellYe", "q", "tracercount", require_all=False).fill_null(0.0),
+            cs.starts_with("X_").fill_null(0.0), cs.by_name("Ye", "q", "tracercount", require_all=False).fill_null(0.0)
         )
         .sort("inputcellid")
     )

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -31,9 +31,9 @@ from artistools.misc import print_warning
 from artistools.misc import read_parquet_cache_metadata
 from artistools.misc import read_wsv
 from artistools.misc import resolve_outputfile
-from artistools.misc import stripallsuffixes
 from artistools.misc import write_parquet_atomic
 from artistools.misc import zopen
+from artistools.misc.fileio import COMPRESSED_EXTENSIONS
 
 
 def read_modelfile_text(
@@ -391,7 +391,13 @@ def get_text_source_cached(
     that it cannot read, e.g. a malformed json string, and the cache is then stale.
     """
     textsource_mtime = textfilepath.stat().st_mtime
-    parquetfilepath = stripallsuffixes(textfilepath).with_suffix(".txt.parquet.tmp")
+    # model_a.1.txt and model_a.2.txt must not share a cache, thus remove only a compression suffix
+    textname = (
+        textfilepath.name.removesuffix(textfilepath.suffix)
+        if textfilepath.suffix in COMPRESSED_EXTENSIONS
+        else textfilepath.name
+    )
+    parquetfilepath = textfilepath.with_name(f"{textname}.parquet.tmp")
     # the identity of the cache that a rewrite replaces, from the same moment as the existence check
     outdatedparquet = get_file_identity(parquetfilepath)
     hadcachefile = outdatedparquet is not None

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -72,8 +72,8 @@ def maptogrid(
 ) -> None:
     """Map an SPH ejecta snapshot onto an ncoordgrid^3 Cartesian grid and write grid.dat and gridcontributions.txt."""
     if not ejectasnapshotpath.is_file():
-        print(f"{ejectasnapshotpath} not found")
-        raise FileNotFoundError
+        msg = f"{ejectasnapshotpath} does not exist"
+        raise FileNotFoundError(msg)
 
     outputfolderpath = Path(outputfolderpath)
     if not outputfolderpath.exists():

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -356,7 +356,7 @@ def maptogrid(
         fgrid.write(f"{ncoordgrid**3} # ncoordgrid\n")
         fgrid.write(f"{dtextra} # extra time after explosion simulation ended (in geom units)\n")
         fgrid.write(f"{x0} # xmax\n")
-        fgrid.write(" gridindex    pos_x_min    pos_y_min    pos_z_min    rho    cellYe    tracercount\n")
+        fgrid.write(" gridindex    pos_x_min    pos_y_min    pos_z_min    rho    Ye    tracercount\n")
         # the cell order varies x fastest, which is the Fortran order of the [i, j, k] arrays
         ncells = ncoordgrid**3
         fgrid.writelines(

--- a/artistools/inputmodel/modelfromhydro.py
+++ b/artistools/inputmodel/modelfromhydro.py
@@ -147,13 +147,15 @@ def read_griddat_file(
             "posx": "pos_x_min",  # for compatibility with fortran maptogrid script
             "posy": "pos_y_min",
             "posz": "pos_z_min",
+            # an old grid.dat names the electron fraction cellYe, and Ye is the name everywhere after this point
+            "cellYe": "Ye",
         },
         strict=False,
     )
 
     griddata = griddata.with_columns(
         # griddata in geom units
-        cs.by_name("rho", "cellYe", "Q", require_all=False).fill_null(0.0)
+        cs.by_name("rho", "Ye", "Q", require_all=False).fill_null(0.0)
     ).with_columns(
         cs.starts_with("pos_") * factor_position * km_to_cm,
         pl.col("rho") * 6.176e17,  # convert to g/cm³
@@ -242,7 +244,7 @@ def add_mass_to_center(griddata: pl.DataFrame, t_model_in_days: float) -> pl.Dat
 
     griddata = griddata.with_columns(
         rho=pl.when(inhole).then(pl.col("rho") + density_hole).otherwise(pl.col("rho")),
-        cellYe=pl.when(inhole).then(pl.max_horizontal(pl.col("cellYe"), pl.lit(0.4))).otherwise(pl.col("cellYe")),
+        Ye=pl.when(inhole).then(pl.max_horizontal(pl.col("Ye"), pl.lit(0.4))).otherwise(pl.col("Ye")),
     )
 
     print(griddata.filter(inhole).select(showcols))
@@ -326,7 +328,7 @@ def makemodelfromgriddata(
             modelmeta=modelmeta,
         )
 
-    if "cellYe" in dfmodel:
+    if "Ye" in dfmodel:
         at.inputmodel.opacityinputfile.write_Ye_file(outputpath, dfmodel)
 
     if dfgridcontributions is not None:

--- a/artistools/inputmodel/opacityinputfile.py
+++ b/artistools/inputmodel/opacityinputfile.py
@@ -18,7 +18,7 @@ def opacity_by_Ye(outputfilepath: Path | str, griddata: pl.DataFrame) -> None:
     """Opacities from Table 1 Tanaka 2020."""
     print("Getting opacity kappa from Ye")
 
-    Ye = pl.col("cellYe")
+    Ye = pl.col("Ye")
     griddata = griddata.with_columns(
         opacity=pl
         .when((Ye == 0.0) & (pl.col("rho") == 0))
@@ -52,7 +52,7 @@ def write_Ye_file(outputfilepath: Path | str, griddata: pl.DataFrame) -> None:
     with Path(outputfilepath, "Ye.txt").open("w", encoding="utf-8") as fYe:
         fYe.write(f"{griddata.height}\n")
         # ARTIS needs a number in every field, thus write a missing and a NaN electron fraction as zero
-        griddata.select("inputcellid", pl.col("cellYe").cast(pl.Float64).fill_null(0.0).fill_nan(0.0)).write_csv(
+        griddata.select("inputcellid", pl.col("Ye").cast(pl.Float64).fill_null(0.0).fill_nan(0.0)).write_csv(
             fYe, separator="\t", include_header=False, float_precision=10
         )
 

--- a/artistools/inputmodel/plotdensity.py
+++ b/artistools/inputmodel/plotdensity.py
@@ -112,7 +112,9 @@ def get_coarse_velocity_bins(dfmodel: pl.DataFrame, nbins: int | None) -> list[f
 
     # a 2D or 3D model has a variable spacing in the radial velocity, thus the largest step sets the bin size
     xmin, xmax, xdeltamax = dfmodel.select(
-        pl.col("vel_r_mid").min(), pl.col("vel_r_mid").max(), pl.col("vel_r_mid").sort().diff().max()
+        pl.col("vel_r_mid").min().alias("xmin"),
+        pl.col("vel_r_mid").max().alias("xmax"),
+        pl.col("vel_r_mid").sort().diff().max().alias("xdeltamax"),
     ).row(0)
     ncoarsevelbins = int((xmax - xmin) / xdeltamax)
     print(f"Using {ncoarsevelbins} velocity bins from {xmin} to {xmax} with max delta {xdeltamax}")

--- a/artistools/inputmodel/plotinitialcomposition.py
+++ b/artistools/inputmodel/plotinitialcomposition.py
@@ -66,7 +66,7 @@ def plot_slice_modelcolumn(
 
     if args.logcolorscale:
         # logscale for colormap
-        if args.floorval:
+        if args.floorval is not None:
             colorscale = np.array([
                 args.floorval if x < args.floorval or not math.isfinite(x) else x for x in colorscale
             ])
@@ -94,14 +94,14 @@ def plot_slice_modelcolumn(
     vmax_ax2 = posmax_ax2 / t_model_s * unitfactor
     if colname == "rho":
         if args.logcolorscale:
-            vmin = args.floorval or -15
+            vmin = -15 if args.floorval is None else args.floorval
             vmax = -7
         else:
-            vmin = args.floorval or 1e-15
+            vmin = 1e-15 if args.floorval is None else args.floorval
             vmax = 1e-7
     elif colname == "Ye":
         assert not args.logcolorscale, "log colorscale not supported for Ye"
-        vmin = args.floorval or 0
+        vmin = 0 if args.floorval is None else args.floorval
         vmax = 0.6
     else:
         vmin = None
@@ -303,7 +303,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("-surfaces3d", type=float, nargs="+", help="Define positions of surfaces for 3D plots")
 
-    parser.add_argument("-floorval", default=False, type=float, help="Set a floor value for colorscale. Expects float")
+    parser.add_argument("-floorval", default=None, type=float, help="Set a floor value for colorscale. Expects float")
 
     parser.add_argument(
         "-axis",

--- a/artistools/inputmodel/plotinitialcomposition.py
+++ b/artistools/inputmodel/plotinitialcomposition.py
@@ -67,6 +67,10 @@ def plot_slice_modelcolumn(
     if args.logcolorscale:
         # logscale for colormap
         if args.floorval is not None:
+            if not args.floorval > 0:
+                # the floor is a linear value that the clamp below applies before the logarithm
+                msg = f"-floorval must be positive with --logcolorscale, got {args.floorval}"
+                raise ValueError(msg)
             colorscale = np.array([
                 args.floorval if x < args.floorval or not math.isfinite(x) else x for x in colorscale
             ])
@@ -94,7 +98,8 @@ def plot_slice_modelcolumn(
     vmax_ax2 = posmax_ax2 / t_model_s * unitfactor
     if colname == "rho":
         if args.logcolorscale:
-            vmin = -15 if args.floorval is None else args.floorval
+            # the colour scale holds log10 of the density, thus the linear floor moves to log units here
+            vmin = -15 if args.floorval is None else math.log10(args.floorval)
             vmax = -7
         else:
             vmin = 1e-15 if args.floorval is None else args.floorval

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2341,6 +2341,33 @@ def test_plotinitialcomposition_takes_a_zero_floor_value(tmp_path: Path) -> None
     assert mockimshow.call_args.kwargs["vmin"] == 0.0
 
 
+def test_plotinitialcomposition_log_scale_takes_a_linear_floor_value(tmp_path: Path) -> None:
+    """With --logcolorscale, the floor is a linear density, and the colour scale starts at its logarithm."""
+    import matplotlib.axes as mplax
+
+    with mock.patch.object(mplax.Axes, "imshow", side_effect=mplax.Axes.imshow, autospec=True) as mockimshow:
+        at.inputmodel.plotinitialcomposition.main(
+            argsraw=[
+                "-modelpath",
+                str(modelpath_3d),
+                "-o",
+                str(tmp_path),
+                "-floorval",
+                "1e-12",
+                "--logcolorscale",
+                "rho",
+            ]
+        )
+
+    assert mockimshow.call_args.kwargs["vmin"] == pytest.approx(-12.0)
+
+    # a floor of zero has no logarithm, thus it is an error and not a colour scale with vmin above vmax
+    with pytest.raises(ValueError, match="must be positive"):
+        at.inputmodel.plotinitialcomposition.main(
+            argsraw=["-modelpath", str(modelpath_3d), "-o", str(tmp_path), "-floorval", "0", "--logcolorscale", "rho"]
+        )
+
+
 def test_model_reader_renames_the_cellye_column_of_an_old_model(tmp_path: Path) -> None:
     """An old model.txt names the electron fraction cellYe, and get_modeldata returns the column as Ye."""
     dfmodel = pl.DataFrame({

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -218,7 +218,7 @@ def test_makeartismodelfrom_sph_particles() -> None:
         "maptogridargs": {"ncoordgrid": 16},
         "maptogrid_sums": {
             "ejectapartanalysis.dat": "e8694a679515c54c2b4867122122263a375d9ffa144a77310873ea053bb5a8b4",
-            "grid.dat": "b179427dc76e3b465d83fb303c866812fa9cb775114d1b8c45411dd36bf295b2",
+            "grid.dat": "d7dbe63efe3544f5d6f77acc202e110e197b02dcfa953d8f2bf84b24d9b8e76d",
             "gridcontributions.txt": "63e6331666c4928bdc6b7d0f59165e96d6555736243ea8998a779519052a425f",
         },
         # the model and abundance files carry eight significant figures, and the vmax header nine, so
@@ -227,7 +227,7 @@ def test_makeartismodelfrom_sph_particles() -> None:
         "makeartismodel_sums": {
             "gridcontributions.txt": "f7ddda0c8789a642ad2399e2ae67acc15e2fac519bbddfcdaa65b93d32e3edeb",
             "abundances.txt": "3fa70e381e9d538d7c07d8447b3b8a23d34a2bcc996370b4b71990e42f219baf",
-            "model.txt": "c0af5ae9e2dda0cf27656f8488030dd03f016d53e3869c0fa4478a2ed1634d9c",
+            "model.txt": "83801b752c315925602929943a42a3fec9ea88b65b20960dcc1b30c2da681e3a",
         },
     }
 
@@ -383,7 +383,7 @@ def test_make_empty_abundance_file() -> None:
 
 def test_opacity_by_Ye_file() -> None:
     griddata = pl.DataFrame({
-        "cellYe": [0.0, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.5],
+        "Ye": [0.0, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.5],
         "rho": [0.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0, 99.0],
         "inputcellid": range(1, 9),
     })
@@ -391,7 +391,7 @@ def test_opacity_by_Ye_file() -> None:
 
 
 def test_opacity_by_integer_Ye(tmp_path: Path) -> None:
-    griddata = pl.DataFrame({"cellYe": [0, 1], "rho": [1.0, 1.0], "inputcellid": [1, 2]})
+    griddata = pl.DataFrame({"Ye": [0, 1], "rho": [1.0, 1.0], "inputcellid": [1, 2]})
     at.inputmodel.opacityinputfile.opacity_by_Ye(tmp_path, griddata=griddata)
     assert np.allclose(np.loadtxt(tmp_path / "opacity.txt", skiprows=1)[:, 1], [19.5, 0.96])
 
@@ -2339,3 +2339,40 @@ def test_plotinitialcomposition_takes_a_zero_floor_value(tmp_path: Path) -> None
         )
 
     assert mockimshow.call_args.kwargs["vmin"] == 0.0
+
+
+def test_model_reader_renames_the_cellye_column_of_an_old_model(tmp_path: Path) -> None:
+    """An old model.txt names the electron fraction cellYe, and get_modeldata returns the column as Ye."""
+    dfmodel = pl.DataFrame({
+        "inputcellid": [1, 2],
+        "vel_r_max_kmps": [1000.0, 2000.0],
+        "logrho": [-10.0, -11.0],
+        "X_Fegroup": [1.0, 1.0],
+        "X_Ni56": [0.5, 0.4],
+        "X_Co56": [0.0, 0.0],
+        "X_Fe52": [0.0, 0.0],
+        "X_Cr48": [0.0, 0.0],
+        "Ye": [0.3, 0.4],
+    })
+    at.inputmodel.save_modeldata(dfmodel, outpath=tmp_path, modelmeta={"dimensions": 1, "t_model_init_days": 1.0})
+    modelfile = tmp_path / "model.txt"
+    modeltext = modelfile.read_text(encoding="utf-8")
+    assert " Ye\n" in modeltext
+    modelfile.write_text(modeltext.replace(" Ye\n", " cellYe\n"), encoding="utf-8")
+
+    lzdfmodel, _modelmeta = at.inputmodel.get_modeldata(tmp_path)
+
+    columns = lzdfmodel.collect_schema().names()
+    assert "Ye" in columns
+    assert "cellYe" not in columns
+    assert lzdfmodel.select("Ye").collect().to_series().to_list() == pytest.approx([0.3, 0.4])
+
+
+def test_griddat_reader_renames_the_cellye_column_of_an_old_grid() -> None:
+    """The grid.dat of the kilonova test data names the electron fraction cellYe, and the reader gives Ye."""
+    from artistools.inputmodel.modelfromhydro import read_griddat_file
+
+    griddata, _t_model, _t_merger, _vmax, _modelmeta = read_griddat_file(at.get_path("testdata") / "kilonova")
+
+    assert "Ye" in griddata.columns
+    assert "cellYe" not in griddata.columns

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2376,3 +2376,30 @@ def test_griddat_reader_renames_the_cellye_column_of_an_old_grid() -> None:
 
     assert "Ye" in griddata.columns
     assert "cellYe" not in griddata.columns
+
+
+def test_model_files_with_dotted_names_keep_separate_caches(tmp_path: Path) -> None:
+    """model_a.1.txt and model_a.2.txt must not share one parquet cache."""
+    for variant, logrho in (("1", -10.0), ("2", -12.0)):
+        dfmodel = pl.DataFrame({
+            "inputcellid": [1, 2],
+            "vel_r_max_kmps": [1000.0, 2000.0],
+            "logrho": [logrho, logrho],
+            "X_Fegroup": [1.0, 1.0],
+            "X_Ni56": [0.5, 0.4],
+            "X_Co56": [0.0, 0.0],
+            "X_Fe52": [0.0, 0.0],
+            "X_Cr48": [0.0, 0.0],
+        })
+        at.inputmodel.save_modeldata(dfmodel, outpath=tmp_path, modelmeta={"dimensions": 1, "t_model_init_days": 1.0})
+        (tmp_path / "model.txt").rename(tmp_path / f"model_a.{variant}.txt")
+        # a cache file that exists makes the reader write a new cache, whatever the size of the model
+        (tmp_path / f"model_a.{variant}.txt.parquet.tmp").touch()
+
+    lzdfmodel1, _meta1 = at.inputmodel.get_modeldata(tmp_path / "model_a.1.txt")
+    lzdfmodel2, _meta2 = at.inputmodel.get_modeldata(tmp_path / "model_a.2.txt")
+
+    assert lzdfmodel1.select("logrho").collect().to_series().to_list() == pytest.approx([-10.0, -10.0])
+    assert lzdfmodel2.select("logrho").collect().to_series().to_list() == pytest.approx([-12.0, -12.0])
+    assert (tmp_path / "model_a.1.txt.parquet.tmp").stat().st_size > 0
+    assert (tmp_path / "model_a.2.txt.parquet.tmp").stat().st_size > 0

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -2305,3 +2305,37 @@ def test_get_modeldata_regenerates_a_cache_with_malformed_metadata(tmp_path: Pat
 
     assert modelmeta == modelmeta_expected
     pltest.assert_frame_equal(dfmodel.collect(), dfmodel_expected.collect())
+
+
+def test_get_coarse_velocity_bins_of_a_3d_model_names_each_projection() -> None:
+    """A select with three expressions of one column needs three output names, or polars raises DuplicateError."""
+    from artistools.inputmodel.plotdensity import get_coarse_velocity_bins
+
+    dfmodel = pl.DataFrame({"vel_r_mid": [1.0e9, 2.0e9, 4.0e9, 5.0e9]})
+
+    binedges = get_coarse_velocity_bins(dfmodel, nbins=None)
+
+    assert binedges == pytest.approx([3.0e9, 5.0e9])
+
+
+def test_describeinputmodel_prints_the_selected_cell(capsys: pytest.CaptureFixture[str]) -> None:
+    """The -cell option must print the row of the cell, and not the plan of the query."""
+    at.inputmodel.describeinputmodel.main(argsraw=[], modelpath=[modelpath], cell=0)
+
+    output = capsys.readouterr().out
+    assert "Selected single cell mgi 0:" in output
+    assert "naive plan" not in output
+    # a collected frame prints its shape, and the one cell gives one row
+    assert "shape: (1," in output
+
+
+def test_plotinitialcomposition_takes_a_zero_floor_value(tmp_path: Path) -> None:
+    """A floor value of zero is a value, thus the colour scale must start there and not at the default."""
+    import matplotlib.axes as mplax
+
+    with mock.patch.object(mplax.Axes, "imshow", side_effect=mplax.Axes.imshow, autospec=True) as mockimshow:
+        at.inputmodel.plotinitialcomposition.main(
+            argsraw=["-modelpath", str(modelpath_3d), "-o", str(tmp_path), "-floorval", "0", "rho"]
+        )
+
+    assert mockimshow.call_args.kwargs["vmin"] == 0.0

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -29,8 +29,8 @@ outputpath = at.get_path("testoutput")
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
-def test_lightcurve_plot(mockplot: mock.MagicMock, benchmark: BenchmarkFixture) -> None:
-    benchmark(lambda: at.lightcurve.plot(argsraw=[], modelpath=[modelpath], outputfile=outputpath, frompackets=False))
+def test_lightcurve_plot(mockplot: mock.MagicMock, benchmark: BenchmarkFixture, tmp_path: Path) -> None:
+    benchmark(lambda: at.lightcurve.plot(argsraw=[], modelpath=[modelpath], outputfile=tmp_path, frompackets=False))
 
     arr_time_d = np.array(mockplot.call_args[0][1])
     arr_lum = np.array(mockplot.call_args[0][2])
@@ -218,7 +218,7 @@ def test_band_magnitude_selection_and_colour() -> None:
     ])
 
 
-def test_band_lightcurve_peakmag_risetime_plot() -> None:
+def test_band_lightcurve_peakmag_risetime_plot(tmp_path: Path) -> None:
     at.lightcurve.plot(
         argsraw=[],
         modelpath=modelpath,
@@ -228,7 +228,7 @@ def test_band_lightcurve_peakmag_risetime_plot() -> None:
         timemin=250,
         timemax=300,
         save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
-        outputfile=outputpath,
+        outputfile=tmp_path,
     )
 
 
@@ -252,8 +252,8 @@ def test_viewing_angle_peakmag_risetime_scatter_plot(monkeypatch: pytest.MonkeyP
     assert list(tmp_path.glob("*risetime_peakmag.pdf"))
 
 
-def test_band_lightcurve_subplots() -> None:
-    at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["bol", "B"], outputfile=outputpath)
+def test_band_lightcurve_subplots(tmp_path: Path) -> None:
+    at.lightcurve.plot(argsraw=[], modelpath=modelpath, filter=["bol", "B"], outputfile=tmp_path)
 
 
 def test_colour_evolution_plot() -> None:
@@ -1650,3 +1650,23 @@ def test_viewing_angle_peakmag_export_without_filter_fits_each_direction_bin(
     assert len(datafiles) == 1
     peakmag_risetime_deltam15 = np.loadtxt(datafiles[0], skiprows=1)
     assert peakmag_risetime_deltam15.shape == (2, 3), "the export holds one row per selected direction bin"
+
+
+def test_band_peakmag_export_writes_one_file_for_each_band(tmp_path: Path) -> None:
+    """Each band has its own data file with one row for each direction bin, and the decline rate is positive."""
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        filter=["bol", "B"],
+        plotviewingangle=-1,
+        timemin=250,
+        timemax=300,
+        save_viewing_angle_peakmag_risetime_delta_m15_to_file=True,
+        outputfile=tmp_path,
+    )
+
+    for band in ("bol", "B"):
+        (datafile,) = tmp_path.glob(f"{band}band_*_viewing_angle_data.txt")
+        data = np.loadtxt(datafile, skiprows=1, ndmin=2)
+        assert data.shape == (1, 3)
+        assert data[0, 2] > 0.0

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1670,3 +1670,23 @@ def test_band_peakmag_export_writes_one_file_for_each_band(tmp_path: Path) -> No
         data = np.loadtxt(datafile, skiprows=1, ndmin=2)
         assert data.shape == (1, 3)
         assert data[0, 2] > 0.0
+
+
+def test_angle_averaged_export_with_two_bands_gives_one_row_for_each_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The angle-averaged writers index their lists by model, thus two bands must not give two rows for one model."""
+    monkeypatch.chdir(tmp_path)
+    at.lightcurve.plot(
+        argsraw=[],
+        modelpath=[modelpath],
+        filter=["bol", "B"],
+        timemin=250,
+        timemax=300,
+        save_angle_averaged_peakmag_risetime_delta_m15_to_file=True,
+        outputfile=tmp_path,
+    )
+
+    (datafile,) = tmp_path.glob("*angle_averaged_all_models_data.txt")
+    # a header line and one line for the one model
+    assert len(datafile.read_text(encoding="utf-8").splitlines()) == 2

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -89,7 +89,8 @@ def save_viewing_angle_data_for_plotting(band_name: str, modelname: str, args: a
             comments="",
         )
 
-    elif wants_angle_averaged_data(args):
+    elif wants_angle_averaged_data(args) and band_name == (args.filter[0] if args.filter else "lightcurve"):
+        # the angle-averaged writers index these lists by model, thus the first band alone gives one entry
         args.band_risetime_angle_averaged_polyfit.append(args.band_risetime_polyfit)
         args.band_peakmag_angle_averaged_polyfit.append(args.band_peakmag_polyfit)
         args.band_delta_m15_angle_averaged_polyfit.append(args.band_deltam15_polyfit)

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -169,15 +169,17 @@ def calculate_peak_time_mag_deltam15(
     mag_after15days_polyfit = fxfit[index_after_15_days]
 
     print(f"{key}_max polyfit = {peakmag_polyfit} at time = {tmax_polyfit}")
-    print(f"deltam15 polyfit = {peakmag_polyfit - mag_after15days_polyfit}")
+    # a decline rate is the magnitude after the peak minus the peak magnitude, thus it is positive for a fainter source
+    deltam15_polyfit = mag_after15days_polyfit - peakmag_polyfit
+    print(f"deltam15 polyfit = {deltam15_polyfit}")
 
     args.band_risetime_polyfit.append(tmax_polyfit)
     args.band_peakmag_polyfit.append(peakmag_polyfit)
-    args.band_deltam15_polyfit.append((peakmag_polyfit - mag_after15days_polyfit) * -1)
+    args.band_deltam15_polyfit.append(deltam15_polyfit)
     if args.include_delta_m40:
-        mag_after40days_polyfit = fxfit[index_of_days_after_peak(40)]
-        print(f"deltam40 polyfit = {peakmag_polyfit - mag_after40days_polyfit}")
-        args.band_deltam40_polyfit.append((peakmag_polyfit - mag_after40days_polyfit) * -1)
+        deltam40_polyfit = fxfit[index_of_days_after_peak(40)] - peakmag_polyfit
+        print(f"deltam40 polyfit = {deltam40_polyfit}")
+        args.band_deltam40_polyfit.append(deltam40_polyfit)
 
     # Plotting the lightcurves for all viewing angles specified in the command line along with the
     # polynomial fit and peak mag, risetime to peak and delta m15 marked on the plots to check the
@@ -559,17 +561,25 @@ def peakmag_risetime_declinerate_init(
             lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=directionresolved)
             lcdataframes = at.lightcurve.readfile(lcpath)
 
-        for dirbin in dirbins:
-            if args.verbose:
-                print(f"Reading spectra: {modelname}")
-            if args.filter:
-                lightcurve_data_filters = at.lightcurve.generate_band_lightcurve_data(
-                    modelpath, args, dirbin, modelnumber=modelnumber
-                )
+        if args.verbose:
+            print(f"Reading spectra: {modelname}")
+        # the spectra of a direction bin hold every band, thus read each direction bin one time before the band loop
+        lightcurve_data_filters_of_dirbin = (
+            {
+                dirbin: at.lightcurve.generate_band_lightcurve_data(modelpath, args, dirbin, modelnumber=modelnumber)
+                for dirbin in dirbins
+            }
+            if args.filter
+            else {}
+        )
 
-            for band_name in plottinglist:
+        # the fit results of one band fill the shared lists, and the save function then empties them for the next band
+        for band_name in plottinglist:
+            for dirbin in dirbins:
                 if args.filter:
-                    time, brightness = at.lightcurve.get_band_lightcurve(lightcurve_data_filters, band_name, args)
+                    time, brightness = at.lightcurve.get_band_lightcurve(
+                        lightcurve_data_filters_of_dirbin[dirbin], band_name, args
+                    )
                 else:
                     lightcurve_data = (
                         lcdataframes[dirbin]
@@ -587,9 +597,8 @@ def peakmag_risetime_declinerate_init(
                 # Calculating band peak time, peak magnitude and delta m15
                 calculate_peak_time_mag_deltam15(time, brightness, modelname, dirbin, band_name, args)
 
-        # Saving viewing angle data so it can be read in and plotted later on without re-running the script
-        #    as it is quite time consuming
-        save_viewing_angle_data_for_plotting(plottinglist[0], modelname, args)
+            # write the data of this band to a file. A later plot then reads the file in place of the slow fit
+            save_viewing_angle_data_for_plotting(band_name, modelname, args)
 
     # Saving all this viewing angle info for each model to a file so that it is available to plot if required again
     # as it takes relatively long to run this for all viewing angles

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -134,28 +134,27 @@ def get_line_luminosities_from_packets(
 
     dfpackets = dfpackets.filter(pl.col(emtypecolumn).is_in(linelistindices_allfeatures))
 
-    dictlcdata = {
+    # one collect_all reads the packets one time for every feature
+    dfluminosities = pl.collect_all([
+        at.packets
+        .bin_and_sum(
+            dfpackets.filter(pl.col(emtypecolumn).is_in(feature.linelistindices)),
+            bincol="t_arrive_d",
+            bins=timearrayplusend,
+            sumcols=["e_rf"],
+        )
+        .with_columns(pl.Series("timedelta_days", arr_timedelta))
+        .select(pl.col("e_rf_sum") / nprocs_read / (day_to_s * pl.col("timedelta_days")))
+        for feature in emfeatures
+    ])
+
+    return pl.DataFrame({
         "time": arr_tmid,
         **{
-            feature.colname: (
-                at.packets
-                .bin_and_sum(
-                    dfpackets.filter(pl.col(emtypecolumn).is_in(feature.linelistindices)),
-                    bincol="t_arrive_d",
-                    bins=timearrayplusend,
-                    sumcols=["e_rf"],
-                )
-                .with_columns(pl.Series("timedelta_days", arr_timedelta))
-                .select(pl.col("e_rf_sum") / nprocs_read / (day_to_s * pl.col("timedelta_days")))
-                .collect()
-                .to_series()
-                .to_numpy()
-            )
-            for feature in emfeatures
+            feature.colname: dfluminosity.to_series().to_numpy()
+            for feature, dfluminosity in zip(emfeatures, dfluminosities, strict=True)
         },
-    }
-
-    return pl.DataFrame(dictlcdata)
+    })
 
 
 def get_line_luminosities_from_pops(

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -132,9 +132,10 @@ def get_line_luminosities_from_packets(
         modelpath=modelpath, maxpacketfiles=maxpacketfiles, packet_type="TYPE_ESCAPE", escape_type="TYPE_RPKT"
     )
 
-    dfpackets = dfpackets.filter(pl.col(emtypecolumn).is_in(linelistindices_allfeatures))
+    # the lines of the features hold a small part of the packets, thus one collect keeps them in memory and
+    # each feature bins the frame there. A lazy plan for each feature would scan the parquet files again
+    dfpackets = dfpackets.filter(pl.col(emtypecolumn).is_in(linelistindices_allfeatures)).collect().lazy()
 
-    # one collect_all reads the packets one time for every feature
     dfluminosities = pl.collect_all([
         at.packets
         .bin_and_sum(

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -63,8 +63,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     input_files = list(Path(args.modelpath).glob("**/macroatom_????.out*"))
 
     if not input_files:
-        print("No macroatom files found")
-        raise FileNotFoundError
+        msg = f"{args.modelpath} holds no macroatom_????.out file"
+        raise FileNotFoundError(msg)
 
     # the template took {0}, {1}, and {2} before it took names, thus a script holds those fields
     outputfile = str(args.outputfile).format(

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -34,6 +34,7 @@ from artistools.misc.cliutils import get_series_label as get_series_label
 from artistools.misc.cliutils import get_single_modelgridindex as get_single_modelgridindex
 from artistools.misc.cliutils import get_template_fields as get_template_fields
 from artistools.misc.cliutils import KeepGivenPaths as KeepGivenPaths
+from artistools.misc.cliutils import make_output_folder as make_output_folder
 from artistools.misc.cliutils import makelist as makelist
 from artistools.misc.cliutils import normalize_path_list as normalize_path_list
 from artistools.misc.cliutils import parse_cli_args as parse_cli_args

--- a/artistools/misc/modelinfo.py
+++ b/artistools/misc/modelinfo.py
@@ -237,13 +237,13 @@ def get_runfolder_timesteps(folderpath: Path | str) -> tuple[int, ...]:
                 dfestfile.select(pl.col("timestep")).unique().sort("timestep").collect().to_series().to_list()
             )
             # the first timestep of a restarted run is duplicate and should be ignored
-            restart_timestep = None if 0 in timesteps_contained else timesteps_contained[0]
+            restart_timestep = timesteps_contained[0] if timesteps_contained and 0 not in timesteps_contained else None
             return tuple(ts for ts in timesteps_contained if ts != restart_timestep)
     if estimfiles := sorted(Path(folderpath).glob("estimators_*.out*")):
         with zopen(estimfiles[0]) as estfile:
             timesteps_contained = sorted({int(line.split()[1]) for line in estfile if line.startswith("timestep ")})
             # the first timestep of a restarted run is duplicate and should be ignored
-            restart_timestep = None if 0 in timesteps_contained else timesteps_contained[0]
+            restart_timestep = timesteps_contained[0] if timesteps_contained and 0 not in timesteps_contained else None
             return tuple(ts for ts in timesteps_contained if ts != restart_timestep)
 
     return ()

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -1623,11 +1623,11 @@ def test_check_time_selection_reads_each_spelling_as_argparse_does() -> None:
     timestep 70. The command took such a value for -t, thus "-ts70 -t 300" named the time range two
     times and ran without a word, on a command whose -timestep holds that value as its default.
     """
-    import artistools.transitions
 
     def parse(argsraw: list[str]) -> tuple[at.commands.SuggestingArgumentParser, argparse.Namespace]:
         parser = at.commands.SuggestingArgumentParser()
-        artistools.transitions.addargs(parser)
+        at.addarg_timedays(parser, kind="str")
+        at.addarg_timestep(parser, default=70)
         return parser, parser.parse_args(argsraw)
 
     # each spelling of the timestep names the range beside -t, and the value is the default here
@@ -1717,10 +1717,11 @@ def test_progress_class_takes_a_spawn_lock_and_keeps_the_start_method() -> None:
         progressbar.close()
 
         assert mp.get_start_method() == "fork", "a bar starts no process, thus it sets no start method"
-        assert tqdm.tqdm.get_lock() is not None, "the bar must hold the lock that get_progress_class gave"
+        # a SemLock records the context that made it, thus a lock of the fork default fails here
+        assert getattr(tqdm.tqdm.get_lock(), "_is_fork_ctx", None) is False, "the bar must hold a spawn lock"
     finally:
-        if original is not None:
-            mp.set_start_method(original, force=True)
+        # None with force=True clears the default again, thus this test leaves no fork default in the worker
+        mp.set_start_method(original, force=True)
 
 
 def test_resolve_frameset_paths(tmp_path: Path) -> None:
@@ -1856,3 +1857,12 @@ def test_a_merge_keeps_its_own_product(tmp_path: Path) -> None:
     # the product carries the name of a frame, and the caller gives it as an absolute path
     product = at.merge_pdf_files(framepaths, tmp_path.resolve() / "frame0.pdf")
     assert Path(product).is_file(), "the merge must keep the file that it wrote"
+
+
+def test_get_runfolder_timesteps_of_a_classic_estimator_file_gives_no_timesteps() -> None:
+    """A classic-mode estimator file has no timestep header line, thus the code must not index the empty result."""
+    from artistools.misc.modelinfo import get_runfolder_timesteps
+
+    runfolder = at.get_path("testdata") / "test-classicmode_1d" / "32086771.slurm"
+
+    assert get_runfolder_timesteps(runfolder) == ()

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -334,6 +334,10 @@ def make_ionsubplot(
     if not args.hide_lte_tr:
         lte_columns.append(("n_LTE_T_R", T_R))
 
+    # add_lte_pops moves the superlevel (level -1) above every resolved level. Thus a level number above the
+    # largest resolved level in the file identifies a superlevel row
+    maxresolvedlevel = dfpopthision["level"].max()
+    assert isinstance(maxresolvedlevel, int)
     dfpopthision = at.nltepops.add_lte_pops(dfpopthision, adata, lte_columns, noprint=False, maxlevel=args.maxlevel)
 
     if args.maxlevel >= 0:
@@ -349,14 +353,15 @@ def make_ionsubplot(
     configlist = levelnames[: maxlevel_ion + 1]
     configtexlist = get_config_labels(configlist)
 
+    # a superlevel has no entry in the atomic data, thus its level number must not index the level names
+    levels: list[int] = dfpopthision["level"].to_list()
     dfpopthision = dfpopthision.with_columns(
         # a level name that ends in "o" in front of the term is a level of odd parity
         parity=pl.Series([
-            1 if (level != -1 and levelnames[int(level)].split("[")[0][-1] == "o") else 0
-            for level in dfpopthision["level"]
+            1 if (level <= maxresolvedlevel and levelnames[level].split("[")[0][-1] == "o") else 0 for level in levels
         ]),
-        config=pl.Series([configlist[level] for level in dfpopthision["level"]]),
-        texname=pl.Series([configtexlist[level] for level in dfpopthision["level"]]),
+        config=pl.Series(["superlevel" if level > maxresolvedlevel else configlist[level] for level in levels]),
+        texname=pl.Series(["superlevel" if level > maxresolvedlevel else configtexlist[level] for level in levels]),
     )
 
     set_level_xticks(

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -1,5 +1,6 @@
 """Read ARTIS packets and virtual packets files, caching them as parquet, and bin them by viewing direction."""
 
+import contextlib
 import datetime
 import math
 import time
@@ -360,6 +361,27 @@ def get_vpackets_text_columns(vpacketsfiletext: Path) -> list[str]:
 CACHEVERSION = 1
 
 
+def get_packets_textsource_mtimes(modelpath: Path, virtual: bool) -> dict[int, float]:
+    """Return the change time of the packets text file of each rank, keyed by MPI rank.
+
+    One glob of the model folder and of each subfolder finds every rank, thus the check of a batch
+    does not walk the tree for each rank. The model folder wins over a subfolder, and the plain name
+    wins over a compressed one, as firstexisting decides.
+    """
+    prefix = "vpackets" if virtual else "packets00"
+    mtimes: dict[int, float] = {}
+    for folder in (modelpath, *sorted(child for child in modelpath.iterdir() if child.is_dir())):
+        ranks = {
+            int(textfile.name[len(prefix) + 1 : len(prefix) + 5]) for textfile in folder.glob(f"{prefix}_????.out*")
+        }
+        for rank in sorted(ranks - mtimes.keys()):
+            for suffix in ("", ".zst", ".gz", ".xz"):
+                with contextlib.suppress(FileNotFoundError):
+                    mtimes[rank] = (folder / f"{prefix}_{rank:04d}.out{suffix}").stat().st_mtime
+                    break
+    return mtimes
+
+
 def get_packets_rankbatch_parquetfile(
     modelpath: Path | str, batch_mpiranks: Sequence[int], batchindex: int, virtual: bool
 ) -> Path:
@@ -384,17 +406,9 @@ def get_packets_rankbatch_parquetfile(
         parquetstat = parquetfilepath.stat()
         # every file of the batch counts, thus the newest one decides the freshness. One rank file that a
         # restart rewrote then makes the whole batch cache stale
-        text_filepaths_found = [
-            text_filepath
-            for filename in text_filenames
-            if (
-                text_filepath := at.firstexisting_or_none(
-                    filename, folder=modelpath, tryzipped=True, search_subfolders=True
-                )
-            )
-        ]
-        if text_filepaths_found:
-            textsource_mtime = max(text_filepath.stat().st_mtime for text_filepath in text_filepaths_found)
+        textsource_mtimes = get_packets_textsource_mtimes(modelpath, virtual)
+        if all(rank in textsource_mtimes for rank in batch_mpiranks):
+            textsource_mtime = max(textsource_mtimes[rank] for rank in batch_mpiranks)
 
             _, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
             if stalereason is None:
@@ -413,7 +427,7 @@ def get_packets_rankbatch_parquetfile(
                     " File will be regenerated..."
                 )
         else:
-            # no text file of the batch remains, thus the cache is the only source
+            # a text file of the batch is absent, thus the cache is the only complete source
             conversion_needed = False
 
     if conversion_needed:

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -382,14 +382,21 @@ def get_packets_rankbatch_parquetfile(
     outdatedparquet: tuple[int, int] | None = None
     if parquetfilepath.is_file():
         parquetstat = parquetfilepath.stat()
-        # only the last rank's file is checked, on the assumption that a run writes all of its ranks together. An
-        # individually-updated earlier file will not invalidate the cached parquet
-        if text_filepath := at.firstexisting_or_none(
-            text_filenames[-1], folder=modelpath, tryzipped=True, search_subfolders=True
-        ):
-            last_textfile_mtime = text_filepath.stat().st_mtime
+        # every file of the batch counts, thus the newest one decides the freshness. One rank file that a
+        # restart rewrote then makes the whole batch cache stale
+        text_filepaths_found = [
+            text_filepath
+            for filename in text_filenames
+            if (
+                text_filepath := at.firstexisting_or_none(
+                    filename, folder=modelpath, tryzipped=True, search_subfolders=True
+                )
+            )
+        ]
+        if text_filepaths_found:
+            textsource_mtime = max(text_filepath.stat().st_mtime for text_filepath in text_filepaths_found)
 
-            _, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, last_textfile_mtime)
+            _, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
             if stalereason is None:
                 conversion_needed = False
             else:
@@ -401,11 +408,12 @@ def get_packets_rankbatch_parquetfile(
                 # window in which a concurrent reader (another rank, or another pytest-xdist worker) finds
                 # it missing or half-swapped
                 print(
-                    f"  {parquetfilepath.relative_to(modelpath)} is not a current cache of"
-                    f" {text_filepath.relative_to(modelpath)}, because {stalereason}."
+                    f"  {parquetfilepath.relative_to(modelpath)} is not a current cache of the text files of"
+                    f" ranks {batch_mpiranks[0]} to {batch_mpiranks[-1]}, because {stalereason}."
                     " File will be regenerated..."
                 )
         else:
+            # no text file of the batch remains, thus the cache is the only source
             conversion_needed = False
 
     if conversion_needed:
@@ -417,8 +425,8 @@ def get_packets_rankbatch_parquetfile(
             for filename in text_filenames
         ]
 
-        # the stamp uses the same file that the freshness check reads: the text file of the last rank
-        textsource_mtime = text_file_paths[-1].stat().st_mtime
+        # the stamp uses the same rule as the freshness check: the newest text file of the batch
+        textsource_mtime = max(text_file_path.stat().st_mtime for text_file_path in text_file_paths)
 
         column_names = (
             get_vpackets_text_columns(text_file_paths[0])

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -203,3 +203,27 @@ def test_readfile_text_drops_trailing_null_column(tmp_path: Path) -> None:
 
     assert dfpackets.columns == [*columns, "mpirank"]
     assert dfpackets["mpirank"].to_list() == [0, 0, 0]
+
+
+def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path) -> None:
+    """Every rank of a batch decides the freshness of its cache, and not the last rank alone."""
+    import os
+    import shutil
+
+    from artistools.packets.packets import get_packets_rankbatch_parquetfile
+
+    sourcedir = at.get_path("testdata") / "test-classicmode_3d" / "packets"
+    for rank in (0, 1):
+        shutil.copy(sourcedir / f"packets00_{rank:04d}.out.zst", tmp_path)
+
+    parquetpath = get_packets_rankbatch_parquetfile(tmp_path, batch_mpiranks=[0, 1], batchindex=0, virtual=False)
+    firstwrite = parquetpath.stat().st_mtime_ns
+
+    # only the file of the first rank becomes newer, because a check of the last rank alone would miss it
+    firstrankfile = tmp_path / "packets00_0000.out.zst"
+    newtime = firstrankfile.stat().st_mtime + 100.0
+    os.utime(firstrankfile, (newtime, newtime))
+
+    parquetpath = get_packets_rankbatch_parquetfile(tmp_path, batch_mpiranks=[0, 1], batchindex=0, virtual=False)
+
+    assert parquetpath.stat().st_mtime_ns > firstwrite

--- a/artistools/radfield.py
+++ b/artistools/radfield.py
@@ -36,7 +36,9 @@ from artistools.plottools import set_legend
 from artistools.plottools import set_plot_title
 
 
-def read_files(modelpath: Path | str, timestep: int | None = None, modelgridindex: int | None = None) -> pl.DataFrame:
+def read_files(
+    modelpath: Path | str, timestep: int | None = None, modelgridindex: int | Sequence[int] | None = None
+) -> pl.DataFrame:
     """Read radiation field data from a model folder, possibly with timestep and modelgridindex filters."""
     return at.read_rank_outputfiles(
         modelpath, "radfield_{mpirank:04d}.out", timestep=timestep, modelgridindex=modelgridindex
@@ -429,10 +431,11 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         combines=len(modelgridindexlist) * len(timesteplist) > 1,
     )
 
+    # read_files parses a rank file on each call, thus one read of all the cells serves each cell and timestep
+    radfielddata_allcells = read_files(modelpath, modelgridindex=modelgridindexlist)
     for modelgridindex in modelgridindexlist:
         assert modelgridindex is not None
-        # read_files parses the rank file on each call, thus one read of the cell serves every timestep
-        radfielddata_cell = read_files(modelpath, modelgridindex=modelgridindex)
+        radfielddata_cell = radfielddata_allcells.filter(pl.col("modelgridindex") == modelgridindex)
         for timestep in timesteplist:
             outputfile = at.format_frame_path(frameset.frametemplate, cell=modelgridindex, timestep=timestep)
             if plot_celltimestep(

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -57,6 +57,7 @@ from artistools.misc import get_series_label
 from artistools.misc import get_time_range
 from artistools.misc import get_vpkt_config
 from artistools.misc import KeepGivenPaths
+from artistools.misc import make_output_folder
 from artistools.misc import makelist
 from artistools.misc import normalize_path_list
 from artistools.misc import parse_cli_args
@@ -1675,8 +1676,14 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         return
 
     if args.output_spectra:
-        # -o that names a folder takes the files, and no -o keeps them in the spectra folder of the model
-        outdirectory = Path(args.outputfile) if args.outputfile and Path(args.outputfile).is_dir() else None
+        # -o that names a folder takes the files, and no -o keeps them in the spectra folder of the model. As
+        # everywhere, a path with no suffix names a folder, and the command makes it
+        outputfile = Path(args.outputfile) if args.outputfile else None
+        outdirectory = (
+            make_output_folder(outputfile, "writes")
+            if outputfile is not None and (outputfile.is_dir() or not outputfile.suffixes)
+            else None
+        )
         for modelpath in args.specpath:
             write_flambda_spectra(modelpath, outdirectory=outdirectory)
 

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -47,6 +47,7 @@ from artistools.misc import df_filter_minmax_bracketed
 from artistools.misc import exit_with_error
 from artistools.misc import find_reference_data_file
 from artistools.misc import get_dirbin_definitions
+from artistools.misc import get_dirbins
 from artistools.misc import get_escaped_arrivalrange
 from artistools.misc import get_file_metadata
 from artistools.misc import get_filterfunc
@@ -70,6 +71,7 @@ from artistools.misc import print_warning
 from artistools.misc import read_wsv
 from artistools.misc import resolve_outputfile
 from artistools.misc import resolve_series_styles
+from artistools.packets import get_packets
 from artistools.plottools import FRAMEHEIGHT_INCHES
 from artistools.plottools import FRAMEWIDTH_INCHES
 from artistools.plottools import label_dirbin_series
@@ -464,9 +466,30 @@ def plot_artis_spectrum(
     if yvariable == "packetcount":
         from_packets = True
 
+    clamp_to_timesteps = not args.notimeclamp
+    nprocs_read_dfpackets: tuple[int, pl.DataFrame] | None = None
+    if from_packets and args.multispecplot and use_time == "arrival" and args.plotvspecpol is None:
+        # every panel reads the packets, thus one read of the union of the time windows serves them all. Each
+        # panel then applies its own arrival window to the frame in memory
+        timeranges = [
+            get_time_range(modelpath, timedays_range_str=timedays, clamp_to_timesteps=clamp_to_timesteps)
+            for timedays in args.timedayslist
+        ]
+        nprocs_read, dfpackets = get_packets(
+            modelpath,
+            maxpacketfiles=maxpacketfiles,
+            packet_type="TYPE_ESCAPE",
+            escape_type="TYPE_GAMMA" if args.gamma else "TYPE_RPKT",
+        )
+        timelow = min(timerange[2] for timerange in timeranges)
+        timehigh = max(timerange[3] for timerange in timeranges)
+        nprocs_read_dfpackets = (
+            nprocs_read,
+            dfpackets.filter(pl.col("t_arrive_d").is_between(timelow, timehigh)).collect(),
+        )
+
     for axindex, axis in enumerate(axes):
         assert isinstance(axis, mplax.Axes)
-        clamp_to_timesteps = not args.notimeclamp
         if args.multispecplot:
             (timestepmin, timestepmax, args.timemin, args.timemax) = get_time_range(
                 modelpath, timedays_range_str=args.timedayslist[axindex], clamp_to_timesteps=clamp_to_timesteps
@@ -532,6 +555,7 @@ def plot_artis_spectrum(
                 average_over_phi=average_over_phi,
                 average_over_theta=average_over_theta,
                 fluxfilterfunc=filterfunc,
+                nprocs_read_dfpackets=nprocs_read_dfpackets,
                 directionbins_are_vpkt_observers=args.plotvspecpol is not None,
                 gamma=args.gamma,
             )
@@ -564,6 +588,13 @@ def plot_artis_spectrum(
                 gamma=args.gamma,
             )
 
+        if args.plotvspecpol is None and (average_over_phi or average_over_theta):
+            # an averaged bin is the first bin of its group, thus a different bin has no label and no packets
+            validbins = get_dirbins(average_over_phi=average_over_phi, average_over_theta=average_over_theta)
+            if invalidbins := [dirbin for dirbin in directionbins if dirbin >= 0 and dirbin not in validbins]:
+                msg = f"Direction bin {invalidbins} is not the first bin of an average group. Valid bins: {validbins}"
+                raise ValueError(msg)
+
         dirbin_definitions = get_dirbin_definitions(
             modelpath,
             directionbins,
@@ -581,6 +612,7 @@ def plot_artis_spectrum(
                 directionbins = founddirectionbins
             elif -1 in viewinganglespectra:
                 directionbins = [-1]
+                dirbin_definitions = get_dirbin_definitions(modelpath, directionbins, usedegrees=usedegrees)
                 print("Showing spherically-averaged spectrum instead")
             else:
                 print("No data to plot")
@@ -1643,8 +1675,10 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         return
 
     if args.output_spectra:
+        # -o that names a folder takes the files, and no -o keeps them in the spectra folder of the model
+        outdirectory = Path(args.outputfile) if args.outputfile and Path(args.outputfile).is_dir() else None
         for modelpath in args.specpath:
-            write_flambda_spectra(modelpath)
+            write_flambda_spectra(modelpath, outdirectory=outdirectory)
 
     else:
         if args.emissionabsorption:

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1676,16 +1676,20 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         return
 
     if args.output_spectra:
-        # -o that names a folder takes the files, and no -o keeps them in the spectra folder of the model. As
-        # everywhere, a path with no suffix names a folder, and the command makes it
+        # -o names the folder of the files, and no -o keeps them in the spectra folder of the model
         outputfile = Path(args.outputfile) if args.outputfile else None
-        outdirectory = (
-            make_output_folder(outputfile, "writes")
-            if outputfile is not None and (outputfile.is_dir() or not outputfile.suffixes)
-            else None
-        )
+        if outputfile is not None and outputfile.suffixes and not outputfile.is_dir():
+            msg = f"--output_spectra writes a folder of files, thus -o must name a folder and not {outputfile}"
+            raise ValueError(msg)
+        outdirectory = make_output_folder(outputfile, "writes") if outputfile is not None else None
         for modelpath in args.specpath:
-            write_flambda_spectra(modelpath, outdirectory=outdirectory)
+            # the file names hold no model name, thus several models get a subfolder each
+            modeloutdirectory = (
+                outdirectory / get_model_name(modelpath)
+                if outdirectory is not None and len(args.specpath) > 1
+                else outdirectory
+            )
+            write_flambda_spectra(modelpath, outdirectory=modeloutdirectory)
 
     else:
         if args.emissionabsorption:

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -200,6 +200,10 @@ def get_lambda_bin_edges(
         if not deltalogx > 0:
             msg = f"deltalogx must be positive, got {deltalogx}"
             raise ValueError(msg)
+        if not xmin_plot > 0:
+            # a bin edge of zero stays at zero after each multiplication, thus the loop below does not stop
+            msg = f"deltalogx needs a positive lower x limit, got {xmin_plot}"
+            raise ValueError(msg)
         # xmin_plot is the centre of the first bin, so we need to subtract half a bin width to get the lower edge of the first bin
         xbin_lower = xmin_plot / (1 + deltalogx) ** 0.5
         xmax = xmax_plot * (1 + deltalogx) ** 0.5
@@ -219,11 +223,11 @@ def get_lambda_bin_edges(
         if not deltalambda > 0:
             msg = f"deltalambda must be positive, got {deltalambda}"
             raise ValueError(msg)
-        # the plotted x limits are bin centres, not bin edges, so shift them by half a bin width
-        deltax = convert_angstroms_to_unit(deltalambda, xunit)
-        xmin = xmin_plot - deltax * 0.5
-        xmax = xmax_plot + deltax * 0.5
-        lambda_min, lambda_max = convert_xlimits_to_lambda_range(xmin, xmax, xunit)
+        # the plotted x limits are bin centres and not bin edges, thus shift them by half a bin width. The shift
+        # is in angstroms, because convert_angstroms_to_unit converts a wavelength and not a wavelength interval
+        lambda_min_centre, lambda_max_centre = convert_xlimits_to_lambda_range(xmin_plot, xmax_plot, xunit)
+        lambda_min = lambda_min_centre - deltalambda * 0.5
+        lambda_max = lambda_max_centre + deltalambda * 0.5
         lambda_bin_edges = np.arange(lambda_min, lambda_max + deltalambda, deltalambda)
     else:
         lambda_min_plot, lambda_max_plot = convert_xlimits_to_lambda_range(xmin_plot, xmax_plot, xunit)
@@ -783,6 +787,10 @@ def get_spectra(
     except FileNotFoundError as e:
         if gamma:
             msg = "ERROR: No spherically averaged gamma spectrum found."
+            raise FileNotFoundError(msg) from e
+        if not specdata_alltimesteps:
+            # a run with specpol.out alone has no spec.out, thus only a run with no spectrum file fails here
+            msg = f"{modelpath} holds no spec.out and no spec_res.out"
             raise FileNotFoundError(msg) from e
 
     arr_tdelta = get_timestep_times(modelpath, loc="delta")

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -58,9 +58,11 @@ def test_spectra_frompackets(mockplot: mock.MagicMock) -> None:
 
 
 def test_spectra_outputtext(tmp_path: Path) -> None:
-    at.spectra.plot(argsraw=[], specpath=modelpath, output_spectra=True, outputfile=tmp_path)
+    """-o names the folder of the spectrum files, and the command makes a folder that does not exist yet."""
+    newfolder = tmp_path / "newfolder"
+    at.spectra.plot(argsraw=[], specpath=modelpath, output_spectra=True, outputfile=newfolder)
 
-    assert list(tmp_path.glob("spectrum_ts*.txt"))
+    assert list(newfolder.glob("spectrum_ts*.txt"))
 
 
 @pytest.mark.benchmark

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -57,8 +57,10 @@ def test_spectra_frompackets(mockplot: mock.MagicMock) -> None:
     assert np.isclose(integral, 7.7888e-12, rtol=1e-3)
 
 
-def test_spectra_outputtext() -> None:
-    at.spectra.plot(argsraw=[], specpath=modelpath, output_spectra=True)
+def test_spectra_outputtext(tmp_path: Path) -> None:
+    at.spectra.plot(argsraw=[], specpath=modelpath, output_spectra=True, outputfile=tmp_path)
+
+    assert list(tmp_path.glob("spectrum_ts*.txt"))
 
 
 @pytest.mark.benchmark
@@ -577,8 +579,10 @@ def test_spectraplot_custom_title(mocksettitle: mock.MagicMock) -> None:
     assert all(isinstance(title, str) for title in titles)
 
 
-def test_writespectra() -> None:
-    at.spectra.writespectra.main(argsraw=[], modelpath=modelpath)
+def test_writespectra(tmp_path: Path) -> None:
+    at.spectra.writespectra.main(argsraw=[], modelpath=modelpath, outputfile=tmp_path)
+
+    assert list(tmp_path.glob("spectrum_ts*.txt"))
 
 
 def test_hiding_the_x_tick_labels_holds_the_width_and_the_frame(tmp_path: Path) -> None:
@@ -806,3 +810,49 @@ def test_spectraemissionplot_draws_a_reference_named_out(mockplot: mock.MagicMoc
 
     labels = {callargs.kwargs.get("label") for callargs in mockplot.call_args_list}
     assert any(label and "2003du" in str(label) for label in labels), labels
+
+
+def test_lambda_bin_edges_with_deltalambda_and_a_frequency_axis_stay_positive() -> None:
+    """The unit conversion applies to a wavelength value, thus the code must not apply it to a wavelength interval."""
+    lambda_bin_edges = atspectra.get_lambda_bin_edges(
+        xmin_plot=atspectra.convert_angstroms_to_unit(19000.0, "hz"),
+        xmax_plot=atspectra.convert_angstroms_to_unit(2500.0, "hz"),
+        deltax=None,
+        deltalogx=None,
+        deltalambda=10.0,
+        xunit="hz",
+        modelpath=modelpath,
+    )
+
+    assert lambda_bin_edges[0] == pytest.approx(2495.0)
+    assert lambda_bin_edges[-1] == pytest.approx(19005.0)
+    assert np.all(np.diff(lambda_bin_edges) == pytest.approx(10.0))
+
+
+def test_lambda_bin_edges_reject_a_zero_lower_limit_with_deltalogx() -> None:
+    """A lower limit of zero made the multiplicative bin loop run without end."""
+    with pytest.raises(ValueError, match="positive lower x limit"):
+        atspectra.get_lambda_bin_edges(
+            xmin_plot=0.0,
+            xmax_plot=19000.0,
+            deltax=None,
+            deltalogx=0.05,
+            deltalambda=None,
+            xunit="angstroms",
+            modelpath=modelpath,
+        )
+
+
+def test_spectraplot_falls_back_to_the_angle_averaged_spectrum(tmp_path: Path) -> None:
+    """A model with no spec_res.out shows direction bin -1 in place of the requested bin, and that bin needs a label."""
+    at.spectra.plot(argsraw=[], specpath=[modelpath], plotviewingangle=[5], timedays=290, outputfile=tmp_path)
+
+    assert list(tmp_path.glob("*.pdf"))
+
+
+def test_spectraplot_rejects_a_direction_bin_inside_an_average_group() -> None:
+    """With --average_over_phi_angle, a bin that is not the first of its group has no label and no packets."""
+    with pytest.raises(ValueError, match="first bin of an average group"):
+        at.spectra.plot(
+            argsraw=[], specpath=[modelpath], plotviewingangle=[5], average_over_phi_angle=True, timedays=290
+        )

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -858,3 +858,9 @@ def test_spectraplot_rejects_a_direction_bin_inside_an_average_group() -> None:
         at.spectra.plot(
             argsraw=[], specpath=[modelpath], plotviewingangle=[5], average_over_phi_angle=True, timedays=290
         )
+
+
+def test_output_spectra_rejects_a_file_name_for_the_output(tmp_path: Path) -> None:
+    """--output_spectra writes a folder of files, thus -o with a file suffix is an error and not a fallback."""
+    with pytest.raises(ValueError, match="must name a folder"):
+        at.spectra.plot(argsraw=[], specpath=[modelpath], output_spectra=True, outputfile=tmp_path / "spectra.txt")

--- a/artistools/spectra/writespectra.py
+++ b/artistools/spectra/writespectra.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import polars as pl
 
 from artistools.misc import addarg_modelpath
+from artistools.misc import addarg_output
 from artistools.misc import get_escaped_arrivalrange
 from artistools.misc import get_timestep_times
 from artistools.misc import parse_cli_args
@@ -27,13 +28,15 @@ def write_spectrum(dfspectrum: pl.DataFrame, outfilepath: Path) -> None:
     print_saved(outfilepath)
 
 
-def write_flambda_spectra(modelpath: Path) -> None:
+def write_flambda_spectra(modelpath: Path, outdirectory: Path | None = None) -> None:
     """Write out spectra to text files.
 
     Writes lambda_angstroms and f_lambda to .txt files for all timesteps and create
-    a text file containing the time in days for each timestep.
+    a text file that holds the time in days of each timestep. The files go to
+    outdirectory, or to the spectra folder of the model when the caller gives none.
     """
-    outdirectory = Path(modelpath, "spectra")
+    if outdirectory is None:
+        outdirectory = Path(modelpath, "spectra")
 
     outdirectory.mkdir(parents=True, exist_ok=True)
 
@@ -45,10 +48,15 @@ def write_flambda_spectra(modelpath: Path) -> None:
     assert tmax_d_valid is not None
     timesteps = [ts for ts in range(tslast + 1) if tmids[ts] >= tmin_d_valid and tmids[ts] <= tmax_d_valid]
 
+    lzspectra_of_timestep = [
+        get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep) for timestep in timesteps
+    ]
+    if any(-1 not in lzspectra for lzspectra in lzspectra_of_timestep):
+        msg = f"{modelpath} holds no spec.out, thus there is no angle-averaged spectrum to write"
+        raise FileNotFoundError(msg)
+
     # one collect_all call evaluates the queries of all the timesteps together
-    dfspectra_alltimesteps = pl.collect_all([
-        get_spectra(modelpath=modelpath, timestepmin=timestep, timestepmax=timestep)[-1] for timestep in timesteps
-    ])
+    dfspectra_alltimesteps = pl.collect_all([lzspectra[-1] for lzspectra in lzspectra_of_timestep])
     for timestep, dfspectrum in zip(timesteps, dfspectra_alltimesteps, strict=True):
         write_spectrum(dfspectrum, outfilepath=outdirectory / f"spectrum_ts{timestep:02.0f}_{tmids[timestep]:.2f}d.txt")
 
@@ -67,13 +75,16 @@ def write_flambda_spectra(modelpath: Path) -> None:
 def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     addarg_modelpath(parser, default=Path())
+    addarg_output(
+        parser, kind="folder", helptext="Folder for the spectrum files (default: the spectra folder of the model)"
+    )
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:
     """Write ARTIS spectra for each timestep to individual text files."""
     args = parse_cli_args(addargs, __doc__, args, argsraw, kwargs)
 
-    write_flambda_spectra(args.modelpath)
+    write_flambda_spectra(args.modelpath, outdirectory=args.outputfile)
 
 
 if __name__ == "__main__":

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -2568,3 +2568,9 @@ def test_a_missing_optional_package_gives_no_traceback(capsys: pytest.CaptureFix
     message = capsys.readouterr().err
     assert "This command needs nosuchpackage" in message
     assert "Traceback" not in message
+
+
+def test_writecomparisondata_rejects_an_empty_timestep_list(tmp_path: Path) -> None:
+    """An empty timestep list wrote files that hold a header and no data."""
+    with pytest.raises(ValueError, match="selected_timesteps"):
+        at.writecomparisondata.main(argsraw=[], modelpath=modelpath, outputpath=tmp_path, selected_timesteps=[])

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -267,7 +267,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     addarg_timedays(parser, kind="str")
 
-    addarg_timestep(parser, default=70)
+    addarg_timestep(parser, default="last")
 
     addarg_modelgridindex(parser, default=0)
 

--- a/artistools/writecomparisondata.py
+++ b/artistools/writecomparisondata.py
@@ -19,7 +19,8 @@ from artistools.misc import print_warning
 
 def write_spectra(modelpath: str | Path, selected_timesteps: Sequence[int], outfilepath: Path) -> None:
     """Write the spectra at the selected timesteps in code comparison workshop format."""
-    spec_data = np.loadtxt(at.zopen(at.firstexisting("spec.out", folder=modelpath, tryzipped=True)))
+    with at.zopen(at.firstexisting("spec.out", folder=modelpath, tryzipped=True)) as specfile:
+        spec_data = np.loadtxt(specfile)
 
     times = spec_data[0, 1:]
     freqs = spec_data[1:, 0]
@@ -217,6 +218,10 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     modelpathlist = args.modelpath
     selected_timesteps = args.selected_timesteps
+    if not selected_timesteps:
+        # for an empty list, the loop below writes a valid file with no rows. Raise an error before the loop
+        msg = "Give at least one timestep with -selected_timesteps"
+        raise ValueError(msg)
 
     args.outputfile.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## What changed

A review of the whole package at maximum effort found crashes, silently wrong numbers, stale caches, and slow paths. This PR corrects them and adds a regression test for each fix that a test can cover.

### Crashes and wrong numbers

- `plotdensity` gave every projection of `vel_r_mid` one name, thus polars raised `DuplicateError` for each 2D and 3D model. A regression from #619.
- `get_lambda_bin_edges` converted the `deltalambda` interval as a wavelength, which gave negative bin edges for a frequency or energy axis. Its log loop did not stop for a lower limit of zero.
- The band fit results of `viewingangleanalysis` went into one list and one file named after the first band. Each band now writes its own file, and the printed decline rate shows the stored (positive) sign.
- `plotspectra` indexed a direction bin definition that it did not build on the angle-averaged fallback. A bin inside an average group now gets a `ValueError` that names the valid bins, and not a bare `assert`.
- `plotnltepops` indexed the atomic level names with the level number of the superlevel, which is above every resolved level. The superlevel now gets its own label and parity.
- `get_runfolder_timesteps` indexed an empty list for a classic-mode estimator file.
- `writecomparisondata` wrote files with a header and no rows for an empty timestep list.
- `describeinputmodel -cell` printed the query plan in place of the cell.
- A nuclide with no ground-state beta decay in ENSDF fell out of the decay table, and the gitignored cache made that permanent. It now keeps the Hotokezaka value.
- `get_line_points` kept the weight of a cell with a null value in the divisor of the average.
- `plotinitialcomposition -floorval 0` read as no floor value.

### Estimator columns that are absent mean zero

- The read layer fills a null `deposition_`, `heating_`, or `cooling_` value with zero, because a cell that reports no channel had none of it. The heating ratio columns stay out, because a ratio of zero makes `gamma_dep` and `total_dep` a division by zero.
- The per-cell deposition sum no longer drops the other channels of a cell that reports one channel less. The `cellswithnorate` warning now describes the non-finite case that it detects.

### Caches

- The packets parquet cache took the change time of the last rank of a batch alone, thus a rewrite of any other rank served the previous run's packets. The newest file of every rank now decides, on the read side and on the write stamp, as the estimators cache already did.
- The model parquet cache stripped every suffix of the file name, thus `model_a.1.txt` and `model_a.2.txt` shared one cache. `model.txt` keeps its cache name.

### Slow paths

- The frames of a gif share one collected estimator frame (about 3 full scans per frame before).
- `plot_average_excitation` reads the NLTE files one time for every ion.
- `linefluxes` bins every feature in one `collect_all`.
- A multispec plot from packets reads the packets one time for the union of the arrival windows. The emission and escape time modes keep the read per panel, because their time correction is a mean over the frame.
- `plotradfield` reads each rank file one time for every cell.

### Messages and tests

- Two missing input files gave a bare `FileNotFoundError`, which the dispatcher reported as an internal fault of artistools.
- `get_spectra` and `writespectra` name the missing `spec.out`.
- Two `np.loadtxt(zopen(...))` calls now close the file.
- The default cell of `exportmassfractions` and the default timestep of `plottransitions` now exist on a small model.
- `writespectra` takes `-o`, thus its tests write to `tmp_path` and not into the shared test model folder. Three light curve tests no longer write one shared pdf. The tqdm lock test can now fail, and it restores the start method in every case.

## Notes for the reviewer

- Under the rule "an absent estimator channel is zero", the aggregation in `deposition.py` was already correct. The per-cell `ignore_nulls=False` contradicted the rule, and that is what changed. `test_deposition_rates_read_the_next_timestep` gains cell 3's alpha channel for that reason.
- `test_check_time_selection_reads_each_spelling_as_argparse_does` relied on `plottransitions` defaulting to timestep 70. It now builds its own parser with that default, because the property under test is `check_time_selection`.
- `decayproducts` has no new test, because the ENSDF branch needs the IAEA network service.

## Verification

- `ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`: clean.
- `pytest artistools -n auto`: 594 passed, 1 skipped, on the local `.venv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
