### PR TITLE
Let each subplot set its own ion population type

### DIFF
--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -534,7 +534,7 @@ def plot_levelpop(
 
 # The plot directives that a plot item can carry, e.g. "-p rho yscale=log". The underscore of a name
 # is optional.
-DIRECTIVES = ("ymin", "ymax", "yscale")
+DIRECTIVES = ("ionpoptype", "ymin", "ymax", "yscale")
 
 # a series type groups the names that follow it, e.g. -plot averageionisation Fe Ni. Each one has its
 # own plot function in plot_subplot. An ion series needs no entry here, because the estimator columns
@@ -756,10 +756,15 @@ def plot_multi_ion_series(
     ionlist: Sequence[str],
     estimators: pl.LazyFrame,
     modelpath: str | Path,
+    poptype: str,
     args: argparse.Namespace,
     **plotkwargs: t.Any,
 ) -> SubplotItem:
-    """Return the series of an ion-specific property, e.g. populations."""
+    """Return the series of an ion-specific property, e.g. populations.
+
+    The poptype parameter sets the normalisation of a population series. Each subplot carries its own
+    value, thus one figure can show an absolute density in one subplot and an ion fraction in another.
+    """
     iontuplelist = [get_iontuple(ionstr) for ionstr in ionlist]
     iontuplelist.sort()
     print(f"Subplot with ions: {iontuplelist}")
@@ -798,29 +803,29 @@ def plot_multi_ion_series(
         expr_yvals = pl.col(colname)
         print(f"  plotting {seriestype} {ionstr.replace('_', ' ')}")
 
-        if seriestype != "populations" or args.poptype == "absolute":
+        if seriestype != "populations" or poptype == "absolute":
             expr_normfactor = pl.lit(1)
-        elif args.poptype == "elpop":
+        elif poptype == "elpop":
             elsymbol = at.get_elsymbol(atomic_number)
             expr_normfactor = pl.col(f"nnelement_{elsymbol}")
-        elif args.poptype == "totalpop":
+        elif poptype == "totalpop":
             expr_normfactor = pl.col("nntot")
-        elif args.poptype in {"radialdensity", "cylradialdensity"}:
+        elif poptype in {"radialdensity", "cylradialdensity"}:
             # get the volumetric number density to later be multiplied by the surface area of a sphere or cylinder
             expr_normfactor = pl.lit(1)
-        elif args.poptype == "cumulative":
+        elif poptype == "cumulative":
             expr_normfactor = pl.lit(1)
         else:
             raise AssertionError
 
         # convert the volumetric number density [cm^-3] to a radial density [cm^-1] with the radius of each cell
         expr_tmid_s = pl.col("tmid_days") * day_to_s
-        if args.poptype == "radialdensity":
+        if poptype == "radialdensity":
             expr_yvals *= 4 * math.pi * (pl.col("vel_r_mid") * expr_tmid_s).pow(2)
-        elif args.poptype == "cylradialdensity":
+        elif poptype == "cylradialdensity":
             expr_yvals *= 2 * math.pi * pl.col("vel_rcyl_mid") * expr_tmid_s
 
-        if args.poptype == "cumulative":
+        if poptype == "cumulative":
             # multiply each cell's number density by its volume before the sum, so the result is a particle count
             # the sum is over the cells of one timestep, thus it must restart at each timestep
             expr_yvals = (expr_yvals * pl.col("volume")).cum_sum().over("timestep")
@@ -877,9 +882,9 @@ def plot_multi_ion_series(
         )
 
     if seriestype == "populations":
-        ylabel = POPTYPE_YLABELS.get(args.poptype)
+        ylabel = POPTYPE_YLABELS.get(poptype)
         if ylabel is None:
-            msg = f"Unknown poptype: {args.poptype}"
+            msg = f"Unknown poptype: {poptype}"
             raise ValueError(msg)
         ax.set_ylabel(ylabel)
     else:
@@ -1103,6 +1108,8 @@ def plot_subplot(
     remaining_plotitems: list[t.Any] = []
     ymin, ymax = None, None
     yscalegiven = False
+    # the -ionpoptype argument gives the type for the whole figure. A directive of a subplot replaces it
+    poptype = args.poptype
     for plotitem in plotitems:
         if isinstance(plotitem, str | pl.Expr):
             remaining_plotitems.append(plotitem)
@@ -1133,6 +1140,15 @@ def plot_subplot(
 
         elif seriestype == "ymax":
             ymax = float(params)
+
+        elif seriestype == "ionpoptype":
+            poptype = str(params)
+            if poptype not in POPTYPE_YLABELS:
+                suggestion = suggest_names(poptype, POPTYPE_YLABELS)
+                exit_with_error(
+                    f"'{poptype}' is not an ion population type",
+                    f"{suggestion + ' ' if suggestion else ''}The types are {', '.join(POPTYPE_YLABELS)}",
+                )
 
         elif seriestype == "yscale":
             # the scale must be set before the data, so that the axis autoscales in the right space.
@@ -1201,6 +1217,7 @@ def plot_subplot(
                         ionlist=ionlist,
                         estimators=estimators,
                         modelpath=modelpath,
+                        poptype=poptype,
                         args=args,
                         **plotkwargs,
                     )
@@ -1406,18 +1423,22 @@ def addargs(parser: argparse.ArgumentParser) -> None:
             f"after it, e.g. -plot averageionisation Fe Ni. The types are {', '.join(SERIESTYPES)}, and "
             "an estimator that names an ion, e.g. -plot gamma_NT 'Fe II'. Quote an ion that holds "
             f"a space. The directives are {', '.join(f'{name}=' for name in DIRECTIVES)}, e.g. "
-            "-plot Te TR yscale=lin -plot rho yscale=log ymin=1e-17. The subplots share one horizontal "
-            "axis, thus -xmin and -xmax set that axis for the whole figure"
+            "-plot Te TR yscale=lin -plot rho yscale=log ymin=1e-17 -plot 'Fe II' 'Fe III' ionpoptype=elpop. "
+            "The directive ionpoptype= sets the normalisation of an ion population series to one of "
+            f"{', '.join(POPTYPE_YLABELS)}. The subplots share one horizontal axis, thus -xmin and -xmax set "
+            "that axis for the whole figure"
         ),
     )
 
+    # the ionpoptype= directive of a plot item replaces this argument, because each subplot holds its
+    # own type. The argument gives the type for the whole figure, thus an older script still runs
     parser.add_argument(
         "-ionpoptype",
         "-poptype",
         dest="poptype",
-        default="elpop",
+        default="absolute",
         choices=list(POPTYPE_YLABELS),
-        help="Plot absolute ion populations, or ion populations as a fraction of total or element population",
+        help=argparse.SUPPRESS,
     )
 
     addarg_nolegend(parser)

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -26,7 +26,8 @@ PLOTLIST_FULL: t.Final = (
     ["TR", ["_yscale", "linear"], ["_ymin", 1000], ["_ymax", 22000]],
     ["Te"],
     [["averageionisation", ["Fe", "Ni"]]],
-    [["populations", ["Fe I", "Fe II", "Fe III", "Fe IV", "Fe V"]]],
+    # one figure holds two ion population types, because the directive applies to one subplot only
+    [["populations", ["Fe I", "Fe II", "Fe III", "Fe IV", "Fe V"]], ["ionpoptype", "elpop"]],
     [["populations", ["Co II", "Co III", "Co IV"]]],
     [["gamma_NT", ["Fe I", "Fe II", "Fe III", "Fe IV"]]],
     ["heating_dep", "heating_coll", "heating_bf", "heating_ff", ["_yscale", "linear"]],
@@ -40,7 +41,7 @@ PLOTLIST_IONS: t.Final = (
     ["TR", ["_yscale", "linear"], ["_ymin", 1000], ["_ymax", 22000]],
     ["Te"],
     [["averageionisation", ["Fe"]]],
-    [["populations", ["Fe I", "Fe II", "Fe III", "Fe IV", "Fe V"]]],
+    [["populations", ["Fe I", "Fe II", "Fe III", "Fe IV", "Fe V"]], ["ionpoptype", "elpop"]],
     [["populations", ["Co II", "Co III", "Co IV"]]],
     ["heating_dep", "heating_coll", "heating_bf", "heating_ff", ["_yscale", "linear"]],
     ["cooling_adiabatic", "cooling_coll", "cooling_fb", "cooling_ff", ["_yscale", "linear"]],
@@ -141,9 +142,10 @@ def test_estimator_snapshot(mockplot: mock.MagicMock) -> None:
         "populations_FeIII": 0.3951266859004141,
         "populations_FeIV": 0.21184950941623004,
         "populations_FeV": 0.042194644079016,
-        "populations_CoII": 0.10471832570699871,
-        "populations_CoIII": 0.476333358337709,
-        "populations_CoIV": 0.41894831595529214,
+        # the Co subplot takes the default ionpoptype of absolute, thus it gives a number density
+        "populations_CoII": 2792.0,
+        "populations_CoIII": 12700.0,
+        "populations_CoIV": 11170.0,
         "gamma_NT_FeI": 7.571e-06,
         "gamma_NT_FeII": 3.711e-06,
         "gamma_NT_FeIII": 2.762e-06,
@@ -205,9 +207,10 @@ def test_estimator_averaging(mockplot: mock.MagicMock) -> None:
         "populations_FeIII": 0.39508678896764393,
         "populations_FeIV": 0.21220745115264195,
         "populations_FeV": 0.042389615364484115,
-        "populations_CoII": 0.1044248111887582,
-        "populations_CoIII": 0.4759472294613869,
-        "populations_CoIV": 0.419627959349855,
+        # the Co subplot takes the default ionpoptype of absolute, thus it gives a number density
+        "populations_CoII": 2891.245944314228,
+        "populations_CoIII": 13177.379472537568,
+        "populations_CoIV": 11617.863948679813,
         "gamma_NT_FeI": 7.741022037400234e-06,
         "gamma_NT_FeII": 3.7947153292832773e-06,
         "gamma_NT_FeIII": 2.824587987164586e-06,
@@ -261,9 +264,10 @@ def test_estimator_snapshot_classic_3d(mockplot: mock.MagicMock) -> None:
         "populations_FeIII": 0.06814975291490555,
         "populations_FeIV": 0.8073020577430725,
         "populations_FeV": 0.12433895468711853,
-        "populations_CoII": 0.16990603506565094,
-        "populations_CoIII": 0.2491680532693863,
-        "populations_CoIV": 0.5809222459793091,
+        # the Co subplot takes the default ionpoptype of absolute, thus it gives a number density
+        "populations_CoII": 258420.234375,
+        "populations_CoIII": 3356819.75,
+        "populations_CoIV": 1119509120.0,
         "heating_dep": 2.559114818723174e-06,
         "heating_coll": 0.0002118289703503251,
         "heating_bf": 2.1746404854638968e-06,
@@ -287,9 +291,9 @@ def test_estimator_snapshot_classic_3d(mockplot: mock.MagicMock) -> None:
         "populations_FeIII": 0.2204248011112213,
         "populations_FeIV": 0.31659460067749023,
         "populations_FeV": 0.261174738407135,
-        "populations_CoII": 0.36840304732322693,
-        "populations_CoIII": 0.38466954231262207,
-        "populations_CoIV": 0.457830548286438,
+        "populations_CoII": 2369084.0,
+        "populations_CoIII": 19128034.0,
+        "populations_CoIV": 4299308032.0,
         "heating_dep": 2.440772732370533e-05,
         "heating_coll": 0.004782144911587238,
         "heating_bf": 4.8423054977320135e-05,
@@ -421,9 +425,10 @@ def test_estimator_snapshot_classic_3d_x_axis(mockplot: mock.MagicMock) -> None:
         "populations_FeIII": 7.15164795263741e-05,
         "populations_FeIV": 0.47807180327557336,
         "populations_FeV": 0.5218229725433048,
-        "populations_CoII": 0.166666736471993,
-        "populations_CoIII": 0.015291374246013826,
-        "populations_CoIV": 0.8180049657821655,
+        # the Co subplot takes the default ionpoptype of absolute, thus it gives a number density
+        "populations_CoII": 5.306875965916498,
+        "populations_CoIII": 387430.00000003097,
+        "populations_CoIV": 12652086816.000006,
         "heating_dep": 2.2832464959235988e-14,
         "heating_coll": 0.0,
         "heating_bf": 7.490066713015075e-16,
@@ -1024,6 +1029,62 @@ def test_estimator_directive_underscore_is_optional(prefix: str, capsys: pytest.
     # exit_with_error writes to the standard error and then raises SystemExit, thus a rejected directive
     # would already have ended this test. Read the scale that the directive asked for instead
     assert not capsys.readouterr().err
+
+
+@mock.patch.object(mplax.Axes, "set_ylabel", side_effect=mplax.Axes.set_ylabel, autospec=True)
+def test_estimator_ionpoptype_is_local_to_a_subplot(mockylabel: mock.MagicMock) -> None:
+    """Each subplot carries its own ion population type, thus one figure holds more than one of them."""
+    from artistools.estimators.plotestimators import POPTYPE_YLABELS
+
+    at.estimators.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        outputfile=outputpath,
+        timedays=260,
+        plotlist=[
+            [["populations", ["Fe II", "Fe III"]], ["ionpoptype", "absolute"]],
+            [["populations", ["Fe II", "Fe III"]], ["ionpoptype", "elpop"]],
+        ],
+    )
+
+    labels = {call.args[1] for call in mockylabel.call_args_list if len(call.args) >= 2}
+    assert POPTYPE_YLABELS["absolute"] in labels
+    assert POPTYPE_YLABELS["elpop"] in labels
+
+
+@mock.patch.object(mplax.Axes, "set_ylabel", side_effect=mplax.Axes.set_ylabel, autospec=True)
+def test_estimator_ionpoptype_default_is_absolute(mockylabel: mock.MagicMock) -> None:
+    """A population series with no directive gives an absolute number density."""
+    from artistools.estimators.plotestimators import POPTYPE_YLABELS
+
+    at.estimators.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        outputfile=outputpath,
+        timedays=260,
+        plotlist=[[["populations", ["Fe II", "Fe III"]]]],
+    )
+
+    labels = {call.args[1] for call in mockylabel.call_args_list if len(call.args) >= 2}
+    assert POPTYPE_YLABELS["absolute"] in labels
+    assert POPTYPE_YLABELS["elpop"] not in labels
+
+
+def test_estimator_unknown_ionpoptype_names_the_valid_ones(capsys: pytest.CaptureFixture[str]) -> None:
+    """An unknown ion population type must stop the command. The message must name the valid types."""
+    with pytest.raises(SystemExit) as excinfo:
+        at.estimators.plot(
+            argsraw=[],
+            modelpath=modelpath,
+            outputfile=outputpath,
+            timedays=260,
+            plotlist=[[["populations", ["Fe II"]], ["ionpoptype", "elpops"]]],
+        )
+
+    assert excinfo.value.code == 1
+    message = capsys.readouterr().err
+    assert "elpops" in message
+    assert "elpop" in message
 
 
 def test_estimator_xmin_is_a_figure_argument_and_not_a_directive(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## What changed

`ionpoptype` becomes a plot directive, thus each subplot holds its own type. It joins `ymin=`, `ymax=`, and `yscale=` in `DIRECTIVES`.

- `plot_subplot` reads the directive and gives the value to `plot_multi_ion_series`, which now takes a `poptype` parameter in place of `args.poptype`.
- An unknown value stops the command and names the valid types, e.g. `'elpops' is not an ion population type` and `Did you mean elpop? The types are absolute, elpop, totalpop, radialdensity, cylradialdensity, cumulative`.
- The default becomes `absolute`, which was `elpop`.

```sh
artistools plotestimators -modelpath tests/data/testmodel -timedays 300 \
  -p 'Fe II' 'Fe III' -p 'Fe II' 'Fe III' ionpoptype=elpop
```

## Why

The `-ionpoptype` argument gave one type to the whole figure. Thus a figure of many subplots could not show an absolute number density in one subplot and an ion fraction in another.

## For the reviewer

**The default changes the values that a population subplot draws.** A command that gives no type now draws a number density and not a fraction of the element population. A user who wants the old result writes `ionpoptype=elpop` on that subplot.

**The `-ionpoptype` argument stays.** It gives the type for the whole figure, and it now carries `help=argparse.SUPPRESS`. An older script that holds `-ionpoptype elpop` still runs, and the help text gives one spelling, which is the directive.

**The reference values of four tests change.** The two shared plot lists give `ionpoptype=elpop` to the Fe subplot and let the Co subplot take the new default. One figure thus covers both paths, and the Co values become number densities.

Three new tests cover the directive:

- `test_estimator_ionpoptype_is_local_to_a_subplot` draws two subplots of different types in one figure and reads both y labels.
- `test_estimator_ionpoptype_default_is_absolute` reads the y label of a subplot that gives no directive.
- `test_estimator_unknown_ionpoptype_names_the_valid_ones` reads the error message.

## Checks

From the repository root: `ruff format`, `ruff check --no-fix`, `pyrefly check`, `ty check`, `refurb`, `vulture` (three pre-existing reports only), `prek run --all-files`, and `pytest -n auto` (625 passed, 1 skipped). The change touches no Rust, thus `cargo clippy` did not run.

The `-plot` help text holds more sentences than ASD-STE100 permits. That paragraph was already too long before this change, and this change adds one sentence to it. A separate change can make it a vertical list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)