### PR TITLE
Simplify excitation input and correct packet source checks

### DIFF
--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -776,11 +776,7 @@ def read_estimators(
 
 
 def get_averageexcitation(
-    modelpath: Path | str,
-    atomic_number: int,
-    ion_stage: int,
-    dftexc: pl.LazyFrame,
-    dfnltepops: pl.DataFrame | None = None,
+    modelpath: Path | str, atomic_number: int, ion_stage: int, dftexc: pl.LazyFrame, dfnltepops: pl.LazyFrame
 ) -> pl.LazyFrame:
     """Return the population-weighted mean level excitation energy [eV] of an ion per timestep and cell.
 
@@ -788,10 +784,7 @@ def get_averageexcitation(
     the superlevel population over the levels that it replaces. dfnltepops holds the NLTE populations
     of every ion, which a caller that asks for several ions reads one time.
     """
-    if dfnltepops is None:
-        dfnltepops = at.nltepops.read_files(modelpath)
-
-    dfpops = dfnltepops.lazy().filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))
+    dfpops = dfnltepops.filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))
 
     adata = at.atomic.get_levels(modelpath)
     dfionlevels = adata.filter((pl.col("Z") == atomic_number) & (pl.col("ion_stage") == ion_stage))["levels"].item()

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -411,7 +411,7 @@ def plot_average_excitation(
         atomic_number, ion_stage = iontuple
 
         dfavgexc = at.estimators.get_averageexcitation(
-            modelpath, atomic_number, ion_stage, dftexc, dfnltepops=dfnltepops_allions
+            modelpath, atomic_number, ion_stage, dftexc, dfnltepops=dfnltepops_allions.lazy()
         )
 
         # weight the average by the ion population where it is available, as plot_average_ionisation

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -649,7 +649,7 @@ def test_get_averageexcitation() -> None:
     timestep = min(dfpops["timestep"].to_list())
     dftexc = pl.LazyFrame({"timestep": [timestep], "modelgridindex": [0], "T_exc": [6000.0]})
 
-    dfavgexc = at.estimators.get_averageexcitation(modelpath, 26, 2, dftexc).collect()
+    dfavgexc = at.estimators.get_averageexcitation(modelpath, 26, 2, dftexc, dfnltepops=dfpops.lazy()).collect()
     assert len(dfavgexc) == 1
 
     avgexc = dfavgexc["averageexcitation"].item()

--- a/artistools/packets/__init__.py
+++ b/artistools/packets/__init__.py
@@ -7,4 +7,5 @@ from artistools.packets.packets import bin_packet_directions_polars as bin_packe
 from artistools.packets.packets import filter_packets_dirbin as filter_packets_dirbin
 from artistools.packets.packets import get_directionbin as get_directionbin
 from artistools.packets.packets import get_packets as get_packets
+from artistools.packets.packets import get_packets_textsource_mtimes as get_packets_textsource_mtimes
 from artistools.packets.packets import get_virtual_packets as get_virtual_packets

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -1,6 +1,5 @@
 """Read ARTIS packets and virtual packets files, caching them as parquet, and bin them by viewing direction."""
 
-import contextlib
 import datetime
 import math
 import time
@@ -361,27 +360,6 @@ def get_vpackets_text_columns(vpacketsfiletext: Path) -> list[str]:
 CACHEVERSION = 1
 
 
-def get_packets_textsource_mtimes(modelpath: Path, virtual: bool) -> dict[int, float]:
-    """Return the change time of the packets text file of each rank, keyed by MPI rank.
-
-    One glob of the model folder and of each subfolder finds every rank, thus the check of a batch
-    does not walk the tree for each rank. The model folder wins over a subfolder, and the plain name
-    wins over a compressed one, as firstexisting decides.
-    """
-    prefix = "vpackets" if virtual else "packets00"
-    mtimes: dict[int, float] = {}
-    for folder in (modelpath, *sorted(child for child in modelpath.iterdir() if child.is_dir())):
-        ranks = {
-            int(textfile.name[len(prefix) + 1 : len(prefix) + 5]) for textfile in folder.glob(f"{prefix}_????.out*")
-        }
-        for rank in sorted(ranks - mtimes.keys()):
-            for suffix in ("", ".zst", ".gz", ".xz"):
-                with contextlib.suppress(FileNotFoundError):
-                    mtimes[rank] = (folder / f"{prefix}_{rank:04d}.out{suffix}").stat().st_mtime
-                    break
-    return mtimes
-
-
 def get_packets_rankbatch_parquetfile(
     modelpath: Path | str, batch_mpiranks: Sequence[int], batchindex: int, virtual: bool
 ) -> Path:
@@ -406,9 +384,13 @@ def get_packets_rankbatch_parquetfile(
         parquetstat = parquetfilepath.stat()
         # every file of the batch counts, thus the newest one decides the freshness. One rank file that a
         # restart rewrote then makes the whole batch cache stale
-        textsource_mtimes = get_packets_textsource_mtimes(modelpath, virtual)
-        if all(rank in textsource_mtimes for rank in batch_mpiranks):
-            textsource_mtime = max(textsource_mtimes[rank] for rank in batch_mpiranks)
+        textsource_mtimes = [
+            textpath.stat().st_mtime
+            for filename in text_filenames
+            if (textpath := at.firstexisting_or_none(filename, folder=modelpath)) is not None
+        ]
+        if len(textsource_mtimes) == len(batch_mpiranks):
+            textsource_mtime = max(textsource_mtimes)
 
             _, stalereason = read_parquet_cache_metadata(parquetfilepath, CACHEVERSION, textsource_mtime)
             if stalereason is None:

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -18,6 +18,7 @@ from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.misc import read_parquet_cache_metadata
+from artistools.misc.fileio import COMPRESSED_EXTENSIONS
 
 type_ids = {"TYPE_GAMMA": 10, "TYPE_RPKT": 11, "TYPE_NTLEPTON": 20, "TYPE_ESCAPE": 32}
 
@@ -360,6 +361,26 @@ def get_vpackets_text_columns(vpacketsfiletext: Path) -> list[str]:
 CACHEVERSION = 1
 
 
+def get_packets_textsource_mtimes(modelpath: Path, filenames: Sequence[str]) -> list[float]:
+    """Return source modification times with at most one scan of each folder."""
+    rootentries = list(modelpath.iterdir())
+    mtimes: dict[str, float] = {}
+    for folder in (modelpath, *(entry for entry in rootentries if entry.is_dir())):
+        entries = rootentries if folder == modelpath else folder.iterdir()
+        paths = {entry.name: entry for entry in entries}
+        for filename in filenames:
+            if filename in mtimes:
+                continue
+            # Use the same folder and compression order as the source reader.
+            for suffix in ("", *COMPRESSED_EXTENSIONS):
+                if (path := paths.get(f"{filename}{suffix}")) is not None and path.exists():
+                    mtimes[filename] = path.stat().st_mtime
+                    break
+        if len(mtimes) == len(filenames):
+            break
+    return list(mtimes.values())
+
+
 def get_packets_rankbatch_parquetfile(
     modelpath: Path | str, batch_mpiranks: Sequence[int], batchindex: int, virtual: bool
 ) -> Path:
@@ -384,11 +405,7 @@ def get_packets_rankbatch_parquetfile(
         parquetstat = parquetfilepath.stat()
         # every file of the batch counts, thus the newest one decides the freshness. One rank file that a
         # restart rewrote then makes the whole batch cache stale
-        textsource_mtimes = [
-            textpath.stat().st_mtime
-            for filename in text_filenames
-            if (textpath := at.firstexisting_or_none(filename, folder=modelpath)) is not None
-        ]
+        textsource_mtimes = get_packets_textsource_mtimes(modelpath, text_filenames)
         if len(textsource_mtimes) == len(batch_mpiranks):
             textsource_mtime = max(textsource_mtimes)
 

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -205,7 +205,8 @@ def test_readfile_text_drops_trailing_null_column(tmp_path: Path) -> None:
     assert dfpackets["mpirank"].to_list() == [0, 0, 0]
 
 
-def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path) -> None:
+@pytest.mark.parametrize("unrelated_filename", [None, "packets00_note.out"])
+def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path, unrelated_filename: str | None) -> None:
     """Every rank of a batch decides the freshness of its cache, and not the last rank alone."""
     import os
     import shutil
@@ -218,6 +219,9 @@ def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path) -> 
 
     parquetpath = get_packets_rankbatch_parquetfile(tmp_path, batch_mpiranks=[0, 1], batchindex=0, virtual=False)
     firstwrite = parquetpath.stat().st_mtime_ns
