### PR TITLE
Let an estimator that gives a total also take the ions after it

### DIFF
--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -581,8 +581,8 @@ def is_ionseriestype(name: t.Any, estimatorcolumns: Collection[str], params: Seq
         return False
 
     # A column of one of the ions proves the reading, also for a name that is a variable of its own.
-    # The test takes one column and not every column, because an element can lose its top ion here,
-    # e.g. gamma_NT_Fe_V of a model that holds Fe I to Fe V.
+    # The test takes one column and not every column. An element can lose its top ion here, e.g. a
+    # model that holds Fe I to Fe V has no gamma_NT_Fe_V.
     if any(get_column_name(name, *get_iontuple(param))[0] in estimatorcolumns for param in params):
         return True
 
@@ -815,6 +815,18 @@ def plot_multi_ion_series(
         print_warning(f"Can't plot {seriestype} for {missingions} because these ions are not in compositiondata.txt")
 
     iontuplelist = [iontuple for iontuple in iontuplelist if iontuple not in missingions]
+
+    # An ion of the model can still have no column of this series. The top ion of an element has no
+    # gamma_NT and no bound-free cooling. Drop such an ion here, so that the plot gives the others.
+    estimatorcolumns = estimators.collect_schema().names()
+    nocolumnions = {
+        iontuple for iontuple in iontuplelist if get_column_name(seriestype, *iontuple)[0] not in estimatorcolumns
+    }
+    if nocolumnions:
+        print_warning(f"Can't plot {seriestype} for {nocolumnions} because the estimators hold no such column")
+
+    iontuplelist = [iontuple for iontuple in iontuplelist if iontuple not in nocolumnions]
+
     lazyframes = []
     for atomic_number, ion_stage in iontuplelist:
         colname, ionstr = get_column_name(seriestype, atomic_number, ion_stage)

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -568,14 +568,27 @@ def is_ionseriestype(name: t.Any, estimatorcolumns: Collection[str], params: Seq
     An estimator that names an ion, e.g. gamma_NT_Fe_II, gives the series type gamma_NT. Every name
     after it must be an ion, because a name such as "heating" is also the prefix of heating_coll, and
     "heating coll" must keep the message that names the column.
+
+    A type of series can also be a variable of its own. cooling_coll holds the cooling rate of the
+    whole cell, and cooling_coll_Fe_II holds the part of one ion. A column of one of the named ions
+    then proves the reading. A subplot of the total alone takes its own -plot, e.g.
+    -plot cooling_coll -plot cooling_coll "Fe II".
     """
-    if not isinstance(name, str) or name in estimatorcolumns or not params:
+    if not isinstance(name, str) or not params:
         return False
 
     if not all(isinstance(param, str) and is_valid_ion(param) for param in params):
         return False
 
-    return any(col.startswith(f"{name}_") for col in estimatorcolumns)
+    # A column of one of the ions proves the reading, also for a name that is a variable of its own.
+    # The test takes one column and not every column, because an element can lose its top ion here,
+    # e.g. gamma_NT_Fe_V of a model that holds Fe I to Fe V.
+    if any(get_column_name(name, *get_iontuple(param))[0] in estimatorcolumns for param in params):
+        return True
+
+    # A name that gives no variable of its own keeps the older and looser test, which asks only that
+    # the model holds the family. Such a name has no other reading, thus it needs no column here.
+    return name not in estimatorcolumns and any(col.startswith(f"{name}_") for col in estimatorcolumns)
 
 
 # The subplots share one horizontal axis, thus no directive can set it for one subplot alone. The
@@ -1520,7 +1533,10 @@ def addargs(parser: argparse.ArgumentParser) -> None:
             "of series with the names that it covers, or a directive of the form key=value. Examples: "
             "-plot Te TR -plot nne -plot SrI 'Sr II'. A type of series comes first and groups the names "
             f"after it, e.g. -plot averageionisation Fe Ni. The types are {', '.join(SERIESTYPES)}, and "
-            "an estimator that names an ion, e.g. -plot gamma_NT 'Fe II'. Quote an ion that holds "
+            "an estimator that names an ion, e.g. -plot gamma_NT 'Fe II' or -plot cooling_coll 'Fe II'. "
+            "A name that also gives a total of the cell, e.g. cooling_coll, gives the ions when the "
+            "model holds a column for one of them. Give the total its own subplot, e.g. -plot "
+            "cooling_coll -plot cooling_coll 'Fe II'. Quote an ion that holds "
             f"a space. The directives are {', '.join(f'{name}=' for name in DIRECTIVES)}, e.g. "
             "-plot Te TR yscale=lin -plot rho yscale=log ymin=1e-17 -plot 'Fe II' 'Fe III' ionpoptype=elpop. "
             "The directive ionpoptype= sets the normalisation of an ion population series to one of "

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -631,6 +631,30 @@ def test_estimator_default_plotlist_skips_absent_elements(mockplot: mock.MagicMo
 
 
 @mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_estimator_ion_series_skips_an_ion_with_no_column(mockplot: mock.MagicMock) -> None:
+    """An ion of the model can have no column of a series, e.g. the top ion has no gamma_NT.
+
+    testmodel holds Fe V as an ion but writes no gamma_NT_Fe_V. The plot took the ion from
+    compositiondata.txt and then asked polars for that column, which raised ColumnNotFoundError.
+    """
+    funcoutpath = outputpath / "test_estimator_ion_series_skips_an_ion_with_no_column"
+    funcoutpath.mkdir(exist_ok=True, parents=True)
+
+    at.estimators.plot(
+        argsraw=[],
+        modelpath=modelpath,
+        timedays=300,
+        outputfile=funcoutpath,
+        plotlist=[[["gamma_NT", ["Fe IV", "Fe V"]]]],
+    )
+
+    # Fe IV holds a column and Fe V does not, thus one line reaches the plot
+    assert len(mockplot.call_args_list) == 1
+    yvalues = np.array(mockplot.call_args_list[0][0][2], dtype=float)
+    assert np.all(np.isfinite(yvalues))
+
+
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
 def test_estimator_levelpopulation_dn_on_dvel(mockplot: mock.MagicMock) -> None:
     """Plotting dN/dv needs the inner shell velocity, which is a derived model column."""
     funcoutpath = outputpath / "test_estimator_levelpopulation_dn_on_dvel"

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -2188,6 +2188,42 @@ def test_plot_argument_takes_a_grouped_series_type() -> None:
     assert normalise_plotitems(["Fe I", "Fe II"], estimatorcolumns) == [["populations", ["Fe I", "Fe II"]]]
 
 
+def test_plot_argument_takes_ions_of_a_variable_that_is_also_a_total() -> None:
+    """A name that gives a total of the cell must still take the ions after it.
+
+    The estimators file holds cooling_coll for the whole cell and cooling_coll_Fe_II for one ion.
+    "-plot cooling_coll 'Fe II'" gave the error that 'Fe II' is not an estimator variable, because
+    the test for an ion series rejected every name that is a column.
+    """
+    from artistools.estimators.plotestimators import normalise_plotitems
+
+    estimatorcolumns = [
+        "Te",
+        "nne",
+        "cooling_coll",
+        "cooling_coll_Fe_II",
+        "cooling_coll_Fe_III",
+        "nnion_Fe_II",
+        "vel_r_mid",
+        "vel_r_mid_kmps",
+    ]
+
+    assert normalise_plotitems(["cooling_coll", "Fe II", "Fe III"], estimatorcolumns) == [
+        ["cooling_coll", ["Fe II", "Fe III"]]
+    ]
+
+    # one column of the family is enough, because an element can lose its top ion here
+    assert normalise_plotitems(["cooling_coll", "Fe II", "Fe X"], estimatorcolumns) == [
+        ["cooling_coll", ["Fe II", "Fe X"]]
+    ]
+
+    # the total alone keeps its own shape
+    assert normalise_plotitems(["cooling_coll"], estimatorcolumns) == ["cooling_coll"]
+
+    # vel_r_mid starts vel_r_mid_kmps, which no ion names, thus the ions give no series here
+    assert normalise_plotitems(["vel_r_mid", "Fe II"], estimatorcolumns) == ["vel_r_mid", "Fe II"]
+
+
 def test_plot_argument_rejects_a_series_type_with_no_names() -> None:
     """A type of series covers the names after it, thus it must not stand alone."""
     from artistools.estimators.plotestimators import normalise_plotitems


### PR DESCRIPTION
## The defect

The estimators file can hold one name as a total of the cell and as a value of each ion. The ARTIS
option `WRITE_ION_HEATING_COOLING_RATES` ([artis-mcrt/artis#581](https://github.com/artis-mcrt/artis/pull/581))
writes `cooling_coll` for the whole cell and `cooling_coll_Fe_II` for one ion.

`is_ionseriestype()` rejected every name that is a column of its own, thus the shorthand gave an
error:

```
$ artistools plotestimators -p cooling_coll 'Fe II' .
error: 'Fe II' is not an estimator variable
```

The same holds for `heating_bf`, `heating_coll`, `heating_ff`, `cooling_ff`, and `cooling_fb`. The
full column name was the only form that worked, e.g. `-p cooling_coll_Fe_II`.

## The correction

The test now asks for a column of one of the named ions, e.g. `cooling_coll_Fe_II`. That column
proves the reading, so the name can also give a total. A name that gives no variable of its own
keeps the older and looser test, thus `gamma_NT`, `gammaestimator`, and the other families do not
change.

Two points that the comments in the code also give:

- The test takes one column and not every column, because an element can lose its top ion here,
  e.g. `gamma_NT_Fe_V` of a model that holds Fe I to Fe V.
- A name that starts other columns that no ion names stays a plain variable, e.g. `vel_r_mid` with
  `vel_r_mid_kmps`.

The help text of `-plot` names the new form and says that the total takes its own subplot.

## Tests

`test_plot_argument_takes_ions_of_a_variable_that_is_also_a_total` covers the four cases above.
All 118 tests of `artistools/estimators` pass, and ruff, pyrefly, ty, and refurb give no message.

A run of the ARTIS `nebular_1d_3dgrid` test with the new option confirms the plot:

```
$ artistools plotestimators -x timestep -modelgridindex 0 -p cooling_coll 'Fe II' 'Fe III' 'Ni III' .
Subplot: [['cooling_coll', ['Fe II', 'Fe III', 'Ni III']]]
  plotting cooling_coll Fe II
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)