+
+    if unrelated_filename is not None:
+        (tmp_path / unrelated_filename).touch()
 
     # only the file of the first rank becomes newer, because a check of the last rank alone would miss it
     firstrankfile = tmp_path / "packets00_0000.out.zst"

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -1,5 +1,7 @@
 import math
+import os
 from pathlib import Path
+from unittest import mock
 
 import numpy as np
 import polars as pl
@@ -208,7 +210,6 @@ def test_readfile_text_drops_trailing_null_column(tmp_path: Path) -> None:
 @pytest.mark.parametrize("unrelated_filename", [None, "packets00_note.out"])
 def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path, unrelated_filename: str | None) -> None:
     """Every rank of a batch decides the freshness of its cache, and not the last rank alone."""
-    import os
     import shutil
 
     from artistools.packets.packets import get_packets_rankbatch_parquetfile
@@ -231,3 +232,59 @@ def test_packets_cache_goes_stale_when_any_rank_file_changes(tmp_path: Path, unr
     parquetpath = get_packets_rankbatch_parquetfile(tmp_path, batch_mpiranks=[0, 1], batchindex=0, virtual=False)
 
     assert parquetpath.stat().st_mtime_ns > firstwrite
+
+
+@pytest.mark.parametrize("virtual", [False, True])
+def test_packets_cache_scans_each_folder_once(tmp_path: Path, virtual: bool) -> None:
+    """Keep the number of directory scans independent of the number of ranks."""
+    from artistools.packets.packets import CACHEVERSION
+    from artistools.packets.packets import get_packets_rankbatch_parquetfile
+
+    sourcefolder = tmp_path / "run1"
+    sourcefolder.mkdir()
+    prefix = "vpackets" if virtual else "packets00"
+    sourcefiles = [sourcefolder / f"{prefix}_{rank:04d}.out" for rank in range(32)]
+    for sourcefile in sourcefiles:
+        sourcefile.touch()
+    packetkind = "vpackets" if virtual else "packets"
+    cachefolder = tmp_path / packetkind
+    cachefolder.mkdir()
+    cachepath = cachefolder / f"{packetkind}batch00_0000_0031.out.parquet.tmp"
+    at.write_parquet_atomic(
+        pl.DataFrame({"number": [0]}),
+        cachepath,
+        metadata={
+            "cacheversion": str(CACHEVERSION),
+            "textsource_mtime": str(max(path.stat().st_mtime for path in sourcefiles)),
+        },
+    )
+    firstwrite = cachepath.stat().st_mtime_ns
+
+    with mock.patch("os.scandir", wraps=os.scandir) as scandir:
+        result = get_packets_rankbatch_parquetfile(tmp_path, batch_mpiranks=range(32), batchindex=0, virtual=virtual)
+
+    assert result == cachepath
+    assert result.stat().st_mtime_ns == firstwrite
+    assert scandir.call_count <= 3
+
+
+def test_packets_source_index_matches_the_reader(tmp_path: Path) -> None:
+    """Use the source reader's order for folders and compressed files, and omit absent sources."""
+    sourcefolder = tmp_path / "run1"
+    sourcefolder.mkdir()
+    filenames = [f"packets00_{rank:04d}.out" for rank in (0, 1, 10000)]
+    paths = [
+        tmp_path / f"{filenames[0]}.gz",
+        sourcefolder / filenames[0],
+        sourcefolder / f"{filenames[1]}.gz",
+        sourcefolder / f"{filenames[1]}.zst",
+        sourcefolder / f"{filenames[2]}.xz",
+        sourcefolder / "packets00_note.out",
+    ]
+    for index, path in enumerate(paths):
+        path.touch()
+        os.utime(path, (1000 + index, 1000 + index))
+
+    mtimes = at.packets.get_packets_textsource_mtimes(tmp_path, [*filenames, "packets00_0002.out"])
+    expected = [at.firstexisting(filename, folder=tmp_path).stat().st_mtime for filename in filenames]
+    assert sorted(mtimes) == pytest.approx(sorted(expected))


### PR DESCRIPTION
The packet cache check failed when an unrelated file such as `packets00_note.out` was present. Match only requested source filenames, and use the shared compression suffix order. Keep one directory index per cache check, the check of every rank, and the cache fallback when a source file is absent.

Require callers of `get_averageexcitation` to supply population data as a lazy frame. Delete the optional file read, which only the test used. The plot still reads the population files once for all ions, and the test now uses its existing data.

Validation:

- Packet and estimator tests: 97 passed for the initial change on Python 3.14.7.
- All 12 packet tests passed after the review fix.
- The 32-rank subfolder regression used 96 directory scans before the review fix. It now uses at most three scans.
- Tests cover real packets, virtual packets, source precedence, absent files, unrelated filenames, and ranks above 9999.
- Ruff format, Ruff check, pyrefly, ty, and refurb passed after the review fix.
- The applicable repository hooks passed.
- Vulture reported six findings outside the changed code.
- The full test suite and Rust checks were not run because these changes affect Python packet and estimator code.
