### PR TITLE
Correct the defects from the codebase review, and make the large-model commands faster

### DIFF
--- a/artistools/_polarscompat.py
+++ b/artistools/_polarscompat.py
@@ -37,14 +37,14 @@ _DISPATCH_CLASSES: tuple[type, ...] = (
 )
 
 
-def _is_empty_method(func: Callable[..., pl.Series]) -> bool:
+def is_empty_method(func: Callable[..., pl.Series]) -> bool:
     """Report whether a polars method is a stub whose body is nothing but a docstring."""
     # matching an empty function's bytecode already implies a body that only returns None, so unlike
     # polars' own check there is nothing left to confirm in the version-dependent co_consts
     return isinstance(func, FunctionType) and func.__code__.co_code in plseriesutils._EMPTY_BYTECODE  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
 
 
-def _dispatch_is_working() -> bool:
+def dispatch_is_working() -> bool:
     """Report whether polars rebound its stubs, by calling a Series method it never implements itself."""
     # the type stubs promise a Series, so cast away the lie that an unrepaired stub returns one
     return t.cast("object", pl.Series("x", [1]).unique()) is not None
@@ -52,18 +52,18 @@ def _dispatch_is_working() -> bool:
 
 def repair_series_expr_dispatch() -> None:
     """Rebind polars' unimplemented Series methods to their Expr equivalents if polars itself failed to."""
-    if _dispatch_is_working():
+    if dispatch_is_working():
         return
 
     # expr_dispatch reads _is_empty_method as a module global, so swap it only for the rebinding pass
     original = plseriesutils._is_empty_method  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
-    plseriesutils._is_empty_method = _is_empty_method  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]  # ty:ignore[invalid-assignment]
+    plseriesutils._is_empty_method = is_empty_method  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]  # ty:ignore[invalid-assignment]
     try:
         for cls in _DISPATCH_CLASSES:
             plseriesutils.expr_dispatch(cls)
     finally:
         plseriesutils._is_empty_method = original  # ruff:ignore[private-member-access]  # pyright: ignore[reportPrivateUsage]
 
-    if not _dispatch_is_working():
+    if not dispatch_is_working():
         msg = "failed to restore the polars Series methods that polars leaves unimplemented on this Python version"
         raise RuntimeError(msg)

--- a/artistools/atomic/_atomic_core.py
+++ b/artistools/atomic/_atomic_core.py
@@ -492,7 +492,7 @@ def get_z_a_nucname(nucname: str) -> tuple[int, int]:
         nucname = nucname.split("_")[1]
 
     z = get_atomic_number(nucname.rstrip(string.digits))
-    assert z > 0
+    assert z >= 0, f"{nucname} does not start with an element symbol"
 
     a = int(nucname.lower().lstrip(string.ascii_lowercase))
 
@@ -579,7 +579,12 @@ def get_atomic_number(elsymbol: str) -> int:
     elsymbol = elsymbol.split("_")[0].split("-")[0].rstrip(string.digits)
 
     # a dict lookup, because this is called once per column name in some loops
-    return get_atomic_number_of_elsymbol().get(elsymbol.title(), -1)
+    atomic_number_of_elsymbol = get_atomic_number_of_elsymbol()
+    if elsymbol in atomic_number_of_elsymbol:
+        # the exact symbol comes first, because the neutron "n" and nitrogen "N" differ only in case
+        return atomic_number_of_elsymbol[elsymbol]
+
+    return atomic_number_of_elsymbol.get(elsymbol.title(), -1)
 
 
 ROMANNUMERALCHARS = frozenset("IVXLCDM")

--- a/artistools/codecomparison.py
+++ b/artistools/codecomparison.py
@@ -72,7 +72,7 @@ def get_timestep_times(modelpath: Path | str, loc: t.Literal["start", "mid", "en
 
 
 def read_reference_estimators(modelpath: str | Path) -> dict[tuple[int, int], t.Any]:
-    """Read every cell and timestep of a code comparison workshop file.
+    """Read every cell and timestep of a file from the code comparison workshop.
 
     The caller filters the result. This function always parses the whole phys file.
     """

--- a/artistools/codecomparison.py
+++ b/artistools/codecomparison.py
@@ -7,7 +7,6 @@ e.g., codecomparison/DDC10/artisnebular
 
 import math
 import typing as t
-from collections.abc import Sequence
 from pathlib import Path
 
 import matplotlib.axes as mplax
@@ -47,12 +46,17 @@ def get_timestep_times(modelpath: Path | str, loc: t.Literal["start", "mid", "en
         tmids = read_header_times(fphys)
 
     tstarts = np.zeros_like(tmids)
-    tstarts[1:] = (tmids[1:] + tmids[:-1]) / 2.0
-    tstarts[0] = tmids[0] - (tstarts[1] - tmids[0])
-
     tends = np.zeros_like(tmids)
-    tends[:-1] = (tmids[:-1] + tmids[1:]) / 2.0
-    tends[-1] = tmids[-1] + (tmids[-1] - tstarts[-1])
+    if len(tmids) == 1:
+        # one epoch gives no neighbour to halve the gap with, thus the epoch alone sets the bounds
+        tstarts[0] = tmids[0]
+        tends[0] = tmids[0]
+    else:
+        tstarts[1:] = (tmids[1:] + tmids[:-1]) / 2.0
+        tstarts[0] = tmids[0] - (tstarts[1] - tmids[0])
+
+        tends[:-1] = (tmids[:-1] + tmids[1:]) / 2.0
+        tends[-1] = tmids[-1] + (tmids[-1] - tstarts[-1])
 
     if loc == "mid":
         return list(tmids)
@@ -67,12 +71,11 @@ def get_timestep_times(modelpath: Path | str, loc: t.Literal["start", "mid", "en
     raise ValueError(msg)
 
 
-def read_reference_estimators(
-    modelpath: str | Path,
-    modelgridindex: int | Sequence[int] | None = None,  # ruff:ignore[unused-function-argument]
-    timestep: int | Sequence[int] | None = None,  # ruff:ignore[unused-function-argument]
-) -> dict[tuple[int, int], t.Any]:
-    """Read estimators from code comparison workshop file."""
+def read_reference_estimators(modelpath: str | Path) -> dict[tuple[int, int], t.Any]:
+    """Read every cell and timestep of a code comparison workshop file.
+
+    The caller filters the result. This function always parses the whole phys file.
+    """
     inputmodelfolder, inputmodel, codename = split_codecomparison_path(modelpath)
 
     physfilepath = Path(inputmodelfolder, f"phys_{inputmodel}_{codename}.txt")
@@ -139,9 +142,12 @@ def read_reference_estimators(
                     _nvel = int(row[1])
 
                 elif row[0] == "#vel_mid[km/s]":
-                    row = [
-                        s for s in line.split("  ") if s
-                    ]  # need a double space because some ion columns have a space
+                    # a column name of some codes holds a space, e.g. "Fe 2", thus a double space
+                    # separates the columns. A header whose names hold no space uses single spaces,
+                    # which is what write_ionfracts gives
+                    row = [s for s in line.split("  ") if s]
+                    if len(row) == 1:
+                        row = line.split()
                     iontuples = []
                     ion_startnumber = None
                     for ionstr in row[1:]:

--- a/artistools/ejectaopacity.py
+++ b/artistools/ejectaopacity.py
@@ -50,7 +50,7 @@ def get_binned_opacities_ion(
             # the last bin, not into an out-of-range category with the index -1
             pl
             .col("lambda_angstroms")
-            .cut(breaks=list(lambda_bin_edges[1:-1]))
+            .cut(breaks=lambda_bin_edges[1:-1])
             .to_physical()
             .cast(pl.Int32)
             .alias("lambda_angstroms_binindex")

--- a/artistools/ejectaopacity.py
+++ b/artistools/ejectaopacity.py
@@ -46,9 +46,14 @@ def get_binned_opacities_ion(
         .with_columns(B_ul=C_cm_per_s**2 / 2 / h_erg_s / pl.col("nu_trans").pow(3) * pl.col("A"))
         .with_columns(B_lu=pl.col("upper_g") / pl.col("lower_g") * pl.col("B_ul"))
         .with_columns(
-            (pl.col("lambda_angstroms").cut(breaks=lambda_bin_edges).to_physical().cast(pl.Int32) - 1).alias(
-                "lambda_angstroms_binindex"
-            )
+            # give cut only the interior edges. A line at an outer edge then falls into the first or
+            # the last bin, not into an out-of-range category with the index -1
+            pl
+            .col("lambda_angstroms")
+            .cut(breaks=list(lambda_bin_edges[1:-1]))
+            .to_physical()
+            .cast(pl.Int32)
+            .alias("lambda_angstroms_binindex")
         )
         .join(dfcells.select("modelgridindex", "rho"), how="cross", maintain_order="left")
         .join(

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -921,9 +921,10 @@ def superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupc
 
         dfsuperlevel_thislevel = dfsuperlevel.filter(pl.col("levelnumber_sl") == levelnumber_sl)
 
-        # the cross join makes one row for each pair of superlevel row and level above it. A 3D model
-        # with 100k NLTE cells and a few hundred levels would need tens of GB, thus each query takes
-        # a batch of the superlevel rows. Each row is one group, thus a batch never splits a group
+        # the cross join makes one row for each pair of superlevel row and level above it. A 3D
+        # model with 100k NLTE cells and a few hundred levels would need tens of GB. Thus each
+        # query takes a batch of the superlevel rows. Each row is one group, thus a batch never
+        # splits a group
         batchheight = max(1, maxcrossrows // dflevels_above.height)
         contributions.extend(
             dfsuperlevel_thislevel

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -716,9 +716,7 @@ def scan_estimators(
     is_codecomparison = path_is_codecomparison(modelpath)
 
     if is_codecomparison:
-        pldflazy = lazyframe_from_estimator_dict(
-            at.codecomparison.read_reference_estimators(modelpath, timestep=timestep, modelgridindex=modelgridindex)
-        )
+        pldflazy = lazyframe_from_estimator_dict(at.codecomparison.read_reference_estimators(modelpath))
     elif classicartis:
         from artistools.estimators.estimators_classic import read_classic_estimators
 

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -3,7 +3,6 @@
 Examples are temperatures, populations, and heating/cooling rates.
 """
 
-import contextlib
 import dataclasses as dc
 import datetime
 import string
@@ -26,6 +25,7 @@ from artistools.constants import K_B_ev_per_K
 from artistools.misc import path_is_codecomparison
 from artistools.misc import print_warning
 from artistools.misc import read_parquet_cache_metadata
+from artistools.misc.fileio import firstexisting_or_none
 from artistools.misc.fileio import format_mtime
 from artistools.misc.fileio import MTIME_TOLERANCE_S
 from artistools.misc.fileio import parquet_is_readable
@@ -399,13 +399,19 @@ def get_textsource_mtimes(folderpath: Path | str) -> dict[int, float]:
     estimators_0000.out.bak beside estimators_0000.out, thus cannot decide the freshness.
     """
     folderpath = Path(folderpath)
-    ranks = {int(textfile.name.split("_")[1].split(".")[0]) for textfile in folderpath.glob("estimators_????.out*")}
+    # ARTIS pads the rank to a minimum width of four, thus a rank of 10000 or more has more digits
+    ranks = {
+        int(rankstr)
+        for rankstr in (textfile.name.split("_")[1].split(".")[0] for textfile in folderpath.glob("estimators_*.out*"))
+        if rankstr.isdigit()
+    }
     mtimes: dict[int, float] = {}
     for rank in sorted(ranks):
-        for suffix in ("", ".zst", ".gz", ".xz"):
-            with contextlib.suppress(FileNotFoundError):
-                mtimes[rank] = (folderpath / f"estimators_{rank:04d}.out{suffix}").stat().st_mtime
-                break
+        rankfile = firstexisting_or_none(
+            f"estimators_{rank:04d}.out", folder=folderpath, tryzipped=True, search_subfolders=False
+        )
+        if rankfile is not None:
+            mtimes[rank] = rankfile.stat().st_mtime
     return mtimes
 
 
@@ -943,6 +949,10 @@ def superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupc
     if dfsuperlevel.is_empty():
         return pl.DataFrame(schema=schema)
 
+    # the largest number of rows that one cross join may make. The batch loop below keeps the peak
+    # memory near this value, whatever the cell count of the model
+    maxcrossrows = 2_000_000
+
     # levelnumber_sl is the same for every cell in practice, so this loops once
     contributions = []
     for levelnumber_sl in dfsuperlevel["levelnumber_sl"].unique().sort():
@@ -950,9 +960,15 @@ def superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupc
         if dflevels_above.is_empty():
             continue
 
-        contributions.append(
-            dfsuperlevel
-            .filter(pl.col("levelnumber_sl") == levelnumber_sl)
+        dfsuperlevel_thislevel = dfsuperlevel.filter(pl.col("levelnumber_sl") == levelnumber_sl)
+
+        # the cross join makes one row for each pair of superlevel row and level above it. A 3D model
+        # with 100k NLTE cells and a few hundred levels would need tens of GB, thus each query takes
+        # a batch of the superlevel rows. Each row is one group, thus a batch never splits a group
+        batchheight = max(1, maxcrossrows // dflevels_above.height)
+        contributions.extend(
+            dfsuperlevel_thislevel
+            .slice(batchstart, batchheight)
             .join(dflevels_above, how="cross", maintain_order="left")
             .with_columns(boltzfac=pl.col("g") * (-pl.col("energy_ev") / K_B_ev_per_K / pl.col("T_exc")).exp())
             .group_by(groupcols)
@@ -961,6 +977,7 @@ def superlevel_energy(dfsuperlevel: pl.DataFrame, dflevels: pl.DataFrame, groupc
                 * (pl.col("energy_ev") * pl.col("boltzfac")).sum()
                 / pl.col("boltzfac").sum()
             )
+            for batchstart in range(0, dfsuperlevel_thislevel.height, batchheight)
         )
 
     return pl.concat(contributions) if contributions else pl.DataFrame(schema=schema)

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -24,11 +24,9 @@ import artistools as at
 from artistools.constants import K_B_ev_per_K
 from artistools.misc import path_is_codecomparison
 from artistools.misc import print_warning
-from artistools.misc import read_parquet_cache_metadata
 from artistools.misc.fileio import firstexisting_or_none
-from artistools.misc.fileio import format_mtime
-from artistools.misc.fileio import MTIME_TOLERANCE_S
 from artistools.misc.fileio import parquet_is_readable
+from artistools.misc.fileio import rankbatch_parquet_staleness
 
 if t.TYPE_CHECKING:
     from collections.abc import Iterable
@@ -429,46 +427,6 @@ def get_batch_textsource_state(
     return max(batchmtimes, default=None), len(batchmtimes) == rankmax - rankmin + 1
 
 
-def rankbatch_parquet_staleness(
-    parquetfilepath: Path, textsource_mtime: float | None, *, textsource_complete: bool
-) -> str | None:
-    """Return the reason why the parquet cache is stale, or None when the cache is current.
-
-    The reader of a run and the writer of one batch both ask this, thus one rule decides whether a
-    conversion of the text files takes place. read_parquet_cache_metadata gives every other reason,
-    e.g. a cache that is absent, damaged, or written for a different cache format version.
-
-    A complete batch compares the newest text file with the stamp of the cache. An incomplete batch
-    compares in one direction only: a text file that is newer than the stamp proves a rewrite, and an
-    absent text file proves nothing. The cache format version applies to a batch of either kind.
-    """
-    # an archived run of estimators costs hours to convert again, thus a cache from before the stamps
-    # stays in use. See the accept_unstamped argument of read_parquet_cache_metadata
-    pqmetadata, stalereason = read_parquet_cache_metadata(
-        parquetfilepath, CACHEVERSION, textsource_mtime if textsource_complete else None, accept_unstamped=True
-    )
-    if stalereason is not None or textsource_complete or textsource_mtime is None:
-        return stalereason
-
-    stampedmtime = (pqmetadata or {}).get("textsource_mtime")
-    if stampedmtime is None:
-        return None
-
-    try:
-        stampedvalue = float(stampedmtime)
-    except ValueError:
-        # a stamp that no writer of this repository can produce cannot date the text files
-        return None
-
-    if textsource_mtime > stampedvalue + MTIME_TOLERANCE_S:
-        return (
-            f"a text file of the batch changed at {format_mtime(textsource_mtime)},"
-            f" after the cache stamp of {format_mtime(stampedmtime)}"
-        )
-
-    return None
-
-
 def rankbatch_cache_cannot_be_rebuilt(parquetfilepath: Path, *, textsource_complete: bool) -> bool:
     """Return True when the cache is readable and the estimator text files cannot replace it.
 
@@ -489,7 +447,10 @@ def rankbatch_parquet_is_current(
     a readable cache of such a batch answers here even when it is stale. A complete batch converts
     its text files again, thus only a current cache answers there.
     """
-    if rankbatch_parquet_staleness(parquetfilepath, textsource_mtime, textsource_complete=textsource_complete) is None:
+    staleness = rankbatch_parquet_staleness(
+        parquetfilepath, CACHEVERSION, textsource_mtime, textsource_complete=textsource_complete
+    )
+    if staleness is None:
         return True
 
     # the same rule that get_estimators_rankbatch_parquetfile() applies, so that the two agree
@@ -782,7 +743,7 @@ def scan_artis_estimators(
         # file that the check saw
         outdatedparquets = [at.get_file_identity(cachepath) for cachepath in cachepaths]
         stalereasons = [
-            rankbatch_parquet_staleness(cachepath, mtime, textsource_complete=complete)
+            rankbatch_parquet_staleness(cachepath, CACHEVERSION, mtime, textsource_complete=complete)
             for cachepath, mtime, complete in zip(cachepaths, batchmtimes, batchcomplete, strict=True)
         ]
         # a batch that no conversion can replace keeps its cache, thus it starts no progress bar

--- a/artistools/estimators/estimators.py
+++ b/artistools/estimators/estimators.py
@@ -790,9 +790,28 @@ def scan_artis_estimators(
             print(
                 f"  scanning {len(parquetfiles)} parquet estimator files ({datasize_GB:.1f} GB) from {str_runfolders}..."
             )
-        pldflazy = pl.concat([pl.scan_parquet(pfile) for pfile in parquetfiles], how="diagonal_relaxed").unique(
-            ["timestep", "modelgridindex"], maintain_order=True, keep="first"
+        # the first timestep of a restarted run repeats the last timestep of the run before it, thus the first
+        # row of each key stays. A unique() keeps every column of every row in memory until the query ends.
+        # This used 14 GB for a 3D model on the streaming engine. The group_by reads only the key columns and
+        # the row position
+        indexedrows = pl.concat(
+            [
+                pl.scan_parquet(pfile, row_index_name="sourcerow").with_columns(
+                    sourcerow=pl.lit(fileindex << 32, dtype=pl.UInt64) + pl.col("sourcerow").cast(pl.UInt64)
+                )
+                for fileindex, pfile in enumerate(parquetfiles)
+            ],
+            how="diagonal_relaxed",
         )
+        firstrows = (
+            indexedrows
+            .select("timestep", "modelgridindex", "sourcerow")
+            .group_by("timestep", "modelgridindex")
+            .agg(pl.col("sourcerow").min())
+        )
+        pldflazy = indexedrows.join(
+            firstrows, on=["timestep", "modelgridindex", "sourcerow"], how="semi", maintain_order="left"
+        ).drop("sourcerow")
     else:
         # get_runfolders() gives no folder for two different reasons. Name the one that applies.
         # A run that stopped early gives a plot of a timestep that the run never reached

--- a/artistools/estimators/estimators_classic.py
+++ b/artistools/estimators/estimators_classic.py
@@ -189,7 +189,8 @@ def read_classic_estimators_cached(modelpath: Path) -> dict[tuple[int, int], t.A
                 parse_ion_row_classic(row, estimcell, atomic_composition)
 
                 # heatingrates[tid].ff, heatingrates[tid].bf, heatingrates[tid].collisional, heatingrates[tid].gamma,
-                # coolingrates[tid].ff, coolingrates[tid].fb, coolingrates[tid].collisional, coolingrates[tid].adiabatic)
+                # coolingrates[tid].ff, coolingrates[tid].fb, coolingrates[tid].collisional,
+                # coolingrates[tid].adiabatic)
 
                 estimcell["heating_ff"] = float(row[-9])
                 estimcell["heating_bf"] = float(row[-8])

--- a/artistools/estimators/estimators_classic.py
+++ b/artistools/estimators/estimators_classic.py
@@ -143,10 +143,14 @@ def read_classic_estimators_cached(modelpath: Path) -> dict[tuple[int, int], t.A
             modelgridindex = -1
             for line in estfile:
                 row = line.split()
+                # a restart, or the concatenation of two rank files, can leave a blank line
+                if not row:
+                    continue
+
                 # a classic ARTIS run writes a row of numbers that starts with the cell index. A modern
                 # run writes "timestep 0 modelgridindex 0 ...", and it does so even with the options of
                 # the classic code, thus the name of --classicartis misleads
-                if row and row[0] == "timestep":
+                if row[0] == "timestep":
                     msg = (
                         f"{estfilepath} holds the estimator format of a modern ARTIS run, thus "
                         "--classicartis does not read it. That argument reads the output of the classic "

--- a/artistools/estimators/estimators_classic.py
+++ b/artistools/estimators/estimators_classic.py
@@ -188,9 +188,10 @@ def read_classic_estimators_cached(modelpath: Path) -> dict[tuple[int, int], t.A
 
                 parse_ion_row_classic(row, estimcell, atomic_composition)
 
-                # heatingrates[tid].ff, heatingrates[tid].bf, heatingrates[tid].collisional, heatingrates[tid].gamma,
-                # coolingrates[tid].ff, coolingrates[tid].fb, coolingrates[tid].collisional,
-                # coolingrates[tid].adiabatic)
+                # the classic code writes the last nine columns in this order:
+                # heatingrates[tid].ff, heatingrates[tid].bf, heatingrates[tid].collisional,
+                # heatingrates[tid].gamma, coolingrates[tid].ff, coolingrates[tid].fb,
+                # coolingrates[tid].collisional, coolingrates[tid].adiabatic
 
                 estimcell["heating_ff"] = float(row[-9])
                 estimcell["heating_bf"] = float(row[-8])

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -192,7 +192,13 @@ def get_line_points(dfseries: pl.LazyFrame, args: argparse.Namespace) -> pl.Lazy
         .filter(pl.col("yvalue").is_not_null())
         .group_by("xvalue_binned")
         .agg(
-            yvalue_binned=(pl.col("yvalue") * pl.col("celltsweight")).sum() / pl.col("celltsweight").sum(),
+            # every weight of a bin can be zero, e.g. a code comparison file of one epoch gives no
+            # timestep width, and an element that is absent from the bin has no mass. Equal weights
+            # make the weighted average the plain average, thus the bin keeps its point
+            yvalue_binned=pl
+            .when(pl.col("celltsweight").sum() != 0.0)
+            .then((pl.col("yvalue") * pl.col("celltsweight")).sum() / pl.col("celltsweight").sum())
+            .otherwise(pl.col("yvalue").mean()),
             yvalue_binned_min=pl.col("yvalue").min(),
             yvalue_binned_max=pl.col("yvalue").max(),
         )

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -38,6 +38,7 @@ from artistools.misc import addarg_axislimits
 from artistools.misc import addarg_dpi
 from artistools.misc import addarg_figscale
 from artistools.misc import addarg_filter
+from artistools.misc import addarg_labelfontsize
 from artistools.misc import addarg_modelgridindex
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_nolegend
@@ -1600,12 +1601,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     addarg_nolegend(parser)
 
-    parser.add_argument(
-        "-labelfontsize",
-        type=float,
-        default=None,
-        help="Font size of the tick labels. The default comes from the artistools matplotlibrc",
-    )
+    addarg_labelfontsize(parser)
 
     addarg_figscale(parser, include_figwidthscale=True)
     # deprecated spelling of -figwidthscale kept as a hidden alias

--- a/artistools/estimators/plotestimators.py
+++ b/artistools/estimators/plotestimators.py
@@ -429,7 +429,7 @@ def plot_average_excitation(
 
         # weight the average by the ion population where it is available, as plot_average_ionisation
         # weights by the element population
-        nnioncol = f"nnion_{at.get_elsymbol(atomic_number)}_{at.roman_numerals[ion_stage]}"
+        nnioncol = f"nnion_{at.get_ionstring(atomic_number, ion_stage, sep='_', style='spectral')}"
         weightcol = pl.col(nnioncol) if nnioncol in estimatorcolumns else pl.lit(1.0)
 
         dfplotdata = (
@@ -452,12 +452,12 @@ def plot_average_excitation(
 
 def plot_levelpop(
     ax: mplax.Axes,
-    xlist: Sequence[int | float],
     seriestype: str,
     params: Sequence[str],
     timestepslist: Sequence[int],
     mgilist: Sequence[int | Sequence[int]],
     modelpath: str | Path,
+    estimators: pl.LazyFrame,
     **plotkwargs: t.Any,
 ) -> list[SeriesPlan]:
     """Return the series of the population of each level in params, directly or per unit velocity."""
@@ -477,6 +477,17 @@ def plot_levelpop(
     adata = at.atomic.get_levels(modelpath)
 
     arr_tdelta = at.get_timestep_times(modelpath, loc="delta")
+
+    # this series draws one point for each cell, thus the horizontal axis must give one value for
+    # each cell. A time axis gives one value for each timestep instead
+    dfxofmgi = estimators.select("modelgridindex", "xvalue").unique().collect()
+    if dfxofmgi.height != dfxofmgi["modelgridindex"].n_unique():
+        exit_with_error(
+            "a level population plot draws one point for each cell, thus the horizontal axis must"
+            " give one value for each cell",
+            "Give -x velocity or -x modelgridindex. A time axis gives one value for each timestep.",
+        )
+    xvalue_of_mgi = dict(zip(dfxofmgi["modelgridindex"], dfxofmgi["xvalue"], strict=True))
 
     # read_files has no cache, thus one read of the NLTE output of every rank serves every param
     dfnltepops_allions = at.nltepops.read_files(modelpath)
@@ -510,17 +521,25 @@ def plot_levelpop(
             levelpop_of_mgi_ts.setdefault((mgi, ts), n_nlte)
 
         ylist = []
+        xlist = []
         for modelgridindex in mgilist:
             assert isinstance(modelgridindex, int)
             valuesum = 0.0
             tdeltasum = 0.0
 
             for timestep in timestepslist:
-                levelpop = levelpop_of_mgi_ts[modelgridindex, timestep]
+                # an empty cell has no NLTE row, thus it gives no population at this timestep
+                levelpop = levelpop_of_mgi_ts.get((modelgridindex, timestep))
+                if levelpop is None:
+                    continue
 
                 valuesum += levelpop * arr_tdelta[timestep]
                 tdeltasum += arr_tdelta[timestep]
 
+            if tdeltasum == 0.0:
+                continue
+
+            xlist.append(xvalue_of_mgi[modelgridindex])
             if seriestype == "levelpopulation_dn_on_dvel":
                 assert isinstance(modelgridindex, int)
                 cell = modeldata.row(modelgridindex, named=True)
@@ -1024,6 +1043,12 @@ def get_xlist(
     xmin = xstats["xmin"] if args.xmin is None else args.xmin
     xmax = xstats["xmax"] if args.xmax is None else args.xmax
 
+    if args.xbins is not None and (args.xbins == 0 or args.xbins < -1):
+        exit_with_error(
+            f"-xbins {args.xbins} names no number of bins",
+            "Give a positive number of bins, or -1 to select the bin width automatically.",
+        )
+
     if args.xbins is None and xstats["multiple_points_per_xvalue"]:
         print("There are multiple plot points per x value. Using automatic bins (use -xbins N to change this)")
         args.xbins = -1
@@ -1031,17 +1056,21 @@ def get_xlist(
 
     if args.xbins is not None and args.xbins < 0:
         xdeltamax = estimators.select(pl.col("xvalue").sort().diff().max()).collect().item()
-        args.xbins = int((xmax - xmin) / xdeltamax)
-        print(
-            f"Setting xbins to {args.xbins} based on data range [{xmin}, {xmax}] and largest x interval of {xdeltamax}"
-        )
-        if args.xbins <= 3:
-            print(f"  would have only {args.xbins} bins. Replacing with 25")
+        if not xdeltamax:
+            # a single row gives None, and a column that holds one x value gives 0.0
+            print(f"The x values give no interval to bin by ({xdeltamax}). Setting xbins to 25")
             args.xbins = 25
+        else:
+            args.xbins = int((xmax - xmin) / xdeltamax)
+            print(
+                f"Setting xbins to {args.xbins} based on data range [{xmin}, {xmax}]"
+                f" and largest x interval of {xdeltamax}"
+            )
+            if args.xbins <= 3:
+                print(f"  would have only {args.xbins} bins. Replacing with 25")
+                args.xbins = 25
 
-    if args.xbins is not None and args.xbins == 0:
-        estimators = estimators.with_columns(xvalue_binned=pl.lit(None).cast(pl.Float64))
-    elif args.xbins is not None:
+    if args.xbins is not None:
         # -xbins gives the number of bins, thus the number of edges is one more than that. It gave
         # the number of edges before, thus "-xbins 30" drew 29 bins and the help said 30
         xbinedges = np.linspace(xmin, xmax, args.xbins + 1)
@@ -1109,7 +1138,6 @@ def get_data_range(ax: mplax.Axes) -> tuple[float, float] | None:
 def plot_subplot(
     ax: mplax.Axes,
     timestepslist: list[int],
-    xlist: list[float | int],
     startfromzero: bool,
     plotitems: list[t.Any],
     mgilist: list[int],
@@ -1223,7 +1251,10 @@ def plot_subplot(
                 ))
 
             elif seriestype == "levelpopulation" or seriestype.startswith("levelpopulation_"):
-                items.append((plot_levelpop(ax, xlist, seriestype, params, timestepslist, mgilist, modelpath), None))
+                items.append((
+                    plot_levelpop(ax, seriestype, params, timestepslist, mgilist, modelpath, estimators),
+                    None,
+                ))
 
             elif seriestype == "averageionisation":
                 items.append((plot_average_ionisation(ax, params, estimators, **plotkwargs), None))
@@ -1325,7 +1356,6 @@ def make_figure(
         plot_subplot(
             ax=ax,
             timestepslist=timestepslist,
-            xlist=xlist,
             plotitems=plotitems,
             mgilist=mgilist,
             modelpath=modelpath,

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -948,6 +948,67 @@ def test_scan_estimators_filters_codecomparison(tmp_path: Path, monkeypatch: pyt
     assert np.isclose(dfone["Te"].item(), 6200.0)
 
 
+@mock.patch.object(mplax.Axes, "plot", side_effect=mplax.Axes.plot, autospec=True)
+def test_plot_codecomparison_single_epoch(
+    mockplot: mock.MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A code comparison file of one epoch gives no timestep width, and the plot still draws its cells.
+
+    The cell weight of the average is the cell volume times the timestep width. One epoch makes every
+    weight zero. get_line_points then divided by zero, and drop_nans removed each line.
+    """
+    physdir = tmp_path / "ccdata" / "toymodel"
+    physdir.mkdir(parents=True)
+    (physdir / "phys_toymodel_toycode.txt").write_text(
+        "#NTIMES: 1\n"
+        "#TIMES[d]: 10.0\n"
+        "#TIME: 10.0\n"
+        "#NVEL: 3\n"
+        "#vel_mid Te rho nne nntot\n"
+        "1000.0 5000.0 1e-13 1e6 1e6\n"
+        "2000.0 5100.0 2e-13 2e6 2e6\n"
+        "3000.0 5200.0 3e-13 3e6 3e6\n"
+    )
+
+    artismodeldir = tmp_path / "ccmodel" / "toymodel"
+    artismodeldir.mkdir(parents=True)
+    (artismodeldir / "model.txt").write_text(
+        "3\n10.0\n1 1000.0 -13.0 0.5 0.3 0.1 0.0 0.0\n2 2000.0 -13.0 0.5 0.3 0.1 0.0 0.0\n"
+        "3 3000.0 -13.0 0.5 0.3 0.1 0.0 0.0\n"
+    )
+    abundrow = " ".join(["0.0"] * 25 + ["0.1", "0.0", "0.9", "0.0", "0.0"])
+    (artismodeldir / "abundances.txt").write_text("".join(f"{cellid} {abundrow}\n" for cellid in (1, 2, 3)))
+
+    realgetpath = at.get_path
+
+    def fake_get_path(key: str) -> Path:
+        if key == "codecomparisondata1path":
+            return tmp_path / "ccdata"
+        if key == "codecomparisonmodelartismodelpath":
+            return tmp_path / "ccmodel"
+        return realgetpath(key)
+
+    import artistools.inputmodel.inputmodel_misc
+
+    # codecomparison.py calls at.get_path, and inputmodel_misc.py holds its own import of the name
+    monkeypatch.setattr(at, "get_path", fake_get_path)
+    monkeypatch.setattr(artistools.inputmodel.inputmodel_misc, "get_path", fake_get_path)
+
+    at.estimators.plot(
+        argsraw=[],
+        modelpath="codecomparison/toymodel/toycode",
+        plotlist=[["Te"]],
+        x="velocity",
+        timestep="0",
+        outputfile=tmp_path / "est.pdf",
+    )
+
+    arr_xvalue, arr_yvalue = mockplot.call_args_list[0].args[1:3]
+    # the first point repeats the innermost cell at the axis origin, thus the three cells follow it
+    assert np.allclose(arr_yvalue[-3:], [5000.0, 5100.0, 5200.0])
+    assert np.allclose(arr_xvalue[-3:], [500.0, 1500.0, 2500.0])
+
+
 def test_exportmassfractions(tmp_path: Path) -> None:
     """Every element the estimators carry should appear, weighted by its standard atomic mass."""
     outfile = tmp_path / "massfracs.txt"

--- a/artistools/estimators/test_estimators.py
+++ b/artistools/estimators/test_estimators.py
@@ -786,14 +786,17 @@ def test_a_current_parquet_cache_starts_no_progress_bar(tmp_path: Path) -> None:
     from artistools.estimators.estimators import CACHEVERSION
     from artistools.estimators.estimators import get_rankbatch_parquetpath
     from artistools.estimators.estimators import rankbatch_parquet_is_current
-    from artistools.estimators.estimators import rankbatch_parquet_staleness
     from artistools.misc.fileio import MTIME_TOLERANCE_S
+    from artistools.misc.fileio import rankbatch_parquet_staleness
 
     parquetfilepath = get_rankbatch_parquetpath(tmp_path, [0, 1, 2], 0)
     assert parquetfilepath.name == "estimbatch00_0000_0002.out.parquet.tmp"
 
     # a cache that no run wrote yet needs the conversion
-    assert rankbatch_parquet_staleness(parquetfilepath, None, textsource_complete=False) == "the file does not exist"
+    assert (
+        rankbatch_parquet_staleness(parquetfilepath, CACHEVERSION, None, textsource_complete=False)
+        == "the file does not exist"
+    )
 
     mtime = 1000.0
     at.write_parquet_atomic(
@@ -2081,9 +2084,10 @@ def test_an_archived_run_keeps_a_cache_of_an_old_version(tmp_path: Path) -> None
     No conversion can replace such a cache. A rejection made get_runfolder_timesteps() find no
     timesteps, thus get_runfolders() dropped the folder and the reader saw a run that holds no data.
     """
+    from artistools.estimators.estimators import CACHEVERSION
     from artistools.estimators.estimators import rankbatch_cache_cannot_be_rebuilt
     from artistools.estimators.estimators import rankbatch_parquet_is_current
-    from artistools.estimators.estimators import rankbatch_parquet_staleness
+    from artistools.misc.fileio import rankbatch_parquet_staleness
 
     oldversion = tmp_path / "estimbatch00_0000_0002.out.parquet.tmp"
     at.write_parquet_atomic(
@@ -2091,7 +2095,9 @@ def test_an_archived_run_keeps_a_cache_of_an_old_version(tmp_path: Path) -> None
     )
 
     # the reason still names the fault, so that the reader can give a warning
-    assert "cache format version" in str(rankbatch_parquet_staleness(oldversion, None, textsource_complete=False))
+    assert "cache format version" in str(
+        rankbatch_parquet_staleness(oldversion, CACHEVERSION, None, textsource_complete=False)
+    )
     # but the cache stays readable, because no conversion can replace it
     assert rankbatch_cache_cannot_be_rebuilt(oldversion, textsource_complete=False)
     assert rankbatch_parquet_is_current(oldversion, None, textsource_complete=False)
@@ -2171,10 +2177,13 @@ def test_a_batch_that_keeps_only_rank_zero_keeps_its_cache(tmp_path: Path) -> No
     # a rewrite of the file that remains still proves that the cache is stale
     os.utime(tmp_path / "estimators_0000.out", (1400.0, 1400.0))
     mtime_rewritten, complete_rewritten = get_batch_textsource_state(get_textsource_mtimes(tmp_path), 0, 2)
-    from artistools.estimators.estimators import rankbatch_parquet_staleness
+    from artistools.estimators.estimators import CACHEVERSION
+    from artistools.misc.fileio import rankbatch_parquet_staleness
 
     assert "after the cache stamp" in str(
-        rankbatch_parquet_staleness(parquetfilepath, mtime_rewritten, textsource_complete=complete_rewritten)
+        rankbatch_parquet_staleness(
+            parquetfilepath, CACHEVERSION, mtime_rewritten, textsource_complete=complete_rewritten
+        )
     )
 
 
@@ -2263,8 +2272,9 @@ def test_a_partial_batch_keeps_a_cache_of_an_old_version(tmp_path: Path) -> None
     read the one text file that remains, thus it lost the timesteps that only the cache holds and it
     named a set that the scan cannot deliver.
     """
+    from artistools.estimators.estimators import CACHEVERSION
     from artistools.estimators.estimators import rankbatch_parquet_is_current
-    from artistools.estimators.estimators import rankbatch_parquet_staleness
+    from artistools.misc.fileio import rankbatch_parquet_staleness
     from artistools.misc.modelinfo import get_runfolder_timesteps
 
     runfolder = tmp_path / "job1.slurm"
@@ -2283,7 +2293,7 @@ def test_a_partial_batch_keeps_a_cache_of_an_old_version(tmp_path: Path) -> None
 
     # the reason still names the fault, so that the reader can give a warning
     assert "cache format version" in str(
-        rankbatch_parquet_staleness(parquetfilepath, 1000.0, textsource_complete=False)
+        rankbatch_parquet_staleness(parquetfilepath, CACHEVERSION, 1000.0, textsource_complete=False)
     )
     # but the cache answers, because the scan of the run keeps it for the same reason
     assert rankbatch_parquet_is_current(parquetfilepath, 1000.0, textsource_complete=False)

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -260,7 +260,7 @@ def process_trajectory(
             decay_powers[f"({A},{Z})_gam"] = np.zeros(len(arr_t_day))
             decay_powers[f"({A},{Z})_nu"] = np.zeros(len(arr_t_day))
 
-    # a plot time can take the same network step as its neighbour, thus each file is read one time
+    # two plot times can use the same network step, thus the code reads each file one time
     networksteps = sorted({int(nts) for nts in arr_networktimestepindex[hasnetworkstep]})
     if networksteps:
         dftrajnucabund, _networktimes = at.inputmodel.rprocess_from_trajectory.get_trajectory_timestepfiles_nuc_abund(
@@ -292,7 +292,7 @@ def process_trajectory(
             .collect()
         )
 
-        # the row of each plot time in the sums of its network step
+        # global_sums has one row for each plot time that has a network step, in the order of plottimesteps_with_network
         plottimesteps_with_network = np.flatnonzero(hasnetworkstep)
         global_sums = (
             pldf_all

--- a/artistools/gsinetwork/decayproducts.py
+++ b/artistools/gsinetwork/decayproducts.py
@@ -245,45 +245,39 @@ def process_trajectory(
             "abundweighted_Qdot",
         )
     }
+    arr_networktimestepindex = np.array(networktimestepindices)
+    hasnetworkstep = arr_networktimestepindex >= 1
     decay_powers |= {
-        col: (
-            np.array([
-                dfheatingthermo[col][networktimestepindex - 1] if networktimestepindex >= 1 else 0.0
-                for networktimestepindex in networktimestepindices
-            ])
-            * traj_mass_grams
-        )
+        col: np.where(hasnetworkstep, dfheatingthermo[col].to_numpy()[arr_networktimestepindex - 1], 0.0)
+        * traj_mass_grams
         for col in ("hbeta", "htot", "Qdot")
     }
     decay_powers |= {"timedays": np.array(arr_t_day)}
 
-    A_arr = nuc_data["A"].to_numpy()
-    Z_arr = nuc_data["Z"].to_numpy()
-
     if nuclide_contrib:
-        for AZ_tuple in zip(A_arr, Z_arr, strict=False):
-            decay_powers[f"({int(AZ_tuple[0])},{int(AZ_tuple[1])})_elec"] = np.zeros(len(arr_t_day))
-            decay_powers[f"({int(AZ_tuple[0])},{int(AZ_tuple[1])})_gam"] = np.zeros(len(arr_t_day))
-            decay_powers[f"({int(AZ_tuple[0])},{int(AZ_tuple[1])})_nu"] = np.zeros(len(arr_t_day))
+        for A, Z in nuc_data.select("A", "Z").iter_rows():
+            decay_powers[f"({A},{Z})_elec"] = np.zeros(len(arr_t_day))
+            decay_powers[f"({A},{Z})_gam"] = np.zeros(len(arr_t_day))
+            decay_powers[f"({A},{Z})_nu"] = np.zeros(len(arr_t_day))
 
-    # now get abundances from single timestep files
-    for plottimestep, networktimestepindex in enumerate(networktimestepindices):
-        if networktimestepindex < 1:
-            continue
-
-        dftrajnucabund, _networktime = at.inputmodel.rprocess_from_trajectory.get_trajectory_timestepfile_nuc_abund(
-            traj_root=traj_root, particleid=traj_ID, memberfilename=f"./Run_rprocess/nz-plane{networktimestepindex:05d}"
+    # a plot time can take the same network step as its neighbour, thus each file is read one time
+    networksteps = sorted({int(nts) for nts in arr_networktimestepindex[hasnetworkstep]})
+    if networksteps:
+        dftrajnucabund, _networktimes = at.inputmodel.rprocess_from_trajectory.get_trajectory_timestepfiles_nuc_abund(
+            traj_root=traj_root,
+            particleid=traj_ID,
+            memberfilenames=[f"./Run_rprocess/nz-plane{nts:05d}" for nts in networksteps],
         )
 
-        assert dftrajnucabund.height > 100, dftrajnucabund.height
+        assert np.bincount(dftrajnucabund["fileindex"].to_numpy(), minlength=len(networksteps)).min() > 100
 
         pldf_all = (
             dftrajnucabund
             .lazy()
             .filter(pl.col("massfrac") > 0.0)
             .with_columns([
+                pl.col("fileindex").replace_strict(range(len(networksteps)), networksteps).alias("nstep"),
                 pl.col(pl.Int32).cast(pl.Int64),
-                pl.col(pl.Float32).cast(pl.Float64),
                 (pl.col("Z") + pl.col("N")).alias("A"),
                 (pl.col("massfrac") * traj_mass_grams / ((pl.col("Z") + pl.col("N")) * amu_g)).alias("num_nuc"),
             ])
@@ -298,26 +292,45 @@ def process_trajectory(
             .collect()
         )
 
-        global_sums = pldf_all.select(
-            abundweighted_nu=pl.sum("eps_nu"),
-            abundweighted_elec=pl.sum("eps_elec"),
-            abundweighted_gamma=pl.sum("eps_gamma"),
-            abundweighted_Qdot=pl.sum("eps_tot"),
+        # the row of each plot time in the sums of its network step
+        plottimesteps_with_network = np.flatnonzero(hasnetworkstep)
+        global_sums = (
+            pldf_all
+            .group_by("nstep")
+            .agg(
+                abundweighted_nu=pl.sum("eps_nu"),
+                abundweighted_elec=pl.sum("eps_elec"),
+                abundweighted_gamma=pl.sum("eps_gamma"),
+                abundweighted_Qdot=pl.sum("eps_tot"),
+            )
+            .join(
+                pl.DataFrame({"nstep": arr_networktimestepindex[hasnetworkstep]}, schema={"nstep": pl.Int64}),
+                on="nstep",
+                how="right",
+                maintain_order="right",
+            )
+            .fill_null(0.0)
         )
-        for col in global_sums.columns:
-            decay_powers[col][plottimestep] = float(global_sums.get_column(col).item())
+        for col in ("abundweighted_nu", "abundweighted_elec", "abundweighted_gamma", "abundweighted_Qdot"):
+            decay_powers[col][plottimesteps_with_network] = global_sums[col].to_numpy()
 
         if nuclide_contrib:
             # store all nuclide contributions in detail
-            grouped = pldf_all.group_by(["A", "Z"]).agg([
+            plottimesteps_of_nstep: dict[int, list[int]] = {}
+            for plottimestep in plottimesteps_with_network.tolist():
+                plottimesteps_of_nstep.setdefault(networktimestepindices[plottimestep], []).append(plottimestep)
+            grouped = pldf_all.group_by("nstep", "A", "Z").agg(
                 pl.sum("eps_elec").alias("eps_elec"),
                 pl.sum("eps_gamma").alias("eps_gamma"),
                 pl.sum("eps_nu").alias("eps_nu"),
-            ])
-            for A, Z, Qe, Qg, Qn in grouped.select("A", "Z", "eps_elec", "eps_gamma", "eps_nu").iter_rows():
-                decay_powers[f"({A},{Z})_elec"][plottimestep] = Qe
-                decay_powers[f"({A},{Z})_gam"][plottimestep] = Qg
-                decay_powers[f"({A},{Z})_nu"][plottimestep] = Qn
+            )
+            for nstep, A, Z, Qe, Qg, Qn in grouped.select(
+                "nstep", "A", "Z", "eps_elec", "eps_gamma", "eps_nu"
+            ).iter_rows():
+                plottimesteps = plottimesteps_of_nstep[nstep]
+                decay_powers[f"({A},{Z})_elec"][plottimesteps] = Qe
+                decay_powers[f"({A},{Z})_gam"][plottimesteps] = Qg
+                decay_powers[f"({A},{Z})_nu"][plottimesteps] = Qn
 
     # dump to parquet
     if traj_parquet_dir is not None:

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -619,14 +619,20 @@ def plot_qdot_abund_modelcells(
 
     if gsinet_available:
         arr_time_gsi_days = [modelmeta["t_model_init_days"], *arr_time_artis_days_alltimesteps]
-        dfcontribsparticledata = get_dfcontribsparticledata(
-            modelpath=modelpath,
-            mgiplotlist=mgiplotlist,
-            arr_strnuc_z_n=arr_strnuc_z_n,
-            traj_root=traj_root,
-            arr_time_gsi_days=arr_time_gsi_days,
-            griddata_root=griddata_root,
-            lzdfmodel=lzdfmodel,
+        # one collect, because plot_qdot and every cell of plot_cell_abund_evolution read this
+        # frame. A lazy plan would run the gridcontributions join again for each of them
+        dfcontribsparticledata = (
+            get_dfcontribsparticledata(
+                modelpath=modelpath,
+                mgiplotlist=mgiplotlist,
+                arr_strnuc_z_n=arr_strnuc_z_n,
+                traj_root=traj_root,
+                arr_time_gsi_days=arr_time_gsi_days,
+                griddata_root=griddata_root,
+                lzdfmodel=lzdfmodel,
+            )
+            .collect()
+            .lazy()
         )
 
     else:

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -8,12 +8,12 @@ import string
 import typing as t
 from collections.abc import Sequence
 from functools import partial
+from itertools import batched
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 import polars as pl
-from polars import selectors as cs
 
 import artistools as at
 from artistools.constants import day_to_s
@@ -23,6 +23,7 @@ from artistools.inputmodel.rprocess_from_trajectory import fix_fortran_exponents
 from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extracted_path
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
+from artistools.misc import get_npts_model
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 from artistools.plottools import set_legend
@@ -138,61 +139,76 @@ def get_artis_abund_sequences(
         if all(mgi >= 0 for mgi in mgiplotlist):
             estimators_lazy = estimators_lazy.filter(pl.col("modelgridindex").is_in(mgiplotlist))
 
-        estimators_lazy = estimators_lazy.select(
-            "modelgridindex",
-            "timestep",
-            "tmid_days",
-            cs.starts_with(*[f"nniso_{strspecies}" for strspecies in arr_species]),
-            "mass_g",
-            "rho",
-            cs.starts_with(*[f"init_X_{strspecies}" for strspecies in arr_species]),
-        )
-        estimators_lazy = estimators_lazy.sort(by=["timestep", "modelgridindex"])
-        allisotopes_in_df = [
-            col.removeprefix("nniso_")
-            for col in estimators_lazy.collect_schema().names()
-            if col.startswith("nniso_") and col.removeprefix("nniso_").lstrip(string.ascii_letters).isdigit()
-        ]
-        estimators_lazy = estimators_lazy.with_columns(
-            (pl.col(f"init_X_{striso}") * (correction_factors.get(striso, 1.0) - 1.0)).alias(f"offset_{striso}")
-            for striso in allisotopes_in_df
-        ).with_columns([
-            (
-                (pl.col(f"nniso_{striso}") * int(striso.lstrip(string.ascii_letters)) * MH_g / pl.col("rho"))
-                + pl.col(f"offset_{striso}")
-            ).alias(f"X_{striso}")
-            for striso in allisotopes_in_df
-        ])
-
+        estimatorcolumns = estimators_lazy.collect_schema().names()
+        isotopes_used: list[str] = []
         cellmassfrac_exprs = []
         for strspecies in arr_species:
-            if strspecies[-1].isdigit() and f"X_{strspecies}" in estimators_lazy.collect_schema().names():
-                cellmassfrac_exprs.append(pl.col(f"X_{strspecies}"))
-            elif len(estimators_lazy.select(cs.matches(rf"^X_{strspecies}\d+")).collect_schema().names()) > 0:
-                cellmassfrac_exprs.append(
-                    pl.sum_horizontal(cs.matches(rf"^X_{strspecies}\d+"))
-                )  # sum over all isotopes of this element
+            isnuclide = strspecies[-1].isdigit() and f"nniso_{strspecies}" in estimatorcolumns
+            # an element sums every isotope column of its symbol, e.g. "nniso_Y89" but not "nniso_Yb170"
+            speciesisotopes = (
+                [strspecies]
+                if isnuclide
+                else [
+                    col.removeprefix("nniso_")
+                    for col in estimatorcolumns
+                    if col.startswith(f"nniso_{strspecies}") and col.removeprefix(f"nniso_{strspecies}").isdigit()
+                ]
+            )
+            isotopemassfrac_exprs = [
+                pl.col(f"nniso_{striso}") * int(striso.lstrip(string.ascii_letters)) * MH_g / pl.col("rho")
+                + pl.col(f"init_X_{striso}") * (correction_factors.get(striso, 1.0) - 1.0)
+                for striso in speciesisotopes
+            ]
+            isotopes_used.extend(speciesisotopes)
+            if isnuclide:
+                cellmassfrac_exprs.append(isotopemassfrac_exprs[0])
+            elif isotopemassfrac_exprs:
+                cellmassfrac_exprs.append(pl.sum_horizontal(isotopemassfrac_exprs))
             else:
                 cellmassfrac_exprs.append(pl.lit(float("-inf")))
 
-        lazydfs = []
-        for mgi in mgiplotlist:
-            assert isinstance(mgi, int)
-            combinedlzdf = (
-                estimators_lazy
-                .filter((pl.col("modelgridindex") == mgi).or_(mgi < 0))
-                .group_by("timestep", maintain_order=True)
-                .agg(
-                    [
-                        ((cellmassfracexpr * pl.col("mass_g")).sum() / pl.col("mass_g").sum()).alias(f"X_{strspecies}")
-                        for strspecies, cellmassfracexpr in zip(arr_species, cellmassfrac_exprs, strict=True)
-                    ]
-                    + [pl.col("tmid_days").mean()]
-                )
-            )
-            lazydfs.append((mgi, combinedlzdf))
+        # a query holds every column that it reads for all its rows. One query for all the timesteps of a 3D
+        # model of 125 000 cells held 10.6 GB. A batch of 2 GiB held 2.7 GB. A batch of 1 GiB took 50% more time.
+        nrows_per_timestep = (
+            get_npts_model(Path(modelpath)) if any(mgi < 0 for mgi in mgiplotlist) else len(mgiplotlist)
+        )
+        ncolumns_read = 2 * len(set(isotopes_used)) + 4
+        timesteps_per_batch = max(1, 2**31 // (nrows_per_timestep * ncolumns_read * 8))
 
-        arr_abund_artis = dict(zip(mgiplotlist, pl.collect_all([lzdf for _, lzdf in lazydfs]), strict=True))
+        # an empty list of timesteps still takes one query, which gives an empty frame for each cell
+        timestepbatches = list(batched(dftimesteps["timestep"].to_list(), timesteps_per_batch, strict=False)) or [()]
+        batchresults: list[list[pl.DataFrame]] = []
+        for batchtimesteps in timestepbatches:
+            lzcellmassfracs = estimators_lazy.filter(pl.col("timestep").is_in(batchtimesteps)).select(
+                "modelgridindex",
+                "timestep",
+                "tmid_days",
+                "mass_g",
+                *[
+                    cellmassfrac_expr.alias(f"X_{strspecies}")
+                    for strspecies, cellmassfrac_expr in zip(arr_species, cellmassfrac_exprs, strict=True)
+                ],
+            )
+            batchresults.append(
+                pl.collect_all([
+                    lzcellmassfracs
+                    .filter((pl.col("modelgridindex") == mgi).or_(mgi < 0))
+                    .group_by("timestep")
+                    .agg(
+                        [
+                            ((pl.col(f"X_{strspecies}") * pl.col("mass_g")).sum() / pl.col("mass_g").sum())
+                            for strspecies in arr_species
+                        ]
+                        + [pl.col("tmid_days").mean()]
+                    )
+                    for mgi in mgiplotlist
+                ])
+            )
+
+        arr_abund_artis = {
+            mgi: pl.concat(dfs_of_mgi).sort("timestep")
+            for mgi, dfs_of_mgi in zip(mgiplotlist, zip(*batchresults, strict=True), strict=True)
+        }
 
     return arr_abund_artis
 

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -8,7 +8,6 @@ import string
 import typing as t
 from collections.abc import Sequence
 from functools import partial
-from itertools import batched
 from pathlib import Path
 
 import numpy as np
@@ -23,7 +22,6 @@ from artistools.inputmodel.rprocess_from_trajectory import fix_fortran_exponents
 from artistools.inputmodel.rprocess_from_trajectory import get_tar_member_extracted_path
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_output
-from artistools.misc import get_npts_model
 from artistools.plottools import make_frame_figure
 from artistools.plottools import save_figure
 from artistools.plottools import set_legend
@@ -140,7 +138,6 @@ def get_artis_abund_sequences(
             estimators_lazy = estimators_lazy.filter(pl.col("modelgridindex").is_in(mgiplotlist))
 
         estimatorcolumns = estimators_lazy.collect_schema().names()
-        isotopes_used: list[str] = []
         cellmassfrac_exprs = []
         for strspecies in arr_species:
             isnuclide = strspecies[-1].isdigit() and f"nniso_{strspecies}" in estimatorcolumns
@@ -159,7 +156,6 @@ def get_artis_abund_sequences(
                 + pl.col(f"init_X_{striso}") * (correction_factors.get(striso, 1.0) - 1.0)
                 for striso in speciesisotopes
             ]
-            isotopes_used.extend(speciesisotopes)
             if isnuclide:
                 cellmassfrac_exprs.append(isotopemassfrac_exprs[0])
             elif isotopemassfrac_exprs:
@@ -167,55 +163,68 @@ def get_artis_abund_sequences(
             else:
                 cellmassfrac_exprs.append(pl.lit(float("-inf")))
 
-        # a query holds every column that it reads for all its rows. One query for all the timesteps of a 3D
-        # model of 125 000 cells held 10.6 GB. A batch of 2 GiB held 2.7 GB. A batch of 1 GiB took 50% more time.
-        nrows_per_timestep = (
-            get_npts_model(Path(modelpath)) if any(mgi < 0 for mgi in mgiplotlist) else len(mgiplotlist)
+        lzcellmassfracs = estimators_lazy.select(
+            "modelgridindex",
+            "timestep",
+            "tmid_days",
+            "mass_g",
+            *[
+                cellmassfrac_expr.alias(f"X_{strspecies}")
+                for strspecies, cellmassfrac_expr in zip(arr_species, cellmassfrac_exprs, strict=True)
+            ],
         )
-        ncolumns_read = 2 * len(set(isotopes_used)) + 4
-        timesteps_per_batch = max(1, 2**31 // (nrows_per_timestep * ncolumns_read * 8))
-
-        # an empty list of timesteps still takes one query, which gives an empty frame for each cell
-        timestepbatches = list(batched(dftimesteps["timestep"].to_list(), timesteps_per_batch, strict=False)) or [()]
-        batchresults: list[list[pl.DataFrame]] = []
-        for batchtimesteps in timestepbatches:
-            lzcellmassfracs = estimators_lazy.filter(pl.col("timestep").is_in(batchtimesteps)).select(
-                "modelgridindex",
-                "timestep",
-                "tmid_days",
-                "mass_g",
-                *[
-                    cellmassfrac_expr.alias(f"X_{strspecies}")
-                    for strspecies, cellmassfrac_expr in zip(arr_species, cellmassfrac_exprs, strict=True)
-                ],
-            )
-            batchresults.append(
-                pl.collect_all([
-                    lzcellmassfracs
-                    .filter((pl.col("modelgridindex") == mgi).or_(mgi < 0))
-                    .group_by("timestep")
-                    .agg(
-                        [
-                            ((pl.col(f"X_{strspecies}") * pl.col("mass_g")).sum() / pl.col("mass_g").sum())
-                            for strspecies in arr_species
-                        ]
-                        + [pl.col("tmid_days").mean()]
-                    )
-                    for mgi in mgiplotlist
-                ])
-            )
-
-        arr_abund_artis = {
-            mgi: pl.concat(dfs_of_mgi).sort("timestep")
-            for mgi, dfs_of_mgi in zip(mgiplotlist, zip(*batchresults, strict=True), strict=True)
-        }
+        # the in-memory engine held every column that the query reads for all the rows: 10.6 GB for a 3D model
+        # of 125 000 cells. The streaming engine held approximately 4 GB
+        dfs_of_mgi = pl.collect_all(
+            [
+                lzcellmassfracs
+                .filter((pl.col("modelgridindex") == mgi).or_(mgi < 0))
+                .group_by("timestep")
+                .agg(
+                    [
+                        ((pl.col(f"X_{strspecies}") * pl.col("mass_g")).sum() / pl.col("mass_g").sum())
+                        for strspecies in arr_species
+                    ]
+                    + [pl.col("tmid_days").mean()]
+                )
+                .sort("timestep")
+                for mgi in mgiplotlist
+            ],
+            engine="streaming",
+        )
+        arr_abund_artis = dict(zip(mgiplotlist, dfs_of_mgi, strict=True))
 
     return arr_abund_artis
 
 
+def sum_weighted_particle_arrays(
+    dfpairs: pl.LazyFrame, dfparticledata: pl.DataFrame, pairweight: pl.Expr, columns: Sequence[str], ntimes: int
+) -> pl.DataFrame:
+    """Return the sum over the pairs of particle and cell of each array column, multiplied by the weight of the pair.
+
+    The query adds the weights of each particle first, thus it joins one row for each particle. A join of the pairs
+    repeats the arrays of a particle for each cell that the particle reaches.
+    """
+    return (
+        dfpairs
+        .group_by("particleid")
+        .agg(weight=pairweight.sum())
+        .join(dfparticledata.lazy().select("particleid", *columns), on="particleid", how="inner")
+        .select(
+            pl
+            .concat_arr((pl.col(col).arr.get(n) * pl.col("weight")).sum() for n in range(ntimes))
+            .explode(empty_as_null=False)
+            .alias(col)
+            for col in columns
+        )
+        .collect()
+    )
+
+
 def plot_qdot(
     modelpath: Path,
-    dfcontribsparticledata: pl.LazyFrame | None,
+    dfpairs: pl.LazyFrame | None,
+    dfparticledata: pl.DataFrame | None,
     arr_time_gsi_days: Sequence[float] | None,
     pdfoutpath: Path | str,
     xmax: float | None = None,
@@ -230,27 +239,18 @@ def plot_qdot(
         print("Can't do qdot plot because no deposition.out file")
         return
 
-    if dfcontribsparticledata is not None:
+    if dfpairs is not None and dfparticledata is not None:
         heatcols = ["hbeta", "halpha", "hspof"]
 
         print("Calculating global heating rates from the individual particle heating rates")
         assert arr_time_gsi_days is not None
-        # a particle that has no network data drops out of the join, thus the weights of the particles
+        # the semi join removes the pairs of a particle that has no network data, thus the weights of the pairs
         # that remain do not sum to one. Divide by that sum. The rate then stays a rate for each gram
         expr_weight = pl.col("frac_of_cellmass") * pl.col("cellmass_on_mtot")
+        weightsum = dfpairs.select(expr_weight.sum()).collect().item()
         dfgsiglobalheating = (
-            dfcontribsparticledata
-            .select([
-                pl
-                .concat_arr(
-                    (pl.col(col).arr.get(n) * expr_weight).sum() / expr_weight.sum()
-                    for n in range(len(arr_time_gsi_days))
-                )
-                .explode(empty_as_null=False)
-                .alias(col)
-                for col in heatcols
-            ])
-            .collect()
+            sum_weighted_particle_arrays(dfpairs, dfparticledata, expr_weight, heatcols, len(arr_time_gsi_days))
+            .select(pl.col(heatcols) / weightsum)
             .with_columns(time_days=pl.Series(arr_time_gsi_days))
         )
     else:
@@ -338,7 +338,8 @@ def plot_qdot(
 
 def plot_cell_abund_evolution(
     modelpath: Path,
-    dfcontribsparticledata: pl.LazyFrame | None,
+    dfpairs: pl.LazyFrame | None,
+    dfparticledata: pl.DataFrame | None,
     arr_time_gsi_days: Sequence[float] | None,
     arr_species: Sequence[str],
     arr_abund_artis: pl.DataFrame | None,
@@ -346,11 +347,9 @@ def plot_cell_abund_evolution(
     mgi: int,
 ) -> None:
     """Plot the abundance evolution of one model cell, comparing ARTIS to the nuclear network trajectories."""
-    if dfcontribsparticledata is not None:
+    if dfpairs is not None and dfparticledata is not None:
         print(f"Calculating abundances in model cell {mgi} from the individual particle abundances")
-        dfpartcontrib_thiscell = (
-            dfcontribsparticledata.filter(pl.col("modelgridindex") == mgi) if mgi >= 0 else dfcontribsparticledata
-        )
+        dfpartcontrib_thiscell = dfpairs.filter(pl.col("modelgridindex") == mgi) if mgi >= 0 else dfpairs
         frac_of_cellmass_sum = dfpartcontrib_thiscell.select(pl.col("frac_of_cellmass").sum()).collect().item()
         print(f"frac_of_cellmass_sum: {frac_of_cellmass_sum} (can be < 1.0 because of missing particles)")
 
@@ -366,16 +365,13 @@ def plot_cell_abund_evolution(
         )
 
         assert arr_time_gsi_days is not None
-        df_gsi_abunds = dfpartcontrib_thiscell.select([
-            pl
-            .concat_arr(
-                (pl.col(strnuc).arr.get(n) * pl.col("frac_of_cellmass") * pl.col("cellmass_on_mtot") / normfactor).sum()
-                for n in range(len(arr_time_gsi_days))
-            )
-            .explode(empty_as_null=False)
-            .alias(strnuc)
-            for strnuc in arr_species
-        ]).collect()
+        df_gsi_abunds = sum_weighted_particle_arrays(
+            dfpartcontrib_thiscell,
+            dfparticledata,
+            pl.col("frac_of_cellmass") * pl.col("cellmass_on_mtot") / normfactor,
+            arr_species,
+            len(arr_time_gsi_days),
+        )
     else:
         df_gsi_abunds = None
 
@@ -436,7 +432,7 @@ def get_particledata(
     traj_root: Path,
     particleid: int,
     verbose: bool = False,
-) -> pl.LazyFrame:
+) -> pl.DataFrame:
     """For an array of times (NSM time including time before merger), interpolate the heating rates of various decay channels and (if arr_strnuc is not empty) the nuclear mass fractions."""
     try:  # ruff:ignore[too-many-statements-in-try-clause]
         if verbose:
@@ -445,7 +441,7 @@ def get_particledata(
                 f" energy_thermo.dat{', and nz-plane abundances' if arr_strnuc_z_n else ''} for particle {particleid}..."
             )
 
-        particledata = pl.LazyFrame({"particleid": [particleid]}, schema={"particleid": pl.Int32})
+        particledata = pl.DataFrame({"particleid": [particleid]}, schema={"particleid": pl.Int32})
         heatingfilepath = get_tar_member_extracted_path(
             traj_root=traj_root, particleid=particleid, memberfilename="./Run_rprocess/heating.dat"
         )
@@ -522,7 +518,7 @@ def get_particledata(
         if arr_strnuc_z_n:
             print("ERROR:", particleid, arr_strnuc_z_n)
         assert not arr_strnuc_z_n
-        return pl.LazyFrame()
+        return pl.DataFrame()
 
     return particledata
 
@@ -535,8 +531,8 @@ def get_dfcontribsparticledata(
     griddata_root: Path,
     lzdfmodel: pl.LazyFrame,
     arr_time_gsi_days: list[float],
-) -> pl.LazyFrame:
-    """Get the grid particle contributions joined with their interpolated heating rates and abundances."""
+) -> tuple[pl.LazyFrame, pl.DataFrame]:
+    """Return the pairs of particle and cell for the network particles, and the frame of the particle data."""
     # times in artis are relative to merger, but NSM simulation time started earlier
     mergertime_geomunits = at.inputmodel.modelfromhydro.get_merger_time_geomunits(griddata_root)
     t_mergertime_s = mergertime_geomunits * 4.926e-6
@@ -579,13 +575,16 @@ def get_dfcontribsparticledata(
     list_particledata_noabund = at.parallel_map(fworkernoabund, list_particleids_noabund, chunksize=16)
     print("  done")
 
-    # one collect, because plot_qdot and every cell of plot_cell_abund_evolution read this frame.
-    # A lazy concat of one frame for each particle runs its whole plan again for each of them.
-    # The join stays lazy, thus a query for one cell reads the pairs of that cell alone, and the
-    # arrays of a particle are not repeated for each cell that the particle reaches
-    allparticledata = pl.concat(list_particledata_withabund + list_particledata_noabund, how="diagonal").collect()
+    # each particle gives an eager frame of one row. A lazy concat of 1957 such frames took most of 198.5 s on
+    # the streaming engine. The time of that engine increases with the square of the number of inputs
+    allparticledata = pl.concat(list_particledata_withabund + list_particledata_noabund, how="diagonal")
 
-    return dfpartcontrib.join(allparticledata.lazy(), on="particleid", how="inner", maintain_order="left")
+    # a semi join removes the pairs of a particle without network data, and it copies no arrays. The frame
+    # stays lazy, thus a query for one cell reads the pairs of that cell alone
+    dfpairs = dfpartcontrib.join(
+        allparticledata.lazy().select("particleid"), on="particleid", how="semi", maintain_order="left"
+    )
+    return dfpairs, allparticledata
 
 
 def plot_qdot_abund_modelcells(
@@ -646,7 +645,7 @@ def plot_qdot_abund_modelcells(
 
     if gsinet_available:
         arr_time_gsi_days = [modelmeta["t_model_init_days"], *arr_time_artis_days_alltimesteps]
-        dfcontribsparticledata = get_dfcontribsparticledata(
+        dfpairs, dfparticledata = get_dfcontribsparticledata(
             modelpath=modelpath,
             mgiplotlist=mgiplotlist,
             arr_strnuc_z_n=arr_strnuc_z_n,
@@ -657,12 +656,14 @@ def plot_qdot_abund_modelcells(
         )
 
     else:
-        dfcontribsparticledata = None
+        dfpairs = None
+        dfparticledata = None
         arr_time_gsi_days = None
 
     plot_qdot(
         modelpath,
-        dfcontribsparticledata,
+        dfpairs,
+        dfparticledata,
         arr_time_gsi_days,
         pdfoutpath=Path(modelpath, "gsinetwork_global-qdot.pdf"),
         xmax=timedaysmax,
@@ -683,7 +684,8 @@ def plot_qdot_abund_modelcells(
             strmgi = f"mgi{mgi}" if mgi >= 0 else "global"
             plot_cell_abund_evolution(
                 modelpath,
-                dfcontribsparticledata,
+                dfpairs,
+                dfparticledata,
                 arr_time_gsi_days,
                 arr_species,
                 arr_abund_artis.get(mgi),

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -556,9 +556,13 @@ def get_dfcontribsparticledata(
     list_particledata_noabund = at.parallel_map(fworkernoabund, list_particleids_noabund, chunksize=16)
     print("  done")
 
-    allparticledata = pl.concat(list_particledata_withabund + list_particledata_noabund, how="diagonal")
+    # one collect, because plot_qdot and every cell of plot_cell_abund_evolution read this frame.
+    # A lazy concat of one frame for each particle runs its whole plan again for each of them.
+    # The join stays lazy, thus a query for one cell reads the pairs of that cell alone, and the
+    # arrays of a particle are not repeated for each cell that the particle reaches
+    allparticledata = pl.concat(list_particledata_withabund + list_particledata_noabund, how="diagonal").collect()
 
-    return dfpartcontrib.join(allparticledata, on="particleid", how="inner", maintain_order="left")
+    return dfpartcontrib.join(allparticledata.lazy(), on="particleid", how="inner", maintain_order="left")
 
 
 def plot_qdot_abund_modelcells(
@@ -619,20 +623,14 @@ def plot_qdot_abund_modelcells(
 
     if gsinet_available:
         arr_time_gsi_days = [modelmeta["t_model_init_days"], *arr_time_artis_days_alltimesteps]
-        # one collect, because plot_qdot and every cell of plot_cell_abund_evolution read this
-        # frame. A lazy plan would run the gridcontributions join again for each of them
-        dfcontribsparticledata = (
-            get_dfcontribsparticledata(
-                modelpath=modelpath,
-                mgiplotlist=mgiplotlist,
-                arr_strnuc_z_n=arr_strnuc_z_n,
-                traj_root=traj_root,
-                arr_time_gsi_days=arr_time_gsi_days,
-                griddata_root=griddata_root,
-                lzdfmodel=lzdfmodel,
-            )
-            .collect()
-            .lazy()
+        dfcontribsparticledata = get_dfcontribsparticledata(
+            modelpath=modelpath,
+            mgiplotlist=mgiplotlist,
+            arr_strnuc_z_n=arr_strnuc_z_n,
+            traj_root=traj_root,
+            arr_time_gsi_days=arr_time_gsi_days,
+            griddata_root=griddata_root,
+            lzdfmodel=lzdfmodel,
         )
 
     else:

--- a/artistools/gsinetwork/plotqdotabund.py
+++ b/artistools/gsinetwork/plotqdotabund.py
@@ -457,35 +457,42 @@ def get_particledata(
                 traj_root, particleid, arr_time_s_incpremerger, cond="greaterthan"
             )
             nts_list = sorted(set(ntslowers + ntsuppers))
-            nts_count = len(nts_list)
-            arr_massfracs = {strnuc: np.zeros(nts_count, dtype=np.float32) for strnuc, _, _ in arr_strnuc_z_n}
-            for i, nts in enumerate(nts_list):
-                dftrajnucabund, traj_time_s = (
-                    at.inputmodel.rprocess_from_trajectory.get_trajectory_timestepfile_nuc_abund(
-                        traj_root, particleid, f"./Run_rprocess/nz-plane{nts:05d}"
-                    )
+            dftrajnucabund, traj_times_s = (
+                at.inputmodel.rprocess_from_trajectory.get_trajectory_timestepfiles_nuc_abund(
+                    traj_root, particleid, [f"./Run_rprocess/nz-plane{nts:05d}" for nts in nts_list]
                 )
+            )
+            for nts, traj_time_s in zip(nts_list, traj_times_s, strict=True):
                 # nts is the exact network step, thus these two times come from the same step and
                 # agree to the precision of the file
                 at.inputmodel.rprocess_from_trajectory.check_traj_time_matches(
                     particleid, traj_time_s, nstep_timesec[nts], rel_tol=1e-6, abs_tol=0.0
                 )
-                # one sum per element and one per nuclide, and then a lookup for each species
-                massfrac_of_z = dict(dftrajnucabund.group_by("Z").agg(pl.col("massfrac").sum()).iter_rows())
-                massfrac_of_z_n = {
-                    (Z, N): massfrac
-                    for Z, N, massfrac in dftrajnucabund.group_by("Z", "N").agg(pl.col("massfrac").sum()).iter_rows()
-                }
-                for strnuc, Z, N in arr_strnuc_z_n:
-                    arr_massfracs[strnuc][i] = (
-                        massfrac_of_z.get(Z, 0.0) if N is None else massfrac_of_z_n.get((Z, N), 0.0)
-                    )
+
+            # one row for each network step, with the mass fraction of each species
+            dfmassfracs = (
+                dftrajnucabund
+                .group_by("fileindex")
+                .agg(
+                    pl
+                    .col("massfrac")
+                    .filter((pl.col("Z") == Z) if N is None else ((pl.col("Z") == Z) & (pl.col("N") == N)))
+                    .sum()
+                    .cast(pl.Float32)
+                    .alias(strnuc)
+                    for strnuc, Z, N in arr_strnuc_z_n
+                )
+                .sort("fileindex")
+            )
+            assert dfmassfracs.height == len(nts_list)
 
             particledata = particledata.with_columns(
                 pl.Series(
                     [
                         np.interp(
-                            arr_time_s_incpremerger, [nstep_timesec[nts] for nts in nts_list], arr_massfracs[strnuc]
+                            arr_time_s_incpremerger,
+                            [nstep_timesec[nts] for nts in nts_list],
+                            dfmassfracs[strnuc].to_numpy(),
                         )
                     ],
                     dtype=pl.Array(pl.Float32, len(arr_time_s_incpremerger)),

--- a/artistools/inputmodel/__init__.py
+++ b/artistools/inputmodel/__init__.py
@@ -22,6 +22,7 @@ from artistools.inputmodel.inputmodel_misc import get_empty_3d_model as get_empt
 from artistools.inputmodel.inputmodel_misc import get_initelemabundances as get_initelemabundances
 from artistools.inputmodel.inputmodel_misc import get_mgi_of_velocity_kms as get_mgi_of_velocity_kms
 from artistools.inputmodel.inputmodel_misc import get_modeldata as get_modeldata
+from artistools.inputmodel.inputmodel_misc import remap_gridcontributions as remap_gridcontributions
 from artistools.inputmodel.inputmodel_misc import save_empty_abundance_file as save_empty_abundance_file
 from artistools.inputmodel.inputmodel_misc import save_initelemabundances as save_initelemabundances
 from artistools.inputmodel.inputmodel_misc import save_modeldata as save_modeldata

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -92,7 +92,7 @@ def get_grid(
     # and the reflection w.r.t. the z-axis for the final model.txt has to be done
     eqsymfac = 2 if np.amax(dat.f.pos[:, 1]) < np.pi / 2.0 else 1
 
-    # Step 2) Collect tracer particle data and account for splitting within the e2e modeling
+    # Step 2) Collect tracer particle data and account for splitting within the e2e modelling
 
     # first re-construct the original post-merger trajectories by merging the
     # splitted dynamical ejecta trajectories
@@ -317,13 +317,13 @@ def get_grid(
     # f1 correction a la Garcia-Senz? (does not seem to make a significant difference)
     rho2dhat = rho2dtraj * f1corr(rcyltraj, hsmooth)
 
-    # cross check: count number of neighbors within smoothing length
+    # cross check: count the number of neighbours within the smoothing length
     neinum = np.zeros(ntraj)
     for i in range(ntraj):
         dist = np.sqrt((rcyltraj[i] - rcyltraj) ** 2 + (zcyltraj[i] - zcyltraj) ** 2)
         neinum[i] = np.sum(np.where(dist / hsmooth < 2.0, 1.0, 0.0))
     neinumavg = np.sum(neinum * mtraj) / np.sum(mtraj)
-    print("average number of neighbors:", neinumavg)
+    print("average number of neighbours:", neinumavg)
 
     # Step 5) Final mapping by interpolating all quantities onto the grid
 
@@ -357,25 +357,26 @@ def get_grid(
     yeinterpol = np.sum(weinor * yetraj, axis=interpol_axis)
     bsinterpol = np.sum(weinor * bstraj, axis=interpol_axis)
 
-    # renormalize so that interpolated mass = sum of particle masses
+    # renormalise so that the interpolated mass equals the sum of the particle masses
     dmgrid = rhoint * volgrid  # either 2D or 3D
-    print("total mass after interpolation (but BEFORE renormalization):", np.sum(dmgrid) / msol * eqsymfac)
+    print("total mass after interpolation (but BEFORE renormalisation):", np.sum(dmgrid) / msol * eqsymfac)
     rescfac = np.sum(mtraj) / np.sum(dmgrid)
     if model_dim == 2:
         rhoint *= rescfac
     elif model_dim == 3:
-        # renormalize each partial density such that isotopic masses on mapped grid = isotopic masses from tracers
+        # renormalise each partial density, so that the isotopic masses on the mapped grid equal the
+        # isotopic masses of the tracers
         rescfacx = np.zeros(ncomp)
         for n in np.arange(ncomp):
             rescfacx[n] = np.sum(xiso0[:, n] * dat.f.mass * msol) / (np.sum(xint[n, :, :] * volgrid) + 1e-100)
             xint[n, :, :] *= rescfacx[n]
         # ... recompute total density from partial densities?
         rhoint = np.sum(xint, axis=0)
-        # ... renormalize total density
+        # ... renormalise the total density
         rescfac = np.sum(mtraj) / np.sum(rhoint * volgrid)
         rhoint *= rescfac
         print("rescfac 1:", rescfac)
-        # ... and finally renormalize all partial densities by the same factor
+        # ... and finally renormalise every partial density by the same factor
         for k in np.arange(ncomp):
             xint[k, :, :] *= rescfac
         # ... obtain mass fractions
@@ -715,7 +716,7 @@ def map_to_artis(
             # replace above threshold
             print(f"Replace dynamical ejecta above dynamical ejecta fraction threshold using model {replacedyn}...")
             # get cell list from original model which shall be replaced
-            id_list = (dfmodel["bin_state"] > bs_thr).to_numpy().nonzero()[0].tolist()
+            id_list = dfmodel.filter(pl.col("bin_state") > bs_thr).select("inputcellid").to_series().to_list()
 
             # do replacement in dfelabundances...
             # obtain dfelabundances from the dyn model first again
@@ -892,9 +893,19 @@ def remap_mass_weighted_quantity(
 
 
 def merge_neighbour_cells(
-    dfmodel: pl.DataFrame, modelmeta: dict[str, t.Any], red_fact: int, ngrid_rcyl: int, ngrid_z: int, vmax: float
-) -> tuple[pl.DataFrame, pl.DataFrame, dict[str, t.Any]]:
-    """red_fact: number of cells to be merged."""
+    dfmodel: pl.DataFrame,
+    modelmeta: dict[str, t.Any],
+    red_fact: int,
+    ngrid_rcyl: int,
+    ngrid_z: int,
+    vmax: float,
+    dfgridcontributions: pl.DataFrame | None = None,
+) -> tuple[pl.DataFrame, pl.DataFrame, dict[str, t.Any], pl.DataFrame | None]:
+    """Merge each block of red_fact cells into one cell of a coarser grid.
+
+    red_fact gives the number of cells that one merged cell holds. The particle contributions follow
+    the same mapping, thus gridcontributions.txt names the cells of the new grid.
+    """
     red_fact_1D = int(np.sqrt(red_fact))
     N_cell_r_old, N_cell_z_old = ngrid_rcyl, ngrid_z
     N_cell_r_new, N_cell_z_new = N_cell_r_old // red_fact_1D, N_cell_z_old // red_fact_1D
@@ -973,8 +984,30 @@ def merge_neighbour_cells(
         "t_model_init_days": t_model_init_s / day_to_s,
         "vmax_cmps": vmax * CLIGHT,
     }
+    # the contributions name the cells of the fine grid, thus they follow the same mapping. A fine
+    # cell outside the first red_fact * N_cell_new cells of an axis belongs to no coarse cell
+    dfgridcontributions_out = None
+    if dfgridcontributions is not None:
+        index_old = np.arange(N_cell_r_old * N_cell_z_old)
+        ir_old = index_old % N_cell_r_old
+        iz_old = index_old // N_cell_r_old
+        in_coarse_grid = (ir_old < red_fact_1D * N_cell_r_new) & (iz_old < red_fact_1D * N_cell_z_new)
+        dfcellmap = (
+            pl
+            .DataFrame({
+                "inputcellid": (index_old + 1).astype(np.int32),
+                "out_inputcellid": np.where(
+                    in_coarse_grid, (iz_old // red_fact_1D) * N_cell_r_new + (ir_old // red_fact_1D) + 1, 0
+                ).astype(np.int32),
+                "mass_g": dfmodel["mass_g"].to_numpy(),
+            })
+            .filter(pl.col("out_inputcellid") > 0)
+            .with_columns(out_mass_g=pl.col("mass_g").sum().over("out_inputcellid"))
+        )
+        dfgridcontributions_out = at.inputmodel.remap_gridcontributions(dfgridcontributions, dfcellmap).collect()
+
     print(f"Remapped model to {N_cell_r_new}x{N_cell_z_new} grid.")
-    return dfmodel_out, dfelabundances, modelmeta_out
+    return dfmodel_out, dfelabundances, modelmeta_out, dfgridcontributions_out
 
 
 def apply_density_perturbations(
@@ -1014,7 +1047,8 @@ def apply_density_perturbations(
         pert_array[r > 1] = 1
 
     elif pert_model[0] == "random":
-        # apply random perturbations to every 2D x-y slice. Random perturbation by default on each grid cell, i.e. no d-parameter as in the sinusoidal mode.
+        # apply a random perturbation to every 2D x-y slice. The default applies it to each grid
+        # cell, thus this mode takes no d parameter, which the sinusoidal mode does take
         assert len(pert_model) == 2, "Incomplete data provided for random perturbations"
         delta_max = float(pert_model[1])
         rng = np.random.default_rng()
@@ -1223,13 +1257,14 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
             assert (ngrid_rcyl / np.sqrt(args.mergecells)).is_integer(), (
                 "Number of merged cells in r direction is no integer!"
             )
-            dfmodel, dfelabundances, modelmeta = merge_neighbour_cells(
+            dfmodel, dfelabundances, modelmeta, dfgridcontributions = merge_neighbour_cells(
                 dfmodel=dfmodel,
                 modelmeta=modelmeta,
                 red_fact=args.mergecells,
                 ngrid_rcyl=ngrid_rcyl,
                 ngrid_z=ngrid_z,
                 vmax=args.vmax_on_c,
+                dfgridcontributions=dfgridcontributions,
             )
     elif model_dim == 3:
         x3d, y3d, z3d, rhoint, xint, iso, q_ergperg, yeinterpol, bsinterpol, eqsymfac, dfgridcontributions = get_grid(

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -92,7 +92,8 @@ def get_grid(
     # and the reflection w.r.t. the z-axis for the final model.txt has to be done
     eqsymfac = 2 if np.amax(dat.f.pos[:, 1]) < np.pi / 2.0 else 1
 
-    # Step 2) Collect tracer particle data and account for splitting within the e2e modelling
+    # Step 2) Collect the tracer particle data and account for the particles that the
+    # end-to-end (e2e) model splits
 
     # first re-construct the original post-merger trajectories by merging the
     # splitted dynamical ejecta trajectories
@@ -1047,8 +1048,8 @@ def apply_density_perturbations(
         pert_array[r > 1] = 1
 
     elif pert_model[0] == "random":
-        # apply a random perturbation to every 2D x-y slice. The default applies it to each grid
-        # cell, thus this mode takes no d parameter, which the sinusoidal mode does take
+        # apply a random perturbation to every 2D x-y slice. The default applies it to each cell,
+        # thus this mode takes no d parameter, which the sinusoidal mode does take
         assert len(pert_model) == 2, "Incomplete data provided for random perturbations"
         delta_max = float(pert_model[1])
         rng = np.random.default_rng()

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -705,8 +705,6 @@ def map_to_artis(
                 Z = at.get_atomic_number(isot_str)
                 interpol_X_iso = dfmodel[isot_str].to_numpy()
                 elem_str = f"X_{at.get_elsymbol(Z)}"
-                if elem_str == "X_N":
-                    elem_str = "X_n"
                 if elem_str in dictelabunds:
                     dictelabunds[elem_str] = dictelabunds[elem_str].copy()
                     dictelabunds[elem_str] += interpol_X_iso

--- a/artistools/inputmodel/from_e2e_model.py
+++ b/artistools/inputmodel/from_e2e_model.py
@@ -1320,7 +1320,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     at.inputmodel.save_initelemabundances(dfelabundances=dfelabundances, outpath=args.outputfile)
     at.inputmodel.save_modeldata(dfmodel=dfmodel, modelmeta=modelmeta, outpath=args.outputfile)
-    at.inputmodel.rprocess_from_trajectory.save_gridparticlecontributions(dfgridcontributions, args.outputfile)
+    if dfgridcontributions is not None:
+        at.inputmodel.rprocess_from_trajectory.save_gridparticlecontributions(dfgridcontributions, args.outputfile)
 
 
 if __name__ == "__main__":

--- a/artistools/inputmodel/fromcmfgen/convert_to_artis.py
+++ b/artistools/inputmodel/fromcmfgen/convert_to_artis.py
@@ -116,7 +116,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     # fraction without getting an element column of its own.
     ige_index = np.array(atomic_numbers) > 20
 
-    # The radii/velocity in the CMFGEN files are zone centered, while in ARTIS they represent
+    # The radii and the velocity of the CMFGEN files are zone centred, but in ARTIS they give
     # the outer radius of a given zone. So we need to do a transformation
     r = a["rad"] * 1e10
     rmid = 0.5 * (r[:-1] + r[1:])

--- a/artistools/inputmodel/fromcmfgen/rd_cmfgen.py
+++ b/artistools/inputmodel/fromcmfgen/rd_cmfgen.py
@@ -162,9 +162,12 @@ def rd_sn_hydro_data(file: str, reverse: bool = False, quiet: bool = False) -> d
             sumisofrac += isofrac[:, idx[iiso]]
         # compare to corresponding species mass fraction
         absdiff = np.abs(specfrac[:, spec.index(s)] - sumisofrac)
-        relabsdiff = absdiff / sumisofrac
+        # a zone that holds no isotope of this species gives 0/0, which is NaN. np.max returns NaN
+        # then, and "NaN > MAX_POP_DIFF" is False, thus the check passed whatever the columns held.
+        # Such a zone compares the absolute difference, because a relative one has no meaning there
+        relabsdiff = np.divide(absdiff, sumisofrac, out=absdiff.copy(), where=sumisofrac > 0)
         if np.max(relabsdiff) > MAX_POP_DIFF:
-            sys.exit(f"ERROR - Maximum absolute difference > MAX_POP_DIFF for species {s:s}")
+            sys.exit(f"ERROR - Maximum relative difference > MAX_POP_DIFF for species {s:s}")
 
     # reversed vectors if reverse=True
     if reverse:

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -1141,11 +1141,11 @@ def get_dfmodel_dimensions(dfmodel: pl.DataFrame | pl.LazyFrame) -> int:
 def remap_gridcontributions(
     dfgridcontributions: pl.DataFrame | pl.LazyFrame, dfoutcell_inputcells_masses: pl.DataFrame | pl.LazyFrame
 ) -> pl.LazyFrame:
-    """Return the particle contributions on a new grid, weighted by the mass of each cell.
+    """Return the particle contributions on a new grid, with a weight from the mass of each cell.
 
     dfoutcell_inputcells_masses maps the inputcellid of each cell of the old grid to the
     out_inputcellid of its cell on the new grid. It also gives the mass_g of the old cell and the
-    out_mass_g of the new one, thus frac_of_cellmass counts against the mass of the new cell.
+    out_mass_g of the new one. Thus frac_of_cellmass counts against the mass of the new cell.
     """
     return (
         dfgridcontributions

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -24,7 +24,11 @@ from artistools.constants import C_cm_per_s
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.misc import firstexisting
+from artistools.misc import get_costheta_bins
 from artistools.misc import get_file_identity
+from artistools.misc import get_phi_bin_steps
+from artistools.misc import get_viewingdirection_costhetabincount
+from artistools.misc import get_viewingdirection_phibincount
 from artistools.misc import path_is_codecomparison
 from artistools.misc import polars_source
 from artistools.misc import print_warning
@@ -157,7 +161,8 @@ def read_modelfile_text(
         ).lazy()
 
     else:
-        # dfmodelraw can have cells split across two lines, so to avoid reading twice, we read in everything and slice later
+        # a cell of dfmodelraw can span two lines. One read of the full file and a slice after it
+        # prevent a second read
         dfmodelraw = read_wsv(
             filename,
             has_header=False,
@@ -808,14 +813,19 @@ def get_cell_angle(dfmodel: pl.LazyFrame) -> pl.LazyFrame:
 
     cosphi = pos_x / (pos_y**2 + pos_x**2).sqrt()
 
-    # cut() takes only the interior bin boundaries: cos_theta spans [-1, 1] and phi_mirrored spans [0, 2 pi]
-    cos_bins = [-0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8]
-    cos_labels = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
-    # assert at.get_viewingdirection_costhetabincount() == 10
-    # assert at.get_viewingdirection_phibincount() == 10
+    nphibins = get_viewingdirection_phibincount()
+    ncosthetabins = get_viewingdirection_costhetabincount()
 
-    phibins = [math.pi * frac / 5 for frac in (1, 2, 3, 4, 5, 6, 7, 8, 9)]
-    phi_labels = [0, 1, 2, 3, 4, 9, 8, 7, 6, 5]
+    # cut() takes only the interior bin boundaries: cos_theta spans [-1, 1] and phi_mirrored spans [0, 2 pi]
+    costheta_lower, _costheta_upper, _costheta_labels = get_costheta_bins(usedegrees=False)
+    cos_bins = list(costheta_lower[1:])
+    # a direction bin is costhetabin * nphibins + phibin, thus each cos(theta) bin starts at this index
+    cos_labels = [costhetabin * nphibins for costhetabin in range(ncosthetabins)]
+
+    phibins = [2 * math.pi * step / nphibins for step in range(1, nphibins)]
+    # phi_mirrored ascends where phi descends, thus the k-th interval here is the bin of phi step k
+    phisteps = get_phi_bin_steps()
+    phi_labels = [phisteps.index(step) for step in range(nphibins)]
 
     return dfmodel.with_columns(
         cos_theta=pos_z / (pos_x**2 + pos_y**2 + pos_z**2).sqrt(),
@@ -959,7 +969,8 @@ def save_modeldata(
         msg = f"dimensions must be 1, 2, or 3, not {modelmeta['dimensions']}"
         raise ValueError(msg)
 
-    # the Ni57 and Co57 columns are optional, but position is important and they must appear before any other custom cols
+    # the Ni57 and Co57 columns are optional, but their position counts. They must come before
+    # every other custom column
     standardcols = get_standard_columns(
         modelmeta["dimensions"],
         includenico57=("X_Ni57" in dfmodel.collect_schema().names() or "X_Co57" in dfmodel.collect_schema().names()),
@@ -1125,6 +1136,36 @@ def get_dfmodel_dimensions(dfmodel: pl.DataFrame | pl.LazyFrame) -> int:
         return 3
 
     return 2 if "pos_z_mid" in columns else 1
+
+
+def remap_gridcontributions(
+    dfgridcontributions: pl.DataFrame | pl.LazyFrame, dfoutcell_inputcells_masses: pl.DataFrame | pl.LazyFrame
+) -> pl.LazyFrame:
+    """Return the particle contributions on a new grid, weighted by the mass of each cell.
+
+    dfoutcell_inputcells_masses maps the inputcellid of each cell of the old grid to the
+    out_inputcellid of its cell on the new grid. It also gives the mass_g of the old cell and the
+    out_mass_g of the new one, thus frac_of_cellmass counts against the mass of the new cell.
+    """
+    return (
+        dfgridcontributions
+        .lazy()
+        .with_columns(pl.col("cellindex").cast(pl.Int32))
+        .rename({"cellindex": "inputcellid"})
+        .join(dfoutcell_inputcells_masses.lazy(), on="inputcellid", how="left")
+        .drop("inputcellid")
+        .group_by("out_inputcellid", "particleid")
+        .agg((cs.starts_with("frac_").dot(pl.col("mass_g")) / pl.col("out_mass_g").first()).fill_nan(0.0))
+        .rename({"out_inputcellid": "cellindex"})
+        .drop_nulls("cellindex")
+        .sort("cellindex", "particleid")
+        .select(
+            "particleid",
+            "cellindex",
+            "frac_of_cellmass",
+            cs.by_name("frac_of_cellmass_includemissing", require_all=False),
+        )
+    )
 
 
 def dimension_reduce_model(
@@ -1324,25 +1365,7 @@ def dimension_reduce_model(
     )
 
     dfgridcontributions_out = (
-        (
-            dfgridcontributions
-            .lazy()
-            .with_columns(pl.col("cellindex").cast(pl.Int32))
-            .rename({"cellindex": "inputcellid"})
-            .join(dfoutcell_inputcells_masses.lazy(), on="inputcellid", how="left")
-            .drop("inputcellid")
-            .group_by("out_inputcellid", "particleid")
-            .agg((cs.starts_with("frac_").dot(pl.col("mass_g")) / pl.col("out_mass_g").first()).fill_nan(0.0))
-            .rename({"out_inputcellid": "cellindex"})
-            .drop_nulls("cellindex")
-            .sort("cellindex", "particleid")
-            .select(
-                "particleid",
-                "cellindex",
-                "frac_of_cellmass",
-                cs.by_name("frac_of_cellmass_includemissing", require_all=False),
-            )
-        )
+        remap_gridcontributions(dfgridcontributions, dfoutcell_inputcells_masses)
         if dfgridcontributions is not None
         else pl.LazyFrame()
     )

--- a/artistools/inputmodel/inputmodel_misc.py
+++ b/artistools/inputmodel/inputmodel_misc.py
@@ -448,6 +448,20 @@ def get_text_source_cached(
     return df, extrametadata
 
 
+def get_model_text_folder(modelpath: Path | str) -> Path:
+    """Return the folder that holds model.txt and abundances.txt of a model path.
+
+    A code comparison path is virtual. The ARTIS input files of such a model are in a folder of the
+    data set of that project.
+    """
+    inputpath = Path(modelpath)
+    if path_is_codecomparison(inputpath):
+        _, inputmodel, _ = inputpath.parts
+        return Path(get_path("codecomparisonmodelartismodelpath"), inputmodel)
+
+    return inputpath
+
+
 def get_modeldata(
     modelpath: Path | str = ".",
     get_elemabundances: bool = False,
@@ -485,8 +499,7 @@ def get_modeldata(
         modelpath = Path(inputpath).parent
     elif path_is_codecomparison(inputpath):
         modelpath = inputpath
-        _, inputmodel, _ = modelpath.parts
-        textfilepath = Path(get_path("codecomparisonmodelartismodelpath"), inputmodel, "model.txt")
+        textfilepath = Path(get_model_text_folder(inputpath), "model.txt")
     else:
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), inputpath)
 
@@ -1061,7 +1074,7 @@ def get_mgi_of_velocity_kms(modelpath: Path, velocity: float) -> int | None:
 
 def get_initelemabundances(modelpath: Path | str = ".", printwarningsonly: bool = False) -> pl.LazyFrame:
     """Return a table of elemental mass fractions by cell from abundances."""
-    textfilepath = firstexisting("abundances.txt", folder=modelpath, tryzipped=True)
+    textfilepath = firstexisting("abundances.txt", folder=get_model_text_folder(modelpath), tryzipped=True)
 
     def read_text() -> tuple[pl.LazyFrame, dict[str, str]]:
         if not printwarningsonly:

--- a/artistools/inputmodel/make1dslicefrom3d.py
+++ b/artistools/inputmodel/make1dslicefrom3d.py
@@ -62,9 +62,15 @@ def slice_3dmodel(
     dict3dcellidto1dcellid = {}
     outcellid = 0
     with Path(inputfolder, "model.txt").open(encoding="utf-8") as fmodelin:
-        fmodelin.readline()  # npts_model3d
+        npts_model3d = int(fmodelin.readline())
         t_model = fmodelin.readline()  # days
-        fmodelin.readline()  # v_max in [cm/s]
+        vmax_cmps = float(fmodelin.readline())
+
+        # pos_min is the inner face of a cell, but the 1D model gives the outer boundary of a shell.
+        # The cell width makes that outer face, thus the first shell holds a volume
+        ncoordgrid = round(npts_model3d ** (1 / 3))
+        assert ncoordgrid**3 == npts_model3d, f"{npts_model3d} cells do not make a cubic grid"
+        wid_init = 2 * vmax_cmps * float(t_model) * day_to_s / ncoordgrid
 
         while True:
             # two lines making up a model grid cell
@@ -93,7 +99,7 @@ def slice_3dmodel(
             if all(pos == 0.0 or (chosenaxis == ax and pos >= 0.0) for ax, pos in positions.items()):
                 outcellid += 1
                 dict3dcellidto1dcellid[int(cell["cellid"])] = outcellid
-                append_cell_to_output(cell, outcellid, t_model, listout, xlist, ylists)
+                append_cell_to_output(cell, outcellid, t_model, wid_init, listout, xlist, ylists)
                 print(f"Cell {outcellid:4d} input1: {block[0].rstrip()}")
                 print(f"Cell {outcellid:4d} input2: {block[1].rstrip()}")
                 print(f"Cell {outcellid:4d} output: {listout[-1]}")
@@ -152,13 +158,16 @@ def append_cell_to_output(
     cell: dict[str, float | str],
     outcellid: int,
     t_model: str | float,
+    wid_init: float,
     listout: list[str],
     xlist: list[float],
     ylists: list[list[float]],
 ) -> None:
     """Append one cell to the 1D model output lines and to the density and abundance plot series."""
     dist = math.sqrt(float(cell["pos_x_min"]) ** 2 + float(cell["pos_y_min"]) ** 2 + float(cell["pos_z_min"]) ** 2)
-    velocity = dist / float(t_model) / day_to_s / km_to_cm
+    # the slice keeps the positive half-axis, thus pos_min is the inner face and the outer face of
+    # the shell is one cell width further out. vel_r_max_kmps names that outer boundary
+    velocity = (dist + wid_init) / float(t_model) / day_to_s / km_to_cm
 
     listout.append(
         f"{outcellid:6d}  {velocity:8.2f}  {math.log10(max(float(cell['rho']), 1e-100)):8.5f}  "

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -228,9 +228,9 @@ def maptogrid(
             # from the particle h and 150% of the mean h for all particles
             if modifysmoothinglength == "option4" and dis > rmean:
                 h[n] = max(h[n], hmean * 1.5)
-            # option 5 -- for a particle with a radius above the mean, set a minimum smoothing
-            # length of 0.75 * dx and a maximum of 2500. This keeps the smoothing length of an
-            # outer particle within a limit
+            # option 5 -- set a minimum smoothing length of 0.75 * dx and a maximum of 2500.
+            # This applies to a particle with a radius above the mean, and it keeps the length
+            # of an outer particle within a limit
             if modifysmoothinglength == "option5" and dis > rmean:
                 h[n] = max(h[n], 0.75 * dx)
                 h[n] = min(h[n], 2500)
@@ -241,7 +241,8 @@ def maptogrid(
 
             # -------------------------------
 
-            # or with the neighbours. This is not implemented yet
+            # a further option could set the smoothing length from the neighbours. No code
+            # does this yet
 
         maxdist = 2.0 * h[n]
         maxdist2 = maxdist**2

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -26,7 +26,7 @@ dvtable = v2max / itable
 i1 = int(1.0 // dvtable)
 
 
-def get_wij() -> npt.NDArray[np.floating]:
+def get_wij() -> npt.NDArray[np.float64]:
     """Return a lookup table of the normalised cubic spline kernel sampled on a grid of v^2."""
     #
     # --normalisation constant
@@ -46,19 +46,18 @@ def get_wij() -> npt.NDArray[np.floating]:
 
 
 def kernelvals2(
-    rij2: float, hmean: float, wij: npt.NDArray[np.floating]
-) -> float:  # ist schnell berechnet aber keine Gradienten
-    """Return the kernel value for a pair separation rij2 and mean smoothing length, interpolated from wij."""
+    rij2: npt.NDArray[np.float64], hmean: float, wij: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:  # ist schnell berechnet aber keine Gradienten
+    """Return the kernel values for the pair separations rij2 and a mean smoothing length, interpolated from wij."""
     hmean21 = 1.0 / hmean**2
     hmean31 = hmean21 / hmean
     v2 = rij2 * hmean21
-    index = math.floor(v2 / dvtable)
-    dxx = v2 - index * dvtable
-    index1 = index + 1
-    dwdx = (wij[index1] - wij[index]) / dvtable
-    val = (wij[index] + dwdx * dxx) * hmean31
-    assert isinstance(val, float)
-    return val
+    indexfloat = np.floor(v2 / dvtable)
+    dxx = v2 - indexfloat * dvtable
+    index = indexfloat.astype(np.int64)
+    wijlow = np.take(wij, index)
+    dwdx = (np.take(wij, index + 1) - wijlow) / dvtable
+    return (wijlow + dwdx * dxx) * hmean31
 
 
 def maptogrid(
@@ -183,10 +182,13 @@ def maptogrid(
     grho = np.zeros((ncoordgrid, ncoordgrid, ncoordgrid))
     gye = np.zeros((ncoordgrid, ncoordgrid, ncoordgrid))
     gparticlecounter = np.zeros((ncoordgrid, ncoordgrid, ncoordgrid), dtype=int)
-    # the particle index, the cell indices, and the density contribution of each particle-cell pair
-    contrib_particle: list[int] = []
-    contrib_cell: list[tuple[int, int, int]] = []
-    contrib_rho: list[float] = []
+    # the particle index, the cell indices, and the density contribution of each particle-cell pair,
+    # with one array for each particle. The empty first array lets a grid with no pair concatenate
+    contrib_particle: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
+    contrib_celli: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
+    contrib_cellj: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
+    contrib_cellk: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
+    contrib_rho: list[npt.NDArray[np.float64]] = [np.empty(0)]
 
     logprint(f"grid properties {x0=}, {dx=}, {x0 + dx * (ncoordgrid - 1)=}")
 
@@ -257,30 +259,35 @@ def maptogrid(
         if min(ihigh, jhigh, khigh) >= 1 and max(ilow, jlow, klow) <= ncoordgrid:
             particlesinsidegrid.add(n)
 
-        for i in range(ilow, ihigh + 1):
-            for j in range(jlow, jhigh + 1):
-                for k in range(klow, khigh + 1):
-                    dis2 = (arrgx[i] - x[n]) ** 2 + (arrgy[j] - y[n]) ** 2 + (arrgz[k] - z[n]) ** 2
-                    if dis2 > maxdist2:
-                        continue
+        distx2 = (arrgx[ilow : ihigh + 1] - x[n]) ** 2
+        disty2 = (arrgy[jlow : jhigh + 1] - y[n]) ** 2
+        distz2 = (arrgz[klow : khigh + 1] - z[n]) ** 2
+        dis2box = distx2[:, np.newaxis, np.newaxis] + disty2[np.newaxis, :, np.newaxis] + distz2
+        boxi, boxj, boxk = np.nonzero(dis2box <= maxdist2)
+        if boxi.size == 0:
+            continue
 
-                    wtij = kernelvals2(dis2, float(h[n]), wij)
+        wtij = kernelvals2(dis2box[boxi, boxj, boxk], float(h[n]), wij)
 
-                    # this particle's contribution to mass density (rho) in the cell
-                    grho_contrib = pmass[n] * rho[n] / rho_rst[n] * wtij
+        # this particle's contribution to mass density (rho) in each cell
+        grho_contrib = pmass[n] * rho[n] / rho_rst[n] * wtij
 
-                    grho[i, j, k] += grho_contrib
+        # the cells of one particle are all different, thus a fancy-index add needs no np.add.at
+        cells = (boxi + ilow, boxj + jlow, boxk + klow)
+        grho[cells] += grho_contrib
 
-                    contrib_particle.append(n)
-                    contrib_cell.append((i, j, k))
-                    contrib_rho.append(grho_contrib)
+        # mass-weighted electron fraction (needs to be normalised by cell density afterwards)
+        gye[cells] += grho_contrib * Ye[n]
 
-                    # mass-weighted electron fraction (needs to be normalised by cell density afterwards)
-                    gye[i, j, k] += grho_contrib * Ye[n]
+        # count number of particles contributing to each grid cell
+        gparticlecounter[cells] += 1
+        particlesused.add(n)
 
-                    # count number of particles contributing to each grid cell
-                    gparticlecounter[i, j, k] += 1
-                    particlesused.add(n)
+        contrib_particle.append(np.full(boxi.size, n, dtype=np.int64))
+        contrib_celli.append(cells[0])
+        contrib_cellj.append(cells[1])
+        contrib_cellk.append(cells[2])
+        contrib_rho.append(grho_contrib)
 
     logprint(
         f"particles with any cell contribution: {len(particlesused)} of {len(particlesinsidegrid)} inside grid out of"
@@ -299,15 +306,17 @@ def maptogrid(
     with np.errstate(divide="ignore", invalid="ignore"):
         gye = np.divide(gye, grho)
 
-        contrib_i, contrib_j, contrib_k = np.array(contrib_cell, dtype=int).reshape((-1, 3)).T
+        contrib_i = np.concatenate(contrib_celli)
+        contrib_j = np.concatenate(contrib_cellj)
+        contrib_k = np.concatenate(contrib_cellk)
         contrib_gridindex = (contrib_k * ncoordgrid + contrib_j) * ncoordgrid + contrib_i + 1
-        contrib_frac_of_cellmass = np.array(contrib_rho) / grho[contrib_i, contrib_j, contrib_k]
+        contrib_frac_of_cellmass = np.concatenate(contrib_rho) / grho[contrib_i, contrib_j, contrib_k]
         with Path(outputfolderpath, "gridcontributions.txt").open("w", encoding="utf-8") as fcontribs:
             fcontribs.write("particleid cellindex frac_of_cellmass\n")
             fcontribs.writelines(
                 f"{pid} {gridindex} {frac}\n"
                 for pid, gridindex, frac in zip(
-                    particleid[contrib_particle].tolist(),
+                    particleid[np.concatenate(contrib_particle)].tolist(),
                     contrib_gridindex.tolist(),
                     contrib_frac_of_cellmass.tolist(),
                     strict=True,

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -183,7 +183,7 @@ def maptogrid(
     gye = np.zeros((ncoordgrid, ncoordgrid, ncoordgrid))
     gparticlecounter = np.zeros((ncoordgrid, ncoordgrid, ncoordgrid), dtype=int)
     # the particle index, the cell indices, and the density contribution of each particle-cell pair,
-    # with one array for each particle. The empty first array lets a grid with no pair concatenate
+    # with one array for each particle. The empty first array lets np.concatenate operate on a grid with no pair.
     contrib_particle: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
     contrib_celli: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
     contrib_cellj: list[npt.NDArray[np.int64]] = [np.empty(0, dtype=np.int64)]
@@ -272,7 +272,7 @@ def maptogrid(
         # this particle's contribution to mass density (rho) in each cell
         grho_contrib = pmass[n] * rho[n] / rho_rst[n] * wtij
 
-        # the cells of one particle are all different, thus a fancy-index add needs no np.add.at
+        # the cells of one particle are all different, thus an add with an index array is correct without np.add.at
         cells = (boxi + ilow, boxj + jlow, boxk + klow)
         grho[cells] += grho_contrib
 

--- a/artistools/inputmodel/maptogrid.py
+++ b/artistools/inputmodel/maptogrid.py
@@ -170,7 +170,8 @@ def maptogrid(
     logprint(
         f"setgrid_fractionrmax={setgrid_fractionrmax}: gridmax is set to {setgrid_fractionrmax}*rmax of the SPH particles"
     )
-    x0 = -setgrid_fractionrmax * rmax  # Set x0 (gridmax) to a fraction of the maximum radius of the SPH particles
+    # x0 is a fraction of the largest radius of the SPH particles
+    x0 = -setgrid_fractionrmax * rmax
 
     dx = 2.0 * abs(x0) / (ncoordgrid)  # -1 to be symmetric, right?
 
@@ -199,24 +200,8 @@ def maptogrid(
     logprint(f"modifysmoothinglength: {modifysmoothinglength}")
 
     for n in range(npart):
-        maxdist = 2.0 * h[n]
-        maxdist2 = maxdist**2
-
-        ilow = max(math.floor((x[n] - maxdist - x0) / dx), 0)
-        ihigh = min(math.ceil((x[n] + maxdist - x0) / dx), ncoordgrid - 1)
-        jlow = max(math.floor((y[n] - maxdist - y0) / dy), 0)
-        jhigh = min(math.ceil((y[n] + maxdist - y0) / dy), ncoordgrid - 1)
-        klow = max(math.floor((z[n] - maxdist - z0) / dz), 0)
-        khigh = min(math.ceil((z[n] + maxdist - z0) / dz), ncoordgrid - 1)
-
-        if min(ihigh, jhigh, khigh) >= 1 and max(ilow, jlow, klow) <= ncoordgrid:
-            particlesinsidegrid.add(n)
-        # check some min max
-
-        # ... kernel reweighting ?
-
-        # the search box above uses the smoothing length of the snapshot. The kernel below uses the
-        # modified smoothing length
+        # the smoothing length changes first, because the search box below and the kernel must use
+        # the same value. A box from the snapshot h drops every contribution that the larger h adds
         if modifysmoothinglength != "False":
             # -- change h by hand ---------
 
@@ -243,20 +228,33 @@ def maptogrid(
             # from the particle h and 150% of the mean h for all particles
             if modifysmoothinglength == "option4" and dis > rmean:
                 h[n] = max(h[n], hmean * 1.5)
-            # option 5 -- for particles with radius > mean particle radius, set a minimum smoothing length of 0.75 * dx,
-            # but also impose a maximum cap of 2500. This can help avoid excessively large smoothing lengths in the outer regions.
+            # option 5 -- for a particle with a radius above the mean, set a minimum smoothing
+            # length of 0.75 * dx and a maximum of 2500. This keeps the smoothing length of an
+            # outer particle within a limit
             if modifysmoothinglength == "option5" and dis > rmean:
                 h[n] = max(h[n], 0.75 * dx)
                 h[n] = min(h[n], 2500)
-            # option 6 -- similar to option 5, but does not impose a maximum cap on the smoothing length.
-            # Use this if you want to allow smoothing lengths to grow freely beyond 0.75 * dx in the outer regions.
+            # option 6 -- as option 5, but with no maximum. Use this option to let the smoothing
+            # length of an outer particle grow above 0.75 * dx
             if modifysmoothinglength == "option6" and dis > rmean:
                 h[n] = max(h[n], 0.75 * dx)
 
-            maxdist2 = (2.0 * h[n]) ** 2
             # -------------------------------
 
-            # or via neighbors  - not yet implemented
+            # or with the neighbours. This is not implemented yet
+
+        maxdist = 2.0 * h[n]
+        maxdist2 = maxdist**2
+
+        ilow = max(math.floor((x[n] - maxdist - x0) / dx), 0)
+        ihigh = min(math.ceil((x[n] + maxdist - x0) / dx), ncoordgrid - 1)
+        jlow = max(math.floor((y[n] - maxdist - y0) / dy), 0)
+        jhigh = min(math.ceil((y[n] + maxdist - y0) / dy), ncoordgrid - 1)
+        klow = max(math.floor((z[n] - maxdist - z0) / dz), 0)
+        khigh = min(math.ceil((z[n] + maxdist - z0) / dz), ncoordgrid - 1)
+
+        if min(ihigh, jhigh, khigh) >= 1 and max(ilow, jlow, klow) <= ncoordgrid:
+            particlesinsidegrid.add(n)
 
         for i in range(ilow, ihigh + 1):
             for j in range(jlow, jhigh + 1):

--- a/artistools/inputmodel/modelfromhydro.py
+++ b/artistools/inputmodel/modelfromhydro.py
@@ -320,13 +320,19 @@ def makemodelfromgriddata(
         dfelabundances = None
 
     if dimensions < 3:
-        dfmodel, dfelabundances, dfgridcontributions, modelmeta = at.inputmodel.dimension_reduce_model(
+        # the function returns an empty frame, not None, for an input that was None. The guards below
+        # test for None, thus an empty frame would write an empty gridcontributions.txt
+        gave_elabundances = dfelabundances is not None
+        gave_gridcontributions = dfgridcontributions is not None
+        dfmodel, dfelabundances_reduced, dfgridcontributions_reduced, modelmeta = at.inputmodel.dimension_reduce_model(
             dfmodel=dfmodel,
             outputdimensions=dimensions,
             dfelabundances=dfelabundances,
             dfgridcontributions=dfgridcontributions,
             modelmeta=modelmeta,
         )
+        dfelabundances = dfelabundances_reduced if gave_elabundances else None
+        dfgridcontributions = dfgridcontributions_reduced if gave_gridcontributions else None
 
     if "Ye" in dfmodel:
         at.inputmodel.opacityinputfile.write_Ye_file(outputpath, dfmodel)

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -257,7 +257,11 @@ def get_trajectory_qdotintegral(particleid: int, traj_root: Path, nts_max: int, 
         traj_root=traj_root, particleid=particleid, memberfilename="./Run_rprocess/energy_thermo.dat"
     )
     dfthermo = at.read_wsv(enthermofilepath).select("time/s", "Qdot").rename({"time/s": "time_s"})
-    startindex: int = int(np.argmax(dfthermo["time_s"] >= 1))  # start integrating at this number of seconds
+    # the integration starts at one second. np.argmax would return 0 for a file that reaches no
+    # such time, which names the first row rather than showing that no row matches
+    rows_from_1s = (dfthermo["time_s"] >= 1).to_numpy().nonzero()[0]
+    assert rows_from_1s.size > 0, f"{enthermofilepath} holds no time of one second or more"
+    startindex = int(rows_from_1s[0])
 
     assert all(dfthermo["Qdot"][startindex : nts_max + 1] >= 0.0)
 

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -26,7 +26,6 @@ import artistools as at
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.inputmodel.inputmodel_misc import backup_existing_file
-from artistools.misc.fileio import scan_lines
 
 
 def get_elemabund_from_nucabund(dfnucabund: pl.DataFrame) -> dict[str, float]:
@@ -119,6 +118,9 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
     memberfilename: file path within the trajectory tarfile, eg. ./Run_rprocess/energy_thermo.dat
     """
     path_extracted_file = Path(traj_root, str(particleid), memberfilename)
+    if extracted_file_is_complete(path_extracted_file):
+        return path_extracted_file
+
     tarfilepaths = [
         Path(traj_root, filename)
         for filename in (
@@ -129,9 +131,6 @@ def get_tar_member_extracted_path(traj_root: Path | str, particleid: int, member
         )
     ]
     tarfilepath = next((tarfilepath for tarfilepath in tarfilepaths if tarfilepath.is_file()), None)
-
-    if extracted_file_is_complete(path_extracted_file):
-        return path_extracted_file
 
     if tarfilepath is None:
         # an incomplete leftover is unusable and there is no archive to replace it from, so clear it out
@@ -220,35 +219,69 @@ def check_traj_time_matches(
         raise AssertionError(msg)
 
 
-def get_trajectory_timestepfile_nuc_abund(
-    traj_root: Path, particleid: int, memberfilename: str
-) -> tuple[pl.DataFrame, float]:
-    """Get the nuclear abundances for a particular trajectory id number and time memberfilename should be something like "./Run_rprocess/tday_nz-plane"."""
-    trajpath = get_tar_member_extracted_path(traj_root=traj_root, particleid=particleid, memberfilename=memberfilename)
-    with trajpath.open(encoding="utf-8") as trajfile:
-        try:
-            _, str_t_model_init_seconds, _, _, _, _ = trajfile.readline().split()
-        except ValueError as exc:
-            msg = f"Problem with {memberfilename} for traj {particleid}"
-            print(msg)
-            raise ValueError(msg) from exc
+def get_trajectory_timestepfiles_nuc_abund(
+    traj_root: Path, particleid: int, memberfilenames: Sequence[str]
+) -> tuple[pl.DataFrame, list[float]]:
+    """Get the nuclear abundances and the time of several timestep files of one trajectory.
 
-    t_model_init_seconds = float(str_t_model_init_seconds)
+    The column "fileindex" gives the position of the file of each row in memberfilenames. One query reads
+    all the files, because the fixed cost of a query is larger than the parse of one file of 400 lines.
+    """
+    trajpaths = [
+        get_tar_member_extracted_path(traj_root=traj_root, particleid=particleid, memberfilename=memberfilename)
+        for memberfilename in memberfilenames
+    ]
+    # an extracted member is never compressed, thus polars reads the paths directly
+    lzlines = pl.scan_csv(
+        trajpaths,
+        separator="\x1f",
+        has_header=False,
+        quote_char=None,
+        new_columns=["line"],
+        infer_schema_length=0,
+        include_file_paths="path",
+    ).with_columns(
+        fileindex=pl.col("path").replace_strict(
+            [str(trajpath) for trajpath in trajpaths], range(len(trajpaths)), return_dtype=pl.UInt32
+        ),
+        linenumber=pl.int_range(pl.len()).over("path"),
+    )
 
-    # the columns of this file have a fixed width, thus each line goes to str.slice and not to a parser
-    dfnucabund = (
-        scan_lines(trajpath, skip_rows=1)
+    headerfields = pl.col("line").str.extract_all(r"\S+")
+    dfheaders, dfnucabund = pl.collect_all([
+        lzlines.filter(pl.col("linenumber") == 0).select(
+            "fileindex", fieldcount=headerfields.list.len(), timesec=headerfields.list.get(1, null_on_oob=True)
+        ),
+        # the columns of this file have a fixed width, thus each line goes to str.slice and not to a parser
+        lzlines
+        .filter(pl.col("linenumber") > 0)
         .select(
+            "fileindex",
             pl.col("line").str.slice(0, 4).str.strip_chars().cast(pl.Int32).alias("N"),
             pl.col("line").str.slice(4, 4).str.strip_chars().cast(pl.Int32).alias("Z"),
             pl.col("line").str.slice(8, 13).str.strip_chars().cast(pl.Float64).alias("log10abund"),
         )
         .with_columns(massfrac=(pl.col("N") + pl.col("Z")) * (10 ** pl.col("log10abund")))
-        .drop("log10abund")
-        .collect()
-    )
+        .drop("log10abund"),
+    ])
 
-    return dfnucabund, t_model_init_seconds
+    dfheaders = dfheaders.sort("fileindex")
+    badheaders = dfheaders.filter(pl.col("fieldcount") != 6)["fileindex"]
+    if dfheaders.height != len(trajpaths) or not badheaders.is_empty():
+        badfileindex = badheaders.item(0) if not badheaders.is_empty() else 0
+        msg = f"Problem with {memberfilenames[badfileindex]} for traj {particleid}"
+        print(msg)
+        raise ValueError(msg)
+
+    return dfnucabund, dfheaders["timesec"].cast(pl.Float64).to_list()
+
+
+def get_trajectory_timestepfile_nuc_abund(
+    traj_root: Path, particleid: int, memberfilename: str
+) -> tuple[pl.DataFrame, float]:
+    """Get the nuclear abundances for a particular trajectory id number and time memberfilename should be something like "./Run_rprocess/tday_nz-plane"."""
+    dfnucabund, timesecs = get_trajectory_timestepfiles_nuc_abund(traj_root, particleid, [memberfilename])
+    return dfnucabund.drop("fileindex"), timesecs[0]
 
 
 def get_trajectory_qdotintegral(particleid: int, traj_root: Path, nts_max: int, t_model_s: float) -> float:

--- a/artistools/inputmodel/rprocess_from_trajectory.py
+++ b/artistools/inputmodel/rprocess_from_trajectory.py
@@ -225,7 +225,7 @@ def get_trajectory_timestepfiles_nuc_abund(
     """Get the nuclear abundances and the time of several timestep files of one trajectory.
 
     The column "fileindex" gives the position of the file of each row in memberfilenames. One query reads
-    all the files, because the fixed cost of a query is larger than the parse of one file of 400 lines.
+    all the files, because the fixed cost of a query is larger than the time to parse one file of 400 lines.
     """
     trajpaths = [
         get_tar_member_extracted_path(traj_root=traj_root, particleid=particleid, memberfilename=memberfilename)
@@ -269,7 +269,7 @@ def get_trajectory_timestepfiles_nuc_abund(
     badheaders = dfheaders.filter(pl.col("fieldcount") != 6)["fileindex"]
     if dfheaders.height != len(trajpaths) or not badheaders.is_empty():
         badfileindex = badheaders.item(0) if not badheaders.is_empty() else 0
-        msg = f"Problem with {memberfilenames[badfileindex]} for traj {particleid}"
+        msg = f"Cannot read the header line of {memberfilenames[badfileindex]} for trajectory {particleid}"
         print(msg)
         raise ValueError(msg)
 

--- a/artistools/inputmodel/slice1dfromconein3dmodel.py
+++ b/artistools/inputmodel/slice1dfromconein3dmodel.py
@@ -152,11 +152,11 @@ def get_cone_shells(
                 "1D model but worth checking the log file to ensure the normalisation of the cells in the 3D \n"
                 "model used in the 1D model shells is close to 1 before this\n"
             )
-        # Skipping first 5 columns which contain the radioisotopes utilised in SN models
-        # the remaining columns contain the 30 elements in the composition file for SN models
-        # which have the radioisotopes already included in the composition total for the
-        # relevant elements
-        sum_composition_check = sum(composition[species] for species in speciescols[5:])
+        # sum the elemental mass fractions alone. A nuclide column such as X_Ni56 already counts in
+        # the mass fraction of its element, and X_Fegroup is a sum over several elements. A count of
+        # the leading nuclide columns cannot do this: a model can carry X_Ni57 and X_Co57 as well
+        elementcols = [col for col in speciescols if col != "X_Fegroup" and not col[-1].isdigit()]
+        sum_composition_check = sum(composition[species] for species in elementcols)
         logprint(
             f"Shell {i + 1:<3}     3D cells averaged: {shell['cellcount']:<6} composition sum before norm: {sum_composition_check}"
         )
@@ -234,7 +234,6 @@ def make_1d_profile(args: argparse.Namespace, logprint: Callable[..., None]) -> 
         logprint("Scaling density by a factor of:", args.rhoscale)
         slice1d = slice1d.with_columns(pl.col("rho") * args.rhoscale)
 
-    # slice1d = slice1d[slice1d['rho_model'] != -100]  # Remove empty cells
     # TODO: fix this, -100 probably breaks things if it's not one of the outer cells that gets chopped
     slice1d = slice1d.with_columns(
         pl.when(pl.col("rho") != 0).then(pl.col("rho").log10()).otherwise(-100).alias("rho")

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -1843,7 +1843,7 @@ def test_slice_3dmodel_matches_axis_numerically(tmp_path: Path) -> None:
     # line 3 of model.txt gives vmax in cm/s, thus the outermost face sits at vmax * t_model
     vmax_cmps = xmax / (t_model_days * at.constants.day_to_s)
     # a 2x2x2 grid written with scientific notation, as save_modeldata() does (float_scientific=True)
-    lines = ["8", f"{t_model_days}", f"{vmax_cmps:.4e}"]
+    lines = ["8", str(t_model_days), f"{vmax_cmps:.4e}"]
     cellid = 0
     for zpos in (-xmax, 0.0):
         for ypos in (-xmax, 0.0):

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -422,8 +422,7 @@ def test_get_elemabund_from_nucabund() -> None:
 
 def test_get_trajectory_abund_q() -> None:
     # Ensure that the testdatapath is correctly defined as in other tests
-    # modelpath = at.get_config()["path_testdata"] / "testmodel" makes testdatapath the same as
-    # at.get_config()["path_testdata"]
+    # this test reads the test data folder itself, and not the testmodel folder below it
     # In this file, testdatapath is defined globally: testdatapath = at.get_config()["path_testdata"]
 
     particleid = 109215

--- a/artistools/inputmodel/test_inputmodel.py
+++ b/artistools/inputmodel/test_inputmodel.py
@@ -422,7 +422,8 @@ def test_get_elemabund_from_nucabund() -> None:
 
 def test_get_trajectory_abund_q() -> None:
     # Ensure that the testdatapath is correctly defined as in other tests
-    # modelpath = at.get_config()["path_testdata"] / "testmodel" implies testdatapath is at.get_config()["path_testdata"]
+    # modelpath = at.get_config()["path_testdata"] / "testmodel" makes testdatapath the same as
+    # at.get_config()["path_testdata"]
     # In this file, testdatapath is defined globally: testdatapath = at.get_config()["path_testdata"]
 
     particleid = 109215
@@ -1649,7 +1650,8 @@ def test_save_load_3d_model() -> None:
         pl.Series(name=isocol, values=randommassfracs, dtype=pl.Float32) for isocol in isocolnames
     ])
 
-    # abundances don't matter if rho is zero, so we'll set them to zero to match the resulting dataframe that will be loaded
+    # an abundance counts for nothing when rho is zero. Set each one to zero, so that the values
+    # match the dataframe that the reader gives
     dfmodel = dfmodel.with_columns(
         pl.when(dfmodel["rho"] > 0).then(pl.col(col)).otherwise(0) for col in dfmodel.columns if col.startswith("X_")
     )
@@ -1836,9 +1838,12 @@ def test_slice_3dmodel_matches_axis_numerically(tmp_path: Path) -> None:
     inputfolder.mkdir()
     outputfolder.mkdir()
 
+    t_model_days = 1.0
     xmax = 1.0e15
+    # line 3 of model.txt gives vmax in cm/s, thus the outermost face sits at vmax * t_model
+    vmax_cmps = xmax / (t_model_days * at.constants.day_to_s)
     # a 2x2x2 grid written with scientific notation, as save_modeldata() does (float_scientific=True)
-    lines = ["8", "1.0", f"{xmax:.4e}"]
+    lines = ["8", f"{t_model_days}", f"{vmax_cmps:.4e}"]
     cellid = 0
     for zpos in (-xmax, 0.0):
         for ypos in (-xmax, 0.0):
@@ -1851,7 +1856,11 @@ def test_slice_3dmodel_matches_axis_numerically(tmp_path: Path) -> None:
 
     # only the cell at (0, 0, 0) is on the positive x axis with y == z == 0
     assert dict3dcellidto1dcellid == {8: 1}
-    assert xlist == pytest.approx([0.0])
+    # the 1D model gives the outer boundary of each shell. That cell spans 0 to one cell width, thus
+    # its vel_r_max_kmps is the velocity of the cell width and not zero
+    # the file holds the rounded value, thus the expectation must read it back
+    wid_init = 2 * float(f"{vmax_cmps:.4e}") * t_model_days * at.constants.day_to_s / 2
+    assert xlist == pytest.approx([wid_init / (t_model_days * at.constants.day_to_s) / at.constants.km_to_cm])
     assert (outputfolder / "model.txt").read_text(encoding="utf-8").splitlines()[0].strip() == "1"
 
 

--- a/artistools/inputmodel/to_tardis.py
+++ b/artistools/inputmodel/to_tardis.py
@@ -48,20 +48,13 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     dfmodel = pldfmodel.collect()
 
-    if args.abundtype == "nuclear":
-        # nuclide abundances
-        listspecies = [
-            col[2:]
-            for col in dfmodel.columns
-            if col.startswith("X_") and col.upper() != "X_FEGROUP" and col[-1].isdigit()
-        ]
-    else:
-        # nuclide abundances
-        listspecies = [
-            col[2:]
-            for col in dfmodel.columns
-            if col.startswith("X_") and col.upper() != "X_FEGROUP" and not col[-1].isdigit()
-        ]
+    # a nuclide column ends with a mass number, e.g. X_Ni56. An elemental column does not
+    wantsnuclides = args.abundtype == "nuclear"
+    listspecies = [
+        col[2:]
+        for col in dfmodel.columns
+        if col.startswith("X_") and col.upper() != "X_FEGROUP" and col[-1].isdigit() == wantsnuclides
+    ]
 
     if args.maxatomicnumber and args.maxatomicnumber > 0:
         listspecies = [species for species in listspecies if at.get_atomic_number(species) <= args.maxatomicnumber]

--- a/artistools/lightcurve/lightcurve.py
+++ b/artistools/lightcurve/lightcurve.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from collections.abc import Iterable
 from collections.abc import Mapping
 from collections.abc import Sequence
+from functools import lru_cache
 from pathlib import Path
 from types import MappingProxyType
 
@@ -242,7 +243,6 @@ def generate_band_lightcurve_data(
     modelpath: Path | str,
     args: argparse.Namespace | None = None,
     dirbin: int = -1,
-    modelnumber: int | None = None,  # ruff:ignore[unused-function-argument]
     filternames: Sequence[str] | None = None,
     **kwargs: t.Any,
 ) -> dict[str, t.Any]:
@@ -393,6 +393,7 @@ def get_bolometric_luminosities(
     }
 
 
+@lru_cache(maxsize=32)
 def get_filter_data(
     filterdir: Path | str, filter_name: str
 ) -> tuple[float, npt.NDArray[np.floating], npt.NDArray[np.floating], float, float]:
@@ -415,6 +416,10 @@ def get_filter_data(
     sortidx = np.argsort(wavefilter)
     arr_wavefilter = np.array(wavefilter)[sortidx]
     arr_transmission = np.array(transmission)[sortidx]
+
+    # the cache shares one instance with every caller, thus a write must not reach it
+    arr_wavefilter.setflags(write=False)
+    arr_transmission.setflags(write=False)
 
     return zeropointenergyflux, arr_wavefilter, arr_transmission, float(arr_wavefilter[0]), float(arr_wavefilter[-1])
 
@@ -591,7 +596,8 @@ def luminosity_distance(H0: float, Om0: float, z: float) -> float:
 def read_reflightcurve_band_data(lightcurvefilename: Path | str) -> tuple[pl.DataFrame, dict[str, t.Any]]:
     """Return an observed band light curve from the bundled reference data, along with its metadata."""
     filepath = Path(at.get_path("artistools_dir"), "data", "lightcurves", lightcurvefilename)
-    metadata = at.get_file_metadata(filepath)
+    # a copy, because get_file_metadata is cached and this function adds a derived distance below
+    metadata = dict(at.get_file_metadata(filepath))
 
     data_path = Path(at.get_path("artistools_dir"), f"data/lightcurves/{lightcurvefilename}")
     # a reference light curve file can put a comment after a value, thus cut each line at the first "#"
@@ -631,6 +637,13 @@ def find_lightcurve_file(modelpath: Path | str, *, directionresolved: bool = Fal
     One owner of the file name, so that every command reads the same file for the same request and
     reports the same message when it is absent.
     """
+    if directionresolved and gamma:
+        msg = (
+            "ARTIS writes no direction-resolved gamma-ray light curve file."
+            " Give --frompackets to make one from the packets"
+        )
+        raise FileNotFoundError(msg)
+
     if directionresolved:
         lcfilename = "light_curve_res.out"
     elif gamma:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -44,12 +44,12 @@ from artistools.misc import addarg_timedays
 from artistools.misc import addarg_timestep
 from artistools.misc import addarg_verbose
 from artistools.misc import addarg_yscale
+from artistools.misc import apply_time_range_args
 from artistools.misc import color_arg
 from artistools.misc import exit_with_error
 from artistools.misc import get_model_folder
 from artistools.misc import get_series_label
 from artistools.misc import makelist
-from artistools.misc import path_is_artis_model
 from artistools.misc import print_product
 from artistools.misc import print_theta_phi_definitions
 from artistools.misc import print_warning
@@ -1506,50 +1506,6 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--legendframeon", action="store_true", help="Frame on in legend")
 
     addarg_labelfontsize(parser)
-
-
-def apply_time_range_args(args: argparse.Namespace, modelpaths: Sequence[Path | str]) -> None:
-    """Narrow the plotted time range from -timestep or from a -timedays range.
-
-    -timemin and -timemax give the range directly. A single -timedays value names one time for
-    --brightnessattime, thus only a value that holds a range takes part here.
-    """
-    dayrange = at.misc.parse_timedays_range(args.timedays) if args.timedays is not None else None
-    if args.timestep is dayrange is None:
-        return
-
-    # only a timestep needs the times of a model. A reference light curve holds no such data, thus a
-    # command that plots reference data alone still takes a range in days
-    # a path can name a light curve file of a run, and get_time_range reads the folder of the run
-    artispaths = [get_model_folder(path) for path in modelpaths if path_is_artis_model(path)]
-    if not artispaths:
-        if dayrange is None:
-            msg = "-timestep names a timestep of an ARTIS model, and no model path gives one. Give -timedays"
-            raise ValueError(msg)
-        rangemin, rangemax = dayrange
-    else:
-        _, _, rangemin, rangemax = at.get_time_range(
-            artispaths[0], timestep_range_str=args.timestep, timedays_range_str=args.timedays
-        )
-
-        # the plot holds one time axis, thus one range in days must serve every model. A timestep
-        # names different days on a different timestep grid, and applying the days of the first
-        # model would show another timestep of the second without a word
-        if args.timestep is not None:
-            for otherpath in artispaths[1:]:
-                _, _, othermin, othermax = at.get_time_range(otherpath, timestep_range_str=args.timestep)
-                if abs(othermin - rangemin) > 1e-4 or abs(othermax - rangemax) > 1e-4:
-                    exit_with_error(
-                        f"timestep {args.timestep} covers {rangemin:.2f} to {rangemax:.2f} days in "
-                        f"{at.get_model_name(artispaths[0])} and {othermin:.2f} to {othermax:.2f} days in "
-                        f"{at.get_model_name(otherpath)}, because their timestep grids differ. Give the "
-                        "range in days with -timedays, which means the same for every model"
-                    )
-
-    if args.timemin is None:
-        args.timemin = rangemin
-    if args.timemax is None:
-        args.timemax = rangemax
 
 
 def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None = None, **kwargs: t.Any) -> None:

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -380,6 +380,11 @@ def plot_artis_lightcurve(
     else:
         assert pellet_nucname is None, "pellet_nucname is only valid with frompackets=True"
         assert not use_pellet_decay_time, "use_pellet_decay_time is only valid with frompackets=True"
+        if args.plotvspecpol is not None:
+            exit_with_error(
+                "-plotvspecpol names virtual packet observers, which light_curve_res.out does not hold",
+                "Give --frompackets to make the light curve of each virtual observer from the packets.",
+            )
         try:
             lcpath = (
                 at.firstexisting(lcfilename, folder=modelpath, tryzipped=True)
@@ -388,8 +393,8 @@ def plot_artis_lightcurve(
                     modelpath, directionresolved=dirbins != [-1], gamma=escape_type == "TYPE_GAMMA"
                 )
             )
-        except FileNotFoundError:
-            print_warning(f"Skipping because the light curve file of {modelpath} does not exist")
+        except FileNotFoundError as exc:
+            print_warning(f"Skipping {modelpath}: {exc}")
             return None
 
         lcdataframes = at.lightcurve.readfile(
@@ -952,7 +957,7 @@ def make_band_lightcurves_plot(
             if args.verbose:
                 print(f"Reading spectra: {modelname} (angle {dirbin})")
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-                modelpath, args, dirbin, modelnumber=modelnumber, filternames=bandnames
+                modelpath, args, dirbin, filternames=bandnames
             )
 
             if modelnumber == 0 and args.plot_hesma_model:  # TODO: does this work?
@@ -1080,7 +1085,7 @@ def colour_evolution_plot(modelpaths: Sequence[str | Path], outputfolder: str | 
                 dirbincolor = args.color[modelnumber]
 
             band_lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-                modelpath, args, dirbin=dirbin, modelnumber=modelnumber, filternames=bandnames
+                modelpath, args, dirbin=dirbin, filternames=bandnames
             )
 
             for plotnumber, filters in enumerate(args.colour_evolution):

--- a/artistools/lightcurve/plotlightcurve.py
+++ b/artistools/lightcurve/plotlightcurve.py
@@ -32,6 +32,7 @@ from artistools.lightcurve.lightcurve import path_is_reference_lightcurve
 from artistools.misc import addarg_axislimits
 from artistools.misc import addarg_figscale
 from artistools.misc import addarg_filter
+from artistools.misc import addarg_labelfontsize
 from artistools.misc import addarg_maxpacketfiles
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_nolegend
@@ -1504,9 +1505,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--legendframeon", action="store_true", help="Frame on in legend")
 
-    parser.add_argument(
-        "-labelfontsize", type=float, default=None, help="Font size of the tick labels and the axis labels"
-    )
+    addarg_labelfontsize(parser)
 
 
 def apply_time_range_args(args: argparse.Namespace, modelpaths: Sequence[Path | str]) -> None:

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1731,3 +1731,14 @@ def test_escape_type_selects_the_packet_type(mockylabel: mock.MagicMock) -> None
 
     ylabels = [callargs[0][1] for callargs in mockylabel.call_args_list]
     assert ylabels == ["Absolute Bolometric Magnitude"]
+
+
+def test_find_lightcurve_file_refuses_a_direction_resolved_gamma_request() -> None:
+    """ARTIS writes no direction-resolved gamma light curve, thus the request must not read the UVOIR file."""
+    modelpath = at.get_path("testdata")
+
+    with pytest.raises(FileNotFoundError, match="direction-resolved gamma"):
+        at.lightcurve.find_lightcurve_file(modelpath, directionresolved=True, gamma=True)
+
+    # each request on its own still names the file that holds it
+    assert at.lightcurve.find_lightcurve_file(modelpath).name.startswith("light_curve.out")

--- a/artistools/lightcurve/test_lightcurve.py
+++ b/artistools/lightcurve/test_lightcurve.py
@@ -1734,7 +1734,7 @@ def test_escape_type_selects_the_packet_type(mockylabel: mock.MagicMock) -> None
 
 
 def test_find_lightcurve_file_refuses_a_direction_resolved_gamma_request() -> None:
-    """ARTIS writes no direction-resolved gamma light curve, thus the request must not read the UVOIR file."""
+    """ARTIS writes no direction-resolved gamma-ray light curve, thus the request must not read the UVOIR file."""
     modelpath = at.get_path("testdata")
 
     with pytest.raises(FileNotFoundError, match="direction-resolved gamma"):

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -447,9 +447,7 @@ def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
             print(f"All 100 angles are not in file {datafilename}. Quitting")
             sys.exit(1)
 
-        second_band_brightness: t.Any = second_band_brightness_at_peak_first_band(
-            data, bands, modelpath, modelnumber, args
-        )
+        second_band_brightness: t.Any = second_band_brightness_at_peak_first_band(data, bands, modelpath, args)
 
         data[f"{bands[1]}at{bands[0]}max"] = second_band_brightness
 
@@ -486,18 +484,12 @@ def make_peak_colour_viewing_angle_plot(args: argparse.Namespace) -> None:
 
 
 def second_band_brightness_at_peak_first_band(
-    data: dict[str, npt.NDArray[np.float64]],
-    bands: Sequence[str],
-    modelpath: Path,
-    modelnumber: int,
-    args: argparse.Namespace,
+    data: dict[str, npt.NDArray[np.float64]], bands: Sequence[str], modelpath: Path, args: argparse.Namespace
 ) -> list[float]:
     """Return the second band's magnitude at the time the first band peaks, for each direction bin."""
     second_band_brightness: list[float] = []
     for anglenumber, _ in enumerate(data[f"time_{bands[0]}max"]):
-        lightcurve_data = at.lightcurve.generate_band_lightcurve_data(
-            modelpath, args, anglenumber, modelnumber=modelnumber
-        )
+        lightcurve_data = at.lightcurve.generate_band_lightcurve_data(modelpath, args, anglenumber)
         time, brightness_in_mag = at.lightcurve.get_band_lightcurve(lightcurve_data, bands[1], args)
 
         fxfit, xfit = lightcurve_polyfit(time, brightness_in_mag, args)
@@ -542,7 +534,7 @@ def peakmag_risetime_declinerate_init(
     # a band light curve comes from the spectra, and the bolometric light curve from light_curve.out
     plottinglist: list[str] = list(args.filter) if args.filter else ["lightcurve"]
 
-    for modelnumber, modelpath in enumerate(modelpaths):
+    for modelpath in modelpaths:
         modelname = at.get_model_name(modelpath)
         # one entry per model, matching the per-model style lists and the one data file written per model
         modelnames.append(modelname)
@@ -555,21 +547,42 @@ def peakmag_risetime_declinerate_init(
             # alone. The per-direction-bin export keeps the parsed direction bins
             dirbins = [-1]
 
+        dfbolo_of_dirbin: dict[int, pl.DataFrame] = {}
         if not args.filter:
             # dirbin -1 is the angle-averaged light curve, which only light_curve.out holds. The
             # direction-resolved bins come from light_curve_res.out
             directionresolved = list(dirbins) != [-1]
             lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=directionresolved)
-            lcdataframes = at.lightcurve.readfile(lcpath)
+            # an averaging mode groups several direction bins, and dirbins then names the first bin of
+            # each group, thus the reader must apply the same averaging
+            lcdataframes = (
+                at.lightcurve.readfile(
+                    lcpath,
+                    average_over_phi=args.average_over_phi_angle,
+                    average_over_theta=args.average_over_theta_angle,
+                )
+                if directionresolved
+                else at.lightcurve.readfile(lcpath)
+            )
+            # readfile slices one scan of the file, thus one collect_all parses it a single time for
+            # every direction bin, in place of one parse for each bin
+            lazyplans = [
+                lcdataframes[dirbin]
+                .filter(pl.col("time_days").is_between(args.timemin, args.timemax))
+                .fill_nan(0.0)
+                # a time with no luminosity has no magnitude, thus drop the zero and the
+                # non-finite values before the fit
+                .filter(pl.col("mag").is_finite() & (pl.col("mag") != 0.0))
+                .select("time_days", "mag")
+                for dirbin in dirbins
+            ]
+            dfbolo_of_dirbin = dict(zip(dirbins, pl.collect_all(lazyplans), strict=True))
 
         if args.verbose:
             print(f"Reading spectra: {modelname}")
         # the spectra of a direction bin hold every band, thus read each direction bin one time before the band loop
         lightcurve_data_filters_of_dirbin = (
-            {
-                dirbin: at.lightcurve.generate_band_lightcurve_data(modelpath, args, dirbin, modelnumber=modelnumber)
-                for dirbin in dirbins
-            }
+            {dirbin: at.lightcurve.generate_band_lightcurve_data(modelpath, args, dirbin) for dirbin in dirbins}
             if args.filter
             else {}
         )
@@ -582,16 +595,7 @@ def peakmag_risetime_declinerate_init(
                         lightcurve_data_filters_of_dirbin[dirbin], band_name, args
                     )
                 else:
-                    lightcurve_data = (
-                        lcdataframes[dirbin]
-                        .filter(pl.col("time_days").is_between(args.timemin, args.timemax))
-                        .fill_nan(0.0)
-                        # a time with no luminosity has no magnitude, thus drop the zero and the
-                        # non-finite values before the fit
-                        .filter(pl.col("mag").is_finite() & (pl.col("mag") != 0.0))
-                        .select("time_days", "mag")
-                        .collect()
-                    )
+                    lightcurve_data = dfbolo_of_dirbin[dirbin]
                     brightness = lightcurve_data["mag"].to_numpy()
                     time = lightcurve_data["time_days"].to_list()
 

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -283,11 +283,9 @@ def make_plot_test_viewing_angle_fit(
     axis.set_ylabel(f"{FILTERNAME_ALIASES.get(key, key)} Magnitude")
 
     axis.set_xlabel("Time Since Explosion [d]")
+    # before the inversion: set_ylim re-sorts the pair it is given, thus an earlier inversion is lost
+    at.plottools.set_axis_properties(axis, args, xlimits=(args.timemin / 1.05, args.timemax * 1.05, "-timemin"))
     axis.invert_yaxis()
-    axis.set_xlim(args.timemin / 1.05, args.timemax * 1.05)
-    axis.minorticks_on()
-    axis.tick_params(axis="both", which="minor", top=True, right=True, length=5, width=2, labelsize=12)
-    axis.tick_params(axis="both", which="major", top=True, right=True, length=8, width=2, labelsize=12)
     axis.axhline(y=min(fxfit), color="black", linestyle="--")
     axis.axhline(y=mag_after15days_polyfit, color="black", linestyle="--")
     axis.axvline(x=tmax_polyfit, color="black", linestyle="--")
@@ -338,14 +336,10 @@ def set_scatterplot_plot_params(axis: mplax.Axes, args: argparse.Namespace) -> N
     """Set the axis limits, labels, and legend shared by the viewing angle scatter plots."""
     # the x axis here is a rise time or a decline rate, not a time since explosion, so it takes no limit
     # from the command line: this parser spells -xmin/-xmax as aliases of the -timemin/-timemax time range
-    if args.ymin is not None or args.ymax is not None:
-        axis.set_ylim(args.ymin, args.ymax)
+    at.plottools.set_axis_properties(axis, args, xlimits=(None, None, "-xmin"))
     if not args.colouratpeak:
         # after the limits: set_ylim re-sorts the pair it is given, so an inversion applied first is lost
         at.lightcurve.plotlightcurve.invert_magnitude_yaxis(axis)
-    axis.minorticks_on()
-    axis.tick_params(axis="both", which="minor", top=False, right=False, length=5, width=2, labelsize=12)
-    axis.tick_params(axis="both", which="major", top=False, right=False, length=8, width=2, labelsize=12)
 
     if args.colorbarcostheta or args.colorbarphi:
         scaledmap = at.lightcurve.plotlightcurve.make_colorbar_viewingangles_colormap()

--- a/artistools/lightcurve/viewingangleanalysis.py
+++ b/artistools/lightcurve/viewingangleanalysis.py
@@ -283,7 +283,8 @@ def make_plot_test_viewing_angle_fit(
     axis.set_ylabel(f"{FILTERNAME_ALIASES.get(key, key)} Magnitude")
 
     axis.set_xlabel("Time Since Explosion [d]")
-    # before the inversion: set_ylim re-sorts the pair it is given, thus an earlier inversion is lost
+    # set the limits before the inversion: set_ylim re-sorts the pair that the caller gives,
+    # thus it loses an earlier inversion
     at.plottools.set_axis_properties(axis, args, xlimits=(args.timemin / 1.05, args.timemax * 1.05, "-timemin"))
     axis.invert_yaxis()
     axis.axhline(y=min(fxfit), color="black", linestyle="--")
@@ -547,8 +548,8 @@ def peakmag_risetime_declinerate_init(
             # direction-resolved bins come from light_curve_res.out
             directionresolved = list(dirbins) != [-1]
             lcpath = at.lightcurve.find_lightcurve_file(modelpath, directionresolved=directionresolved)
-            # an averaging mode groups several direction bins, and dirbins then names the first bin of
-            # each group, thus the reader must apply the same averaging
+            # a mode that averages over the angles groups several direction bins, and dirbins then
+            # names the first bin of each group. Thus the reader must average in the same way
             lcdataframes = (
                 at.lightcurve.readfile(
                     lcpath,
@@ -558,7 +559,7 @@ def peakmag_risetime_declinerate_init(
                 if directionresolved
                 else at.lightcurve.readfile(lcpath)
             )
-            # readfile slices one scan of the file, thus one collect_all parses it a single time for
+            # readfile slices one scan of the file. Thus one collect_all parses it one time for
             # every direction bin, in place of one parse for each bin
             lazyplans = [
                 lcdataframes[dirbin]

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -124,7 +124,17 @@ def get_line_luminosities_from_packets(
     """
     arr_tstart, arr_tend, arr_tmid = get_timebins(modelpath, arr_tstart, arr_tend)
     arr_timedelta = np.array(arr_tend) - np.array(arr_tstart)
-    timearrayplusend = np.concatenate([arr_tstart, [arr_tend[-1]]]).tolist()
+    lastbin = len(arr_tstart) - 1
+
+    # the bin of a packet comes from the [tstart, tend] of each bin, not from one list of shared
+    # edges, thus a gap between two bins holds no packet. Each bin is [tstart, tend), and the last
+    # bin also holds its upper edge
+    timebin_expr = pl.coalesce([
+        pl.when(pl.col("t_arrive_d").is_between(tstart, tend, closed="both" if binindex == lastbin else "left")).then(
+            pl.lit(binindex, dtype=pl.Int32)
+        )
+        for binindex, (tstart, tend) in enumerate(zip(arr_tstart, arr_tend, strict=True))
+    ])
 
     linelistindices_allfeatures = tuple(lineindex for feature in emfeatures for lineindex in feature.linelistindices)
 
@@ -134,18 +144,30 @@ def get_line_luminosities_from_packets(
 
     # the lines of the features hold a small part of the packets, thus one collect keeps them in memory and
     # each feature bins the frame there. A lazy plan for each feature would scan the parquet files again
-    dfpackets = dfpackets.filter(pl.col(emtypecolumn).is_in(linelistindices_allfeatures)).collect().lazy()
+    dfpackets = (
+        dfpackets
+        .filter(pl.col(emtypecolumn).is_in(linelistindices_allfeatures))
+        .with_columns(timebin=timebin_expr)
+        .filter(pl.col("timebin").is_not_null())
+        .collect()
+        .lazy()
+    )
+
+    # a bin that holds no packet must still give a row, thus the bin list leads the join
+    dftimebins = pl.LazyFrame({"timebin": np.arange(len(arr_tstart), dtype=np.int32), "timedelta_days": arr_timedelta})
 
     dfluminosities = pl.collect_all([
-        at.packets
-        .bin_and_sum(
-            dfpackets.filter(pl.col(emtypecolumn).is_in(feature.linelistindices)),
-            bincol="t_arrive_d",
-            bins=timearrayplusend,
-            sumcols=["e_rf"],
+        dftimebins
+        .join(
+            dfpackets
+            .filter(pl.col(emtypecolumn).is_in(feature.linelistindices))
+            .group_by("timebin")
+            .agg(e_rf_sum=pl.col("e_rf").sum()),
+            on="timebin",
+            how="left",
         )
-        .with_columns(pl.Series("timedelta_days", arr_timedelta))
-        .select(pl.col("e_rf_sum") / nprocs_read / (day_to_s * pl.col("timedelta_days")))
+        .sort("timebin")
+        .select(pl.col("e_rf_sum").fill_null(0.0) / nprocs_read / (day_to_s * pl.col("timedelta_days")))
         for feature in emfeatures
     ])
 

--- a/artistools/linefluxes.py
+++ b/artistools/linefluxes.py
@@ -126,9 +126,9 @@ def get_line_luminosities_from_packets(
     arr_timedelta = np.array(arr_tend) - np.array(arr_tstart)
     lastbin = len(arr_tstart) - 1
 
-    # the bin of a packet comes from the [tstart, tend] of each bin, not from one list of shared
-    # edges, thus a gap between two bins holds no packet. Each bin is [tstart, tend), and the last
-    # bin also holds its upper edge
+    # the bin of a packet comes from the [tstart, tend] of each bin, and not from one list of
+    # shared edges. A gap between two bins thus holds no packet. Each bin is [tstart, tend), and
+    # the last bin also holds its upper edge
     timebin_expr = pl.coalesce([
         pl.when(pl.col("t_arrive_d").is_between(tstart, tend, closed="both" if binindex == lastbin else "left")).then(
             pl.lit(binindex, dtype=pl.Int32)

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -50,7 +50,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     """Plot the macroatom transitions."""
     args = at.parse_cli_args(addargs, "Plot ARTIS macroatom transitions.", args, argsraw, kwargs)
 
-    atomic_number = at.get_atomic_number(args.element.lower())
+    atomic_number = at.get_atomic_number(args.element)
     if atomic_number < 1:
         at.exit_with_error(f"could not find element '{args.element}'")
 

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -60,12 +60,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     timestepmax = timestepmin if not args.timestepmax or args.timestepmax < 0 else args.timestepmax
 
-    input_files = list(Path(args.modelpath).glob("**/macroatom_????.out*"))
-
-    if not input_files:
-        msg = f"{args.modelpath} holds no macroatom_????.out file"
-        raise FileNotFoundError(msg)
-
     # the template took {0}, {1}, and {2} before it took names, thus a script holds those fields
     outputfile = str(args.outputfile).format(
         modelgridindex, timestepmin, timestepmax, cell=modelgridindex, timestep=timestepmin, timestep2=timestepmax
@@ -76,7 +70,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     time_days_min = at.get_timestep_time(modelpath, timestepmin)
     time_days_max = at.get_timestep_time(modelpath, timestepmax)
 
-    dfmacroatom = read_files(input_files, modelgridindex, timestepmin, timestepmax, atomic_number)
+    dfmacroatom = read_files(modelpath, modelgridindex, timestepmin, timestepmax, atomic_number)
     print(f"Plotting {len(dfmacroatom)} transitions")
 
     fig, axesgrid = make_frame_figure(args, aspect=1.059)
@@ -112,39 +106,31 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
 
 def read_files(
-    files: Sequence[Path | str],
+    modelpath: Path | str,
     modelgridindex: int | None = None,
     timestepmin: int | None = None,
     timestepmax: int | None = None,
     atomic_number: int | None = None,
 ) -> pl.DataFrame:
-    """Return the macro atom transitions from the given files, filtered by cell, timestep range, and element."""
-    if not files:
-        print("No files")
+    """Return the macro atom transitions of a model, filtered by cell, timestep range, and element.
 
-    dfs_thisfile = []
-    for filepath in files:
-        print(f"Reading {filepath}...")
+    read_rank_outputfiles reads one file for each rank, thus a run that holds a plain file and a
+    compressed file of the same rank does not read that rank twice.
+    """
+    dfmacroatom = at.read_rank_outputfiles(modelpath, "macroatom_{mpirank:04d}.out", modelgridindex=modelgridindex)
 
-        df_thisfile = at.read_wsv(filepath)
-        if modelgridindex is not None:
-            df_thisfile = df_thisfile.filter(pl.col("modelgridindex") == modelgridindex)
-        if timestepmin is not None:
-            df_thisfile = df_thisfile.filter(pl.col("timestep") >= timestepmin)
-        if timestepmax is not None:
-            df_thisfile = df_thisfile.filter(pl.col("timestep") <= timestepmax)
-        if atomic_number:
-            df_thisfile = df_thisfile.filter(pl.col("Z") == atomic_number)
+    if timestepmin is not None:
+        dfmacroatom = dfmacroatom.filter(pl.col("timestep") >= timestepmin)
+    if timestepmax is not None:
+        dfmacroatom = dfmacroatom.filter(pl.col("timestep") <= timestepmax)
+    if atomic_number:
+        dfmacroatom = dfmacroatom.filter(pl.col("Z") == atomic_number)
 
-        if df_thisfile.height > 0:
-            dfs_thisfile.append(df_thisfile)
+    if dfmacroatom.is_empty():
+        msg = f"{modelpath} holds no macro atom transition for this cell, timestep range, and element"
+        raise ValueError(msg)
 
-    if not dfs_thisfile:
-        msg = "No data found"
-        raise AssertionError(msg)
-
-    # relaxed, because a column can be inferred as integer in one rank's file and float in another's
-    return pl.concat(dfs_thisfile, how="vertical_relaxed")
+    return dfmacroatom
 
 
 if __name__ == "__main__":

--- a/artistools/macroatom.py
+++ b/artistools/macroatom.py
@@ -112,7 +112,7 @@ def read_files(
     timestepmax: int | None = None,
     atomic_number: int | None = None,
 ) -> pl.DataFrame:
-    """Return the macro atom transitions of a model, filtered by cell, timestep range, and element.
+    """Return the macroatom transitions of a model for one cell, a timestep range, and one element.
 
     read_rank_outputfiles reads one file for each rank, thus a run that holds a plain file and a
     compressed file of the same rank does not read that rank twice.
@@ -127,7 +127,7 @@ def read_files(
         dfmacroatom = dfmacroatom.filter(pl.col("Z") == atomic_number)
 
     if dfmacroatom.is_empty():
-        msg = f"{modelpath} holds no macro atom transition for this cell, timestep range, and element"
+        msg = f"{modelpath} holds no macroatom transition for this cell, timestep range, and element"
         raise ValueError(msg)
 
     return dfmacroatom

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -6,6 +6,7 @@ from artistools.misc.cliutils import addarg_collidingflags as addarg_collidingfl
 from artistools.misc.cliutils import addarg_dpi as addarg_dpi
 from artistools.misc.cliutils import addarg_figscale as addarg_figscale
 from artistools.misc.cliutils import addarg_filter as addarg_filter
+from artistools.misc.cliutils import addarg_labelfontsize as addarg_labelfontsize
 from artistools.misc.cliutils import addarg_maxpacketfiles as addarg_maxpacketfiles
 from artistools.misc.cliutils import addarg_modelgridindex as addarg_modelgridindex
 from artistools.misc.cliutils import addarg_modelpath as addarg_modelpath

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -124,6 +124,7 @@ from artistools.misc.modelinfo import get_runfolders as get_runfolders
 from artistools.misc.modelinfo import get_vpkt_config as get_vpkt_config
 from artistools.misc.modelinfo import get_wid_init_at_tmodel as get_wid_init_at_tmodel
 from artistools.misc.modelinfo import read_rank_outputfiles as read_rank_outputfiles
+from artistools.misc.timesteps import apply_time_range_args as apply_time_range_args
 from artistools.misc.timesteps import get_deposition as get_deposition
 from artistools.misc.timesteps import get_escaped_arrivalrange as get_escaped_arrivalrange
 from artistools.misc.timesteps import get_single_timestep as get_single_timestep

--- a/artistools/misc/__init__.py
+++ b/artistools/misc/__init__.py
@@ -69,6 +69,7 @@ from artistools.misc.dirbins import get_dirbin_definitions as get_dirbin_definit
 from artistools.misc.dirbins import get_dirbin_labels as get_dirbin_labels
 from artistools.misc.dirbins import get_dirbins as get_dirbins
 from artistools.misc.dirbins import get_opacity_condition_label as get_opacity_condition_label
+from artistools.misc.dirbins import get_phi_bin_steps as get_phi_bin_steps
 from artistools.misc.dirbins import get_phi_bins as get_phi_bins
 from artistools.misc.dirbins import get_phibin_rank_ascending as get_phibin_rank_ascending
 from artistools.misc.dirbins import get_viewingdirection_costhetabincount as get_viewingdirection_costhetabincount

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -738,6 +738,16 @@ def addarg_dpi(parser: argparse.ArgumentParser, *, default: int = 250) -> None:
     arggroup(parser, "output").add_argument("-dpi", type=int, default=default, help="Dots per inch for the output file")
 
 
+def addarg_labelfontsize(parser: argparse.ArgumentParser) -> None:
+    """Add the -labelfontsize argument that sets the font size of the tick labels and the axis labels."""
+    arggroup(parser, "plot style").add_argument(
+        "-labelfontsize",
+        type=float,
+        default=None,
+        help="Font size of the tick labels and the axis labels. The default comes from the artistools matplotlibrc",
+    )
+
+
 def addarg_yscale(parser: argparse.ArgumentParser) -> None:
     """Add the -yscale argument that selects the scale of the vertical axis.
 

--- a/artistools/misc/cliutils.py
+++ b/artistools/misc/cliutils.py
@@ -1027,7 +1027,8 @@ def set_args_from_dict(parser: argparse.ArgumentParser, kwargs: dict[str, t.Any]
                 kwargs[arg.dest] = kwargs.pop(optstring.lstrip("-"))
 
     parser.set_defaults(**kwargs)
-    # set required=False on all arguments to avoid errors about missing required arguments when we set defaults from kwargs
+    # every argument takes required=False. A keyword argument can give the value instead, thus a
+    # required argument would give an error for a value that the caller did supply
     for arg in realactions:
         if arg.default is not None:
             arg.required = False

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -168,15 +168,24 @@ def get_phibin_rank_ascending(phibin: int) -> int:
     return phibin - halfbins if phibin >= halfbins else nphibins - 1 - phibin
 
 
-def get_phi_bins(usedegrees: bool) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], list[str]]:
-    """Return the lower and upper phi boundaries of each direction bin, and a label for each."""
+def get_phi_bin_steps() -> list[int]:
+    """Return the phi step of each direction bin.
+
+    Direction bin b covers the phi range that step phisteps[b] names, i.e. 2 pi (1 - (step + 1) / n)
+    to 2 pi (1 - step / n). For historical reasons the phi bins descend and flip at half way, thus
+    the steps are [0, 1, 2, 3, 4, 9, 8, 7, 6, 5] for ten bins.
+    """
     nphibins = get_viewingdirection_phibincount()
     # pi/2 must be an exact boundary because of the change in behaviour there
     assert nphibins % 2 == 0
 
-    # for historical reasons, phi bins are descending and include a flip at half way
-    # phisteps = [0, 1, 2, 3, 4, 9, 8, 7, 6, 5] for nphibins == 10
-    phisteps = list(range(nphibins // 2)) + list(reversed(range(nphibins // 2, nphibins)))
+    return list(range(nphibins // 2)) + list(reversed(range(nphibins // 2, nphibins)))
+
+
+def get_phi_bins(usedegrees: bool) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], list[str]]:
+    """Return the lower and upper phi boundaries of each direction bin, and a label for each."""
+    nphibins = get_viewingdirection_phibincount()
+    phisteps = get_phi_bin_steps()
 
     # set up monotonic descending phi bin boundaries
     phi_lower = np.array([2 * math.pi * (1 - (step + 1) / nphibins) for step in phisteps])

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -63,26 +63,14 @@ def average_direction_bins(
             range(start_bin, start_bin + nphibins) if overangle == "phi" else range(start_bin, dirbincount, nphibins)
         )
 
-        dirbindataframesout[start_bin] = dirbindataframes[start_bin].lazy()
-        firstcolname = dirbindataframes[start_bin].collect_schema().names()[0]
-        for dirbin in contribbins[1:]:
-            dirbindataframesout[start_bin] = dirbindataframesout[start_bin].join(
-                dirbindataframes[dirbin].lazy(),
-                on=firstcolname,
-                how="left",
-                suffix=f"_dirbin{dirbin}",
-                maintain_order="left",
-            )
+        colnames = dirbindataframes[start_bin].collect_schema().names()
+        firstcolname = colnames[0]
 
-        dirbindataframesout[start_bin] = dirbindataframesout[start_bin].select(
-            cs.by_index(0),
-            *[
-                (
-                    pl.sum_horizontal([pl.col(col), *[pl.col(f"{col}_dirbin{dirbin}") for dirbin in contribbins[1:]]])
-                    / len(contribbins)
-                ).alias(col)
-                for col in dirbindataframes[start_bin].collect_schema().names()[1:]
-            ],
+        dirbindataframesout[start_bin] = (
+            pl
+            .concat([dirbindataframes[dirbin].lazy().select(colnames) for dirbin in contribbins], how="vertical")
+            .group_by(firstcolname, maintain_order=True)
+            .agg([(pl.col(col).sum() / len(contribbins)).alias(col) for col in colnames[1:]])
         )
 
         print(f"bin number {start_bin:2d} = the average of bins {contribbins}")

--- a/artistools/misc/dirbins.py
+++ b/artistools/misc/dirbins.py
@@ -160,8 +160,8 @@ def get_phi_bin_steps() -> list[int]:
     """Return the phi step of each direction bin.
 
     Direction bin b covers the phi range that step phisteps[b] names, i.e. 2 pi (1 - (step + 1) / n)
-    to 2 pi (1 - step / n). For historical reasons the phi bins descend and flip at half way, thus
-    the steps are [0, 1, 2, 3, 4, 9, 8, 7, 6, 5] for ten bins.
+    to 2 pi (1 - step / n). For historical reasons the phi bins descend and reverse at the middle
+    bin, thus the steps are [0, 1, 2, 3, 4, 9, 8, 7, 6, 5] for ten bins.
     """
     nphibins = get_viewingdirection_phibincount()
     # pi/2 must be an exact boundary because of the change in behaviour there

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -157,7 +157,7 @@ def zopen(filename: Path | str, mode: str = "rt", encoding: str | None = None, e
     return filepath.open(mode=mode, encoding=encoding, errors=errors)
 
 
-def polars_source(filename: Path | str, mode: str = "r", encoding: str | None = None) -> t.IO[bytes] | Path:
+def polars_source(filename: Path | str, mode: str = "r") -> t.IO[bytes] | Path:
     """Return the path of a file that polars reads itself, or a file object that decompresses it.
 
     polars reads a plain file, a zstd file, and a gzip file from the path. It cannot read an xz file.
@@ -168,7 +168,23 @@ def polars_source(filename: Path | str, mode: str = "r", encoding: str | None = 
         return filepath
 
     # the default mode "r" opens a binary stream in all three backends, which is what polars reads
-    return get_decompress_open(filepath.suffix)(filepath, mode=mode, encoding=encoding)
+    return get_decompress_open(filepath.suffix)(filepath, mode=mode)
+
+
+@contextlib.contextmanager
+def polars_source_open(filename: Path | str, mode: str = "r") -> Generator[t.IO[bytes] | Path]:
+    """Yield a polars source and close it after the caller has read it.
+
+    polars reads a file object when it builds the query plan, thus the object can close as soon as
+    the scan_csv or read_csv call returns. A caller that drops the object instead leaks one file
+    descriptor for each xz file that it reads.
+    """
+    source = polars_source(filename, mode=mode)
+    if isinstance(source, Path):
+        yield source
+    else:
+        with source:
+            yield source
 
 
 def zopenpl(filename: Path | str) -> t.IO[bytes] | Path:
@@ -200,12 +216,7 @@ def scan_lines(filepath: Path, skip_rows: int = 0, encoding: t.Literal["utf8", "
     The function drops the first skip_rows lines. polars_source selects the compression format. The caller
     gives a path that it has resolved, thus this function must not search for a compressed sibling.
     """
-    with contextlib.ExitStack() as stack:
-        source = polars_source(filepath, mode="rb")
-        if not isinstance(source, Path):
-            # polars reads a file object when it makes the plan, thus the file can close after that
-            stack.enter_context(source)
-
+    with polars_source_open(filepath, mode="rb") as source:
         return pl.scan_csv(
             source,
             # the ASCII unit separator, which an ARTIS text file never holds, so that each line stays
@@ -429,11 +440,6 @@ def firstexisting(
         filelist = [Path(x) for x in filelist]
 
     folder = Path(folder)
-    thispath = Path(folder, filelist[0])
-
-    if thispath.exists():
-        return thispath
-
     fullpaths = []
 
     def search_folders(filelist: list[str | Path] | list[Path]) -> Generator[Path]:

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -850,6 +850,46 @@ def mtime_matches_stamp(foundmtime: str | None, textsource_mtime: float) -> bool
         return foundmtime == str(textsource_mtime)
 
 
+def rankbatch_parquet_staleness(
+    parquetfilepath: Path, cacheversion: int, textsource_mtime: float | None, *, textsource_complete: bool
+) -> str | None:
+    """Return the reason why the parquet cache is stale, or None when the cache is current.
+
+    The reader of a run and the writer of one batch both ask this, thus one rule decides whether a
+    conversion of the text files takes place. read_parquet_cache_metadata gives every other reason,
+    e.g. a cache that is absent, damaged, or written for a different cache format version.
+
+    A complete batch compares the newest text file with the stamp of the cache. An incomplete batch
+    compares in one direction only: a text file that is newer than the stamp proves a rewrite, and an
+    absent text file proves nothing. The cache format version applies to a batch of either kind.
+    """
+    # an archived run costs hours to convert again, thus a cache from before the stamps stays in
+    # use. See the accept_unstamped argument of read_parquet_cache_metadata
+    pqmetadata, stalereason = read_parquet_cache_metadata(
+        parquetfilepath, cacheversion, textsource_mtime if textsource_complete else None, accept_unstamped=True
+    )
+    if stalereason is not None or textsource_complete or textsource_mtime is None:
+        return stalereason
+
+    stampedmtime = (pqmetadata or {}).get("textsource_mtime")
+    if stampedmtime is None:
+        return None
+
+    try:
+        stampedvalue = float(stampedmtime)
+    except ValueError:
+        # a stamp that no writer of this repository can produce cannot date the text files
+        return None
+
+    if textsource_mtime > stampedvalue + MTIME_TOLERANCE_S:
+        return (
+            f"a text file of the batch changed at {format_mtime(textsource_mtime)},"
+            f" after the cache stamp of {format_mtime(stampedmtime)}"
+        )
+
+    return None
+
+
 def parquet_is_readable(parquetfilepath: Path) -> bool:
     """Return True when polars can read the metadata of a parquet file.
 

--- a/artistools/misc/fileio.py
+++ b/artistools/misc/fileio.py
@@ -855,12 +855,12 @@ def rankbatch_parquet_staleness(
 ) -> str | None:
     """Return the reason why the parquet cache is stale, or None when the cache is current.
 
-    The reader of a run and the writer of one batch both ask this, thus one rule decides whether a
-    conversion of the text files takes place. read_parquet_cache_metadata gives every other reason,
-    e.g. a cache that is absent, damaged, or written for a different cache format version.
+    The reader of a run and the writer of one batch both ask this. Thus one rule decides whether
+    the code converts the text files again. read_parquet_cache_metadata gives every other reason,
+    e.g. a cache that is absent, a cache that is damaged, or a cache of a different format version.
 
     A complete batch compares the newest text file with the stamp of the cache. An incomplete batch
-    compares in one direction only: a text file that is newer than the stamp proves a rewrite, and an
+    compares in one direction only. A text file that is newer than the stamp proves a rewrite. An
     absent text file proves nothing. The cache format version applies to a batch of either kind.
     """
     # an archived run costs hours to convert again, thus a cache from before the stamps stays in

--- a/artistools/misc/modelinfo.py
+++ b/artistools/misc/modelinfo.py
@@ -254,10 +254,14 @@ def get_runfolder_timesteps(folderpath: Path | str) -> tuple[int, ...]:
         for name in (path.name for path in Path(folderpath).glob("estimators_*.out*"))
         if ".out" in name
     })
-    estimfilepath = (
-        firstexisting_or_none(estimstems[0], folder=folderpath, tryzipped=True, search_subfolders=False)
-        if estimstems
-        else None
+    estimfilepath = next(
+        (
+            found
+            for stem in estimstems
+            if (found := firstexisting_or_none(stem, folder=folderpath, tryzipped=True, search_subfolders=False))
+            is not None
+        ),
+        None,
     )
     if estimfilepath is not None:
         with zopen(estimfilepath) as estfile:

--- a/artistools/misc/modelinfo.py
+++ b/artistools/misc/modelinfo.py
@@ -21,7 +21,7 @@ from artistools.misc.fileio import extra_csv_columns_ignored
 from artistools.misc.fileio import firstexisting
 from artistools.misc.fileio import firstexisting_or_none
 from artistools.misc.fileio import path_is_codecomparison
-from artistools.misc.fileio import polars_source
+from artistools.misc.fileio import polars_source_open
 from artistools.misc.fileio import read_wsv
 from artistools.misc.fileio import readnoncommentline
 from artistools.misc.fileio import zopen
@@ -58,13 +58,14 @@ def get_grid_mapping(modelpath: Path | str) -> tuple[dict[int, list[int]], dict[
     """
     modelpath = Path(modelpath)
     filename = firstexisting("grid.out", tryzipped=True, folder=modelpath)
-    dfgrid = pl.read_csv(
-        polars_source(filename),
-        separator=" ",
-        has_header=False,
-        comment_prefix="#",
-        schema={"cellindex": pl.Int32, "modelgridindex": pl.Int32},
-    )
+    with polars_source_open(filename) as source:
+        dfgrid = pl.read_csv(
+            source,
+            separator=" ",
+            has_header=False,
+            comment_prefix="#",
+            schema={"cellindex": pl.Int32, "modelgridindex": pl.Int32},
+        )
     assoc_cells: dict[int, list[int]] = dict(
         dfgrid
         .group_by("modelgridindex")
@@ -107,15 +108,17 @@ def get_wid_init_at_tmodel(
 @lru_cache(maxsize=16)
 def get_nu_grid(modelpath: Path) -> npt.NDArray[np.floating]:
     """Return an array of frequencies at which the ARTIS spectra are binned by exspec."""
-    specdata = pl.read_csv(
-        polars_source(firstexisting(["spec.out", "specpol.out"], folder=modelpath, tryzipped=True)),
-        separator=" ",
-        has_header=False,
-        skip_rows=1,
-        columns=[0],
-        new_columns=["nu"],
-        **extra_csv_columns_ignored(),
-    )
+    specfile = firstexisting(["spec.out", "specpol.out"], folder=modelpath, tryzipped=True)
+    with polars_source_open(specfile) as source:
+        specdata = pl.read_csv(
+            source,
+            separator=" ",
+            has_header=False,
+            skip_rows=1,
+            columns=[0],
+            new_columns=["nu"],
+            **extra_csv_columns_ignored(),
+        )
     return specdata["nu"].to_numpy()
 
 
@@ -244,8 +247,20 @@ def get_runfolder_timesteps(folderpath: Path | str) -> tuple[int, ...]:
             # the first timestep of a restarted run is duplicate and should be ignored
             restart_timestep = timesteps_contained[0] if timesteps_contained and 0 not in timesteps_contained else None
             return tuple(ts for ts in timesteps_contained if ts != restart_timestep)
-    if estimfiles := sorted(Path(folderpath).glob("estimators_*.out*")):
-        with zopen(estimfiles[0]) as estfile:
+    # a leftover sibling such as estimators_0000.out.bak sorts before estimators_0000.out.zst, thus
+    # the glob alone cannot pick the file. firstexisting_or_none applies the precedence that zopen reads
+    estimstems = sorted({
+        name[: name.index(".out") + len(".out")]
+        for name in (path.name for path in Path(folderpath).glob("estimators_*.out*"))
+        if ".out" in name
+    })
+    estimfilepath = (
+        firstexisting_or_none(estimstems[0], folder=folderpath, tryzipped=True, search_subfolders=False)
+        if estimstems
+        else None
+    )
+    if estimfilepath is not None:
+        with zopen(estimfilepath) as estfile:
             timesteps_contained = sorted({int(line.split()[1]) for line in estfile if line.startswith("timestep ")})
             # the first timestep of a restarted run is duplicate and should be ignored
             restart_timestep = timesteps_contained[0] if timesteps_contained and 0 not in timesteps_contained else None
@@ -402,9 +417,10 @@ def get_dfrankassignments(modelpath: Path | str) -> pl.LazyFrame | None:
         "modelgridrankassignments.out", folder=modelpath, tryzipped=True, search_subfolders=False
     )
     if filerankassignments is not None:
-        return pl.scan_csv(polars_source(filerankassignments), has_header=True, separator=" ").rename(
-            lambda column_name: column_name.removeprefix("#")
-        )
+        with polars_source_open(filerankassignments) as source:
+            return pl.scan_csv(source, has_header=True, separator=" ").rename(
+                lambda column_name: column_name.removeprefix("#")
+            )
     return None
 
 

--- a/artistools/misc/test_misc.py
+++ b/artistools/misc/test_misc.py
@@ -1930,6 +1930,23 @@ def test_get_runfolder_timesteps_of_a_classic_estimator_file_gives_no_timesteps(
     assert get_runfolder_timesteps(runfolder) == ()
 
 
+def test_get_runfolder_timesteps_tries_every_rank_stem(tmp_path: Path) -> None:
+    """The lowest rank can exist only as a sibling that zopen does not read, e.g. a .bak file.
+
+    A later rank then still holds a readable file. A test of the lowest stem alone returned no
+    timestep, thus get_runfolders dropped a folder whose data is present.
+    """
+    from artistools.misc.modelinfo import get_runfolder_timesteps
+
+    (tmp_path / "estimators_0000.out.bak").write_text("junk\n", encoding="utf-8")
+    (tmp_path / "estimators_0001.out").write_text(
+        "timestep 7 modelgridindex 0\ntimestep 8 modelgridindex 0\n", encoding="utf-8"
+    )
+
+    # the first timestep of the file counts as the duplicate of a restart, thus 8 remains
+    assert get_runfolder_timesteps(tmp_path) == (8,)
+
+
 def test_gaussian_filter_wrap_passes_over_a_nan() -> None:
     """A NaN element holds no data, thus the filter must keep it in its own element and give it no weight.
 

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -268,8 +268,8 @@ def apply_time_range_args(args: argparse.Namespace, modelpaths: Sequence[Path | 
         )
 
         # the plot holds one time axis, thus one range in days must serve every model. A timestep
-        # names different days on a different timestep grid, and applying the days of the first
-        # model would show another timestep of the second without a word
+        # names different days on a different timestep grid. The days of the first model would
+        # then show another timestep of the second model, and no message would say so
         if args.timestep is not None:
             for otherpath in artispaths[1:]:
                 _, _, othermin, othermax = get_time_range(otherpath, timestep_range_str=args.timestep)

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -17,7 +17,7 @@ from artistools.misc.cliutils import print_warning
 from artistools.misc.fileio import firstexisting
 from artistools.misc.fileio import firstexisting_or_none
 from artistools.misc.fileio import path_is_codecomparison
-from artistools.misc.fileio import polars_source
+from artistools.misc.fileio import polars_source_open
 from artistools.misc.fileio import read_wsv
 from artistools.misc.modelinfo import get_inputparams
 from artistools.misc.modelinfo import get_model_name
@@ -103,12 +103,13 @@ def get_timesteps(modelpath: Path | str) -> pl.LazyFrame:
     # folder with compressed output does not silently fall back to reconstructing logarithmic timesteps
     tsfilepath = firstexisting_or_none("timesteps.out", folder=modelpath, tryzipped=True, search_subfolders=False)
     if tsfilepath is not None:
-        return (
-            pl
-            .scan_csv(polars_source(tsfilepath), has_header=True, separator=" ")
-            .rename(lambda column_name: column_name.removeprefix("#"))
-            .with_columns(tend_days=pl.col("tstart_days") + pl.col("twidth_days"))
-        )
+        with polars_source_open(tsfilepath) as source:
+            return (
+                pl
+                .scan_csv(source, has_header=True, separator=" ")
+                .rename(lambda column_name: column_name.removeprefix("#"))
+                .with_columns(tend_days=pl.col("tstart_days") + pl.col("twidth_days"))
+            )
 
     # older versions of Artis always used logarithmic timesteps and didn't produce a timesteps.out file
     inputparams = get_inputparams(modelpath)
@@ -293,6 +294,13 @@ def get_time_range(
         if timestepmin > dictvars["last"] or timestepmin < 0:
             msg = get_bad_timestep_message(modelpath, timestepmin)
             raise ValueError(msg)
+
+        if timestepmax < timestepmin:
+            msg = (
+                f"'{timestep_range_str}' names the timestep range {timestepmin} to {timestepmax},"
+                " which ends before it starts"
+            )
+            raise ValueError(msg)
     elif (timemin is not None or timemax is not None) or timedays_range_str is not None:
         if timemin is None and timemax is not None:
             timemin = -1.0
@@ -396,13 +404,14 @@ def get_escaped_arrivalrange(modelpath: Path | str) -> tuple[int, float | int | 
         raise ValueError(msg)
     cornervmax = vmax * math.sqrt(dimensions)
 
-    # if the initial conditions were perfect, then t_arrive = tmin would be valid already
-    # (with a free path, light from the origin at tmin would escape sometime later, but that travel time would be subtracted to get t_arrive = tmin),
-    # but we should at least wait until light signals from the origin reach the corners
+    # perfect initial conditions make t_arrive = tmin valid already. Light from the origin at tmin
+    # escapes later, but the code subtracts that travel time, thus t_arrive stays tmin. The code
+    # still waits until light from the origin reaches the corners
     validrange_start_days = get_timestep_times(modelpath, loc="start")[0] * (1 + cornervmax / C_cm_per_s)
 
     t_end = get_timestep_times(modelpath, loc="end")
-    # find the last possible escape time and subtract the largest possible travel time (observer time correction)
+    # find the last escape time, then subtract the longest travel time from the origin. This is the
+    # correction of the observer time
     try:
         depdata = get_deposition(modelpath=modelpath)  # use this file to find the last computed timestep
         # get_deposition() always provides a timestep column, adding a row index if the file has no such column
@@ -414,8 +423,9 @@ def get_escaped_arrivalrange(modelpath: Path | str) -> tuple[int, float | int | 
     assert isinstance(nts_last, int)
     nts_last_tend = t_end[nts_last]
 
-    # last valid observer time is escape at the end of the latest computed timestep minus the longest travel time relative to origin
-    # assume we're on a 3D propagation grid for safety (1D or 2D could reduce the travel time somewhat)
+    # the last observer time is the escape at the end of the last computed timestep, minus the
+    # longest travel time from the origin. The code assumes a 3D propagation grid, which is the safe
+    # assumption. A 1D grid or a 2D grid can give a shorter travel time
     validrange_end_days: float | int = nts_last_tend * (1 - vmax * math.sqrt(3) / C_cm_per_s)
 
     if validrange_start_days > validrange_end_days:

--- a/artistools/misc/timesteps.py
+++ b/artistools/misc/timesteps.py
@@ -1,10 +1,12 @@
 """Timestep definitions, time range selection, and deposition rates."""
 
+import argparse
 import contextlib
 import math
 import re
 import typing as t
 from collections.abc import Iterable
+from collections.abc import Sequence
 from functools import lru_cache
 from pathlib import Path
 
@@ -12,10 +14,13 @@ import numpy as np
 import polars as pl
 
 from artistools.constants import C_cm_per_s
+from artistools.misc.cliutils import exit_with_error
 from artistools.misc.cliutils import parse_float_range
 from artistools.misc.cliutils import print_warning
 from artistools.misc.fileio import firstexisting
 from artistools.misc.fileio import firstexisting_or_none
+from artistools.misc.fileio import get_model_folder
+from artistools.misc.fileio import path_is_artis_model
 from artistools.misc.fileio import path_is_codecomparison
 from artistools.misc.fileio import polars_source_open
 from artistools.misc.fileio import read_wsv
@@ -236,6 +241,50 @@ def parse_timestep_token(token: str, dictvars: dict[str, int]) -> int:
     token = token.strip()
 
     return dictvars[token] if token in dictvars else int(token)
+
+
+def apply_time_range_args(args: argparse.Namespace, modelpaths: Sequence[Path | str]) -> None:
+    """Narrow the plotted time range from -timestep or from a -timedays range.
+
+    -timemin and -timemax give the range directly. A single -timedays value names one time for
+    --brightnessattime, thus only a value that holds a range takes part here.
+    """
+    dayrange = parse_timedays_range(args.timedays) if args.timedays is not None else None
+    if args.timestep is dayrange is None:
+        return
+
+    # only a timestep needs the times of a model. A reference light curve holds no such data, thus a
+    # command that plots reference data alone still takes a range in days
+    # a path can name a light curve file of a run, and get_time_range reads the folder of the run
+    artispaths = [get_model_folder(path) for path in modelpaths if path_is_artis_model(path)]
+    if not artispaths:
+        if dayrange is None:
+            msg = "-timestep names a timestep of an ARTIS model, and no model path gives one. Give -timedays"
+            raise ValueError(msg)
+        rangemin, rangemax = dayrange
+    else:
+        _, _, rangemin, rangemax = get_time_range(
+            artispaths[0], timestep_range_str=args.timestep, timedays_range_str=args.timedays
+        )
+
+        # the plot holds one time axis, thus one range in days must serve every model. A timestep
+        # names different days on a different timestep grid, and applying the days of the first
+        # model would show another timestep of the second without a word
+        if args.timestep is not None:
+            for otherpath in artispaths[1:]:
+                _, _, othermin, othermax = get_time_range(otherpath, timestep_range_str=args.timestep)
+                if abs(othermin - rangemin) > 1e-4 or abs(othermax - rangemax) > 1e-4:
+                    exit_with_error(
+                        f"timestep {args.timestep} covers {rangemin:.2f} to {rangemax:.2f} days in "
+                        f"{get_model_name(artispaths[0])} and {othermin:.2f} to {othermax:.2f} days in "
+                        f"{get_model_name(otherpath)}, because their timestep grids differ. Give the "
+                        "range in days with -timedays, which means the same for every model"
+                    )
+
+    if args.timemin is None:
+        args.timemin = rangemin
+    if args.timemax is None:
+        args.timemax = rangemax
 
 
 def get_time_range(

--- a/artistools/nltepops/nltepops.py
+++ b/artistools/nltepops/nltepops.py
@@ -119,7 +119,8 @@ def add_lte_pops(
             continue
 
         if not noprint:
-            print(f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]} has a superlevel at level {levelnumber_sl}")
+            ionstr = at.get_ionstring(Z, ion_stage, style="spectral")
+            print(f"{ionstr} has a superlevel at level {levelnumber_sl}")
 
         if (Z, ion_stage, levelnumber_sl) not in superlevelpops_of_ion:
             ionlevels = ionlevels_of_ion[Z, ion_stage]

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -370,7 +370,7 @@ def make_ionsubplot(
     )
 
     print(
-        f"{at.get_elsymbol(atomic_number)} {at.roman_numerals[ion_stage]} has a summed "
+        f"{at.get_ionstring(atomic_number, ion_stage, style='spectral')} has a summed "
         f"level population of {ionpopulation:.1f} (from estimator file ion pop = {ionpopulation_fromest})"
     )
 

--- a/artistools/nltepops/plotnltepops.py
+++ b/artistools/nltepops/plotnltepops.py
@@ -21,6 +21,7 @@ from artistools.commands import run_subcommand
 from artistools.constants import km_to_cm
 from artistools.misc import addarg_axislimits
 from artistools.misc import addarg_figscale
+from artistools.misc import addarg_labelfontsize
 from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_nolegend
 from artistools.misc import addarg_notitle
@@ -570,8 +571,6 @@ def plot_populations_with_time_or_velocity(
                 pop_of_level.setdefault(level, n_nlte)
             for ionlevel in ionlevels:
                 populations[timestep, ionlevel, mgi] = pop_of_level[ionlevel]
-                # populationsLTE[(timestep, ionlevel)] = (timesteppops.loc[timesteppops['level']
-                #                                                          == ionlevel]['n_LTE'].values[0])
 
         for ionlevel in ionlevels:
             plottimesteps = [ts for ts, level, _mgi in populations if level == ionlevel]
@@ -579,8 +578,6 @@ def plot_populations_with_time_or_velocity(
             plotpopulations = np.array([
                 populations[ts, level, mgi] for ts, level, mgi in populations if level == ionlevel
             ])
-            # plotpopulationsLTE = np.array([float(populationsLTE[ts, level]) for ts, level in populationsLTE.keys()
-            #                             if level == ionlevel])
             linelabel = str(levelconfignames[ionlevel])
 
             if args.x == "time":
@@ -588,8 +585,6 @@ def plot_populations_with_time_or_velocity(
             elif args.x == "velocity":
                 plotvelocities = [float(velocity[mgi]) for _ts, level, mgi in populations if level == ionlevel]
                 ax.plot(plotvelocities, plotpopulations, marker=markers[modelnumber], label=linelabel)
-            # plt.plot(timedayslist, plotpopulationsLTE, marker=markers[modelnumber+1],
-            #          label=f'level {ionlevel} {modelname} LTE')
 
 
 def get_subplot_block(mgilistindex: int, nionstages: int) -> tuple[int, int]:
@@ -692,7 +687,8 @@ def make_singletimestep_plot(
 
         if dfpop.is_empty():
             print(f"No NLTE population data for modelgrid cell {modelgridindex} timestep {timestep}")
-            return
+            # skip this cell alone. A return would discard the panels that the earlier cells filled
+            continue
 
         dfpop = dfpop.filter(pl.col("Z") == atomic_number)
 
@@ -818,12 +814,7 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     addarg_show(parser)
     addarg_verbose(parser)
 
-    parser.add_argument(
-        "-labelfontsize",
-        type=float,
-        default=None,
-        help="Font size of the tick labels. The default comes from the artistools matplotlibrc",
-    )
+    addarg_labelfontsize(parser)
 
     addarg_axislimits(parser)
 

--- a/artistools/nonthermal/solvespencerfanocmd.py
+++ b/artistools/nonthermal/solvespencerfanocmd.py
@@ -217,6 +217,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         print(f"timestep {args.timestep} cell {args.modelgridindex} (v={velocity} km/s at {args.timedays:.1f}d)")
 
     stepcount = 9 if args.vary else 1
+    # the -ostat header names the ions one time, thus every step must hold the same list
+    ostat_ions: list[str] = []
     for step in range(stepcount):
         emin = args.emin
         emax = args.emax
@@ -258,11 +260,24 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
                 derived_transitions_columns=("epsilon_trans_ev", "lower_g", "upper_g"),
             )
 
-        if step == 0 and args.ostat:
-            strheader = "#emin emax npts x_e frac_sum frac_excitation frac_ionization frac_heating"
-            for atomic_number, ion_stage in ions:
-                strheader += " frac_ionization_" + at.get_ionstring(atomic_number, ion_stage, sep="")
-            Path(args.ostat).write_text(strheader + "\n", encoding="utf-8")
+        if args.ostat:
+            ostat_ions_thisstep = [
+                at.get_ionstring(atomic_number, ion_stage, sep="") for atomic_number, ion_stage in ions
+            ]
+            if step == 0:
+                strheader = "#emin emax npts x_e frac_sum frac_excitation frac_ionization frac_heating"
+                for ionstr in ostat_ions_thisstep:
+                    strheader += f" frac_ionization_{ionstr}"
+                Path(args.ostat).write_text(strheader + "\n", encoding="utf-8")
+                ostat_ions = ostat_ions_thisstep
+            elif ostat_ions_thisstep != ostat_ions:
+                # the file gives one column for each ion, and the header names them one time
+                msg = (
+                    f"-ostat names one column for each ion, but step {step} holds"
+                    f" {ostat_ions_thisstep} and the header names {ostat_ions}."
+                    " Give a -vary mode that keeps the ion list, or leave out -ostat"
+                )
+                raise ValueError(msg)
 
         with pynt.SpencerFanoSolver(emin_ev=emin, emax_ev=emax, npts=npts, verbose=True) as sf:
             for Z, ion_stage in ions:

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -267,7 +267,7 @@ def readfile_text(packetsfiletext: Path | str, column_names: list[str]) -> pl.Da
         "stokes_i": pl.Float32,
         "stokes_q": pl.Float32,
         "stokes_u": pl.Float32,
-        "t_decay": pl.Float32,
+        "tdecay": pl.Float32,
         "true_emission_velocity": pl.Float32,
         "trueem_posx": pl.Float32,
         "trueem_posy": pl.Float32,
@@ -619,8 +619,7 @@ def get_packets(
     # redundant I=1.0 that new cache files omit. Thus stokes2 is Q and stokes3 is U. Such a cache is
     # accepted without a version check when the run has no packet text files any more
     pldfpackets = pl.scan_parquet(packetsparquetfiles).rename(
-        {"originated_from_positron": "originated_from_particlenotgamma", "stokes2": "stokes_q", "stokes3": "stokes_u"},
-        strict=False,
+        {"stokes2": "stokes_q", "stokes3": "stokes_u"}, strict=False
     )
 
     npkts_total = pldfpackets.select(pl.len()).collect().item()
@@ -741,7 +740,9 @@ def add_packet_directions_lazypolars(dfpackets: pl.LazyFrame | pl.DataFrame) -> 
             .alias("phi")
         )
 
-    return dfpackets.drop(["dirmag", "vec1_x", "vec1_y", "vec1_z"])
+    # the columns above are created only when the frame does not already carry the angles, thus the
+    # drop must accept a name that this call did not add
+    return dfpackets.drop(["dirmag", "vec1_x", "vec1_y", "vec1_z"], strict=False)
 
 
 def bin_packet_directions_polars(

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -18,11 +18,9 @@ from artistools.constants import C_cm_per_s as CLIGHT
 from artistools.constants import day_to_s
 from artistools.constants import km_to_cm
 from artistools.misc import print_warning
-from artistools.misc import read_parquet_cache_metadata
 from artistools.misc.fileio import COMPRESSED_EXTENSIONS
-from artistools.misc.fileio import format_mtime
-from artistools.misc.fileio import MTIME_TOLERANCE_S
 from artistools.misc.fileio import parquet_is_readable
+from artistools.misc.fileio import rankbatch_parquet_staleness
 
 type_ids = {"TYPE_GAMMA": 10, "TYPE_RPKT": 11, "TYPE_NTLEPTON": 20, "TYPE_ESCAPE": 32}
 
@@ -415,27 +413,13 @@ def get_packets_rankbatch_parquetfile(
         # modification times give no full comparison, but the cache format version still applies
         textsource_mtime = max(textsource_mtimes) if allranksfound else None
 
-        # an archived run of packets costs hours to convert again, thus a cache from before the stamps
-        # stays in use. See the accept_unstamped argument of read_parquet_cache_metadata
-        pqmetadata, stalereason = read_parquet_cache_metadata(
-            parquetfilepath, CACHEVERSION, textsource_mtime, accept_unstamped=True
+        # one rule decides the freshness of every batch cache of this repository
+        stalereason = rankbatch_parquet_staleness(
+            parquetfilepath,
+            CACHEVERSION,
+            max(textsource_mtimes) if textsource_mtimes else None,
+            textsource_complete=allranksfound,
         )
-
-        if stalereason is None and not allranksfound and textsource_mtimes:
-            # a text file that is newer than the stamp proves that a restart rewrote the source after
-            # the cache. An absent text file gives no proof, thus only this one test applies
-            stampedmtime = (pqmetadata or {}).get("textsource_mtime")
-            try:
-                # a stamp that no writer of this repository can produce dates no text file
-                stampedvalue = float(stampedmtime) if stampedmtime is not None else None
-            except ValueError:
-                stampedvalue = None
-
-            if stampedvalue is not None and max(textsource_mtimes) > stampedvalue + MTIME_TOLERANCE_S:
-                stalereason = (
-                    f"a text file of the batch changed at {format_mtime(max(textsource_mtimes))},"
-                    f" after the cache stamp of {format_mtime(stampedmtime)}"
-                )
 
         if stalereason is None:
             conversion_needed = False
@@ -452,7 +436,7 @@ def get_packets_rankbatch_parquetfile(
                 f" ranks {batch_mpiranks[0]} to {batch_mpiranks[-1]}, because {stalereason}."
                 " File will be regenerated..."
             )
-        elif pqmetadata is not None or parquet_is_readable(parquetfilepath):
+        elif parquet_is_readable(parquetfilepath):
             # the text files are incomplete, thus no conversion can replace this cache. The data can
             # be older than the text files that remain, thus the user needs a warning
             conversion_needed = False

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -409,11 +409,10 @@ def get_packets_rankbatch_parquetfile(
         # restart rewrote then makes the whole batch cache stale
         textsource_mtimes = get_packets_textsource_mtimes(modelpath, text_filenames)
         allranksfound = len(textsource_mtimes) == len(batch_mpiranks)
-        # a text file of the batch is absent, thus artistools cannot do a new conversion. The
-        # modification times give no full comparison, but the cache format version still applies
-        textsource_mtime = max(textsource_mtimes) if allranksfound else None
 
-        # one rule decides the freshness of every batch cache of this repository
+        # one rule decides the freshness of every batch cache of this repository. A text file of the
+        # batch that is absent gives no full comparison of the modification times, but the cache
+        # format version still applies
         stalereason = rankbatch_parquet_staleness(
             parquetfilepath,
             CACHEVERSION,

--- a/artistools/packets/packets.py
+++ b/artistools/packets/packets.py
@@ -724,8 +724,8 @@ def add_packet_directions_lazypolars(dfpackets: pl.LazyFrame | pl.DataFrame) -> 
             .alias("phi")
         )
 
-    # the columns above are created only when the frame does not already carry the angles, thus the
-    # drop must accept a name that this call did not add
+    # the code above creates these columns only for a frame that carries no angles. Thus the drop
+    # must accept a name that this call did not add
     return dfpackets.drop(["dirmag", "vec1_x", "vec1_y", "vec1_z"], strict=False)
 
 

--- a/artistools/packets/packetsplots.py
+++ b/artistools/packets/packetsplots.py
@@ -100,7 +100,7 @@ def packets_2d_hist_bin_and_ejecta_vel(
     """Plot a 2D histogram of packet emission position against ejecta velocity, and save the figure."""
     start_of_filename = "" if modelpath == Path() else f"{modelpath.name}_"
     if wavelen is not None:
-        start_of_filename = f"{wavelen:.0f}A_"
+        start_of_filename = f"{start_of_filename}{wavelen:.0f}A_"
     start_of_filename = f"{start_of_filename}Z={Z}_" if Z else f"{start_of_filename}allelements_"
     start_of_filename = f"{start_of_filename}I={ion_stage_str}_" if ion_stage_str else f"{start_of_filename}allions_"
 

--- a/artistools/packets/test_packets.py
+++ b/artistools/packets/test_packets.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import numpy as np
 import polars as pl
+import polars.testing as pltest
 import pytest
 
 import artistools as at
@@ -288,3 +289,17 @@ def test_packets_source_index_matches_the_reader(tmp_path: Path) -> None:
     mtimes = at.packets.get_packets_textsource_mtimes(tmp_path, [*filenames, "packets00_0002.out"])
     expected = [at.firstexisting(filename, folder=tmp_path).stat().st_mtime for filename in filenames]
     assert sorted(mtimes) == pytest.approx(sorted(expected))
+
+
+def test_add_packet_directions_accepts_a_frame_that_holds_the_angles() -> None:
+    """A frame that already carries phi must pass through, because the parquet cache stores it."""
+    dfpackets = pl.LazyFrame({"dirx": [0.6, 0.0], "diry": [0.0, 0.8], "dirz": [0.8, 0.6]})
+
+    dfonce = at.packets.add_packet_directions_lazypolars(dfpackets).collect()
+    assert "phi" in dfonce.columns
+    assert "vec1_x" not in dfonce.columns
+
+    # the drop named the vec1 columns whatever the input held, thus this raised ColumnNotFoundError
+    dftwice = at.packets.add_packet_directions_lazypolars(dfonce).collect()
+
+    pltest.assert_frame_equal(dfonce, dftwice)

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -145,8 +145,8 @@ def bin_packets_by_direction(
 
     if "temperature" in plotvars or "temperature_sigma" in plotvars or nnelement_vars:
         assert dfestimators is not None
-        # only the variables that this plot draws, thus a null in a column that no plot var names
-        # cannot remove a row
+        # select only the variables that this plot draws. A null in a column that no plot
+        # variable names then cannot remove a row
         wants_temperature = "temperature" in plotvars or "temperature_sigma" in plotvars
         estimatorvars = ["TR", *nnelement_vars] if wants_temperature else nnelement_vars
         dfestimators = (

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -436,13 +436,10 @@ def main(args: argparse.Namespace | None = None, argsraw: list[str] | None = Non
     )
 
     outputfilenames = []
-    for timebin, ((tstart, tend, label), timerange) in enumerate(zip(time_ranges, timeranges, strict=True)):
-        if tstart is not None and tend is not None:
-            print(f"Plotting spherical map for {tstart:.2f}-{tend:.2f} days {label}")
-        elif tend is not None:
-            print(f"Plotting spherical map up to {tend:.2f} days {label}")
-        elif tstart is not None:
-            print(f"Plotting spherical map from {tstart:.2f} days {label}")
+    for timebin, ((_tstart, _tend, label), timerange) in enumerate(zip(time_ranges, timeranges, strict=True)):
+        # the resolved range, not the requested one: resolve_time_range replaces a bound that the
+        # command line left open, thus a requested bound can be absent and can name another time
+        print(f"Plotting spherical map for {timerange[0]:.2f}-{timerange[1]:.2f} days {label}")
         fig, axes = plot_spherical(
             dfdirbins.filter(pl.col("timebin") == timebin),
             plotvars=args.plotvars,

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -23,6 +23,8 @@ from artistools.misc import addarg_modelpath
 from artistools.misc import addarg_notitle
 from artistools.misc import addarg_output
 from artistools.misc import addarg_show
+from artistools.misc import addarg_timeminmax
+from artistools.misc import addarg_timestep
 from artistools.misc import addarg_verbose
 from artistools.misc import gaussian_filter_wrap
 from artistools.misc import print_theta_phi_definitions
@@ -143,9 +145,14 @@ def bin_packets_by_direction(
 
     if "temperature" in plotvars or "temperature_sigma" in plotvars or nnelement_vars:
         assert dfestimators is not None
+        # only the variables that this plot draws, thus a null in a column that no plot var names
+        # cannot remove a row
+        estimatorvars = (["TR"] if "temperature" in plotvars or "temperature_sigma" in plotvars else []) + list(
+            nnelement_vars
+        )
         dfestimators = (
             dfestimators
-            .select(["timestep", "modelgridindex", "TR", *nnelement_vars])
+            .select(["timestep", "modelgridindex", *estimatorvars])
             .drop_nulls()
             .rename({"timestep": "em_timestep", "modelgridindex": "em_modelgridindex"})
         )
@@ -315,9 +322,12 @@ def plot_spherical(
 def addargs(parser: argparse.ArgumentParser) -> None:
     """Add arguments to an argparse parser object."""
     addarg_modelpath(parser, default=Path())
-    parser.add_argument("-timestep", "-ts", default=None, help="Timestep number to plot, e.g. 40, last, or 40-45")
-    parser.add_argument("-timemin", "-tmin", action="store", type=float, default=None, help="Time minimum [d]")
-    parser.add_argument("-timemax", "-tmax", action="store", type=float, default=None, help="Time maximum [d]")
+    addarg_timestep(parser)
+    addarg_timeminmax(parser)
+    # the old spellings stay as aliases, because a script and a note hold them. SUPPRESS keeps the
+    # help text to one spelling
+    parser.add_argument("-tmin", dest="timemin", type=float, help=argparse.SUPPRESS)
+    parser.add_argument("-tmax", dest="timemax", type=float, help=argparse.SUPPRESS)
     parser.add_argument("-nphibins", action="store", type=int, default=64, help="Number of azimuthal bins")
     parser.add_argument("-ncosthetabins", action="store", type=int, default=32, help="Number of polar angle bins")
     addarg_maxpacketfiles(parser)
@@ -428,8 +438,12 @@ def main(args: argparse.Namespace | None = None, argsraw: list[str] | None = Non
 
     outputfilenames = []
     for timebin, ((tstart, tend, label), timerange) in enumerate(zip(time_ranges, timeranges, strict=True)):
-        if tend is not None:
+        if tstart is not None and tend is not None:
             print(f"Plotting spherical map for {tstart:.2f}-{tend:.2f} days {label}")
+        elif tend is not None:
+            print(f"Plotting spherical map up to {tend:.2f} days {label}")
+        elif tstart is not None:
+            print(f"Plotting spherical map from {tstart:.2f} days {label}")
         fig, axes = plot_spherical(
             dfdirbins.filter(pl.col("timebin") == timebin),
             plotvars=args.plotvars,

--- a/artistools/plotspherical.py
+++ b/artistools/plotspherical.py
@@ -147,9 +147,8 @@ def bin_packets_by_direction(
         assert dfestimators is not None
         # only the variables that this plot draws, thus a null in a column that no plot var names
         # cannot remove a row
-        estimatorvars = (["TR"] if "temperature" in plotvars or "temperature_sigma" in plotvars else []) + list(
-            nnelement_vars
-        )
+        wants_temperature = "temperature" in plotvars or "temperature_sigma" in plotvars
+        estimatorvars = ["TR", *nnelement_vars] if wants_temperature else nnelement_vars
         dfestimators = (
             dfestimators
             .select(["timestep", "modelgridindex", *estimatorvars])

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -222,7 +222,7 @@ def plot_polarisation(modelpath: Path, args: argparse.Namespace) -> None:
     timearray = dfspectrum.columns[1:-1]
     # locals, not a write-back onto args: this function runs once for each model, and a range that
     # one model resolved would then reach the next one. get_time_range refuses a timemin that sits
-    # after the last timestep, thus a shorter model was dropped with one line
+    # after the last timestep, thus it dropped a shorter model and printed one line
     (_, _, timemin, timemax) = get_time_range(modelpath, args.timestep, args.timemin, args.timemax, args.timedays)
     assert timemin is not None
     assert timemax is not None
@@ -658,7 +658,7 @@ def plot_artis_spectrum(
 
             if args.binflux:
                 assert args.xunit.lower() == "angstroms"
-                # f_lambda is binned as well, because --write_data returns that column. The earlier
+                # bin f_lambda as well, because --write_data returns that column. The earlier
                 # code gave it the value of y, which holds the selected y variable
                 dfspectrum = (
                     atspectra
@@ -1048,8 +1048,8 @@ def plot_reference_spectra(
 
         if index < len(args.color):
             plotkwargs["color"] = args.color[index]
-            # the dict is shared across the loop, thus a spectrum with no -label must not keep the
-            # label of the spectrum before it. Its own metadata names it instead
+            # the loop shares one dict, thus a spectrum with no -label must not keep the label of
+            # the spectrum before it. Its own metadata names it instead
             plotkwargs.pop("label", None)
             if args.label[index] is not None:
                 plotkwargs["label"] = args.label[index]
@@ -1271,7 +1271,7 @@ def make_plot(args: argparse.Namespace) -> tuple[mplfig.Figure, npt.NDArray[np.o
         legendncol = 1
         defaultoutputfile = Path("plotspectra_{timemin:.2f}d-{timemax:.2f}d.pdf")
 
-        # the legend comes from the first of the axes that were drawn on, which is axes[0] for
+        # the legend comes from the first axis that a plot used, which is axes[0] for
         # --multispecplot and axes[-1] otherwise
         specaxes = list(axes) if args.multispecplot else [axes[-1]]
         dfalldata = make_spectrum_plot(args.specpath, specaxes, filterfunc, args, scale_to_peak=scale_to_peak)
@@ -1623,8 +1623,8 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.timedays = args.timedayslist[0]
 
     # one time axis serves every model, thus the range resolves one time and before any plot runs.
-    # The plot functions used to write it back onto args as they drew, thus the range of one model
-    # reached the next one and get_time_range then dropped a model whose run ends earlier
+    # The plot functions used to write it back onto args as they drew. The range of one model then
+    # reached the next one, and get_time_range dropped a model whose run ends earlier
     apply_time_range_args(args, args.specpath)
     if args.timemin is None and args.timedays is not None:
         # a single -timedays names one time, thus apply_time_range_args leaves it alone. The output

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -43,6 +43,7 @@ from artistools.misc import addarg_timestep
 from artistools.misc import addarg_verbose
 from artistools.misc import addarg_viewingangle
 from artistools.misc import addarg_yscale
+from artistools.misc import apply_time_range_args
 from artistools.misc import df_filter_minmax_bracketed
 from artistools.misc import exit_with_error
 from artistools.misc import find_reference_data_file
@@ -219,13 +220,14 @@ def plot_polarisation(modelpath: Path, args: argparse.Namespace) -> None:
     dfspectrum = stokes_params[args.stokesparam].with_columns(lambda_angstroms=c_ang_per_s / pl.col("nu")).collect()
 
     timearray = dfspectrum.columns[1:-1]
-    (_, _, args.timemin, args.timemax) = get_time_range(
-        modelpath, args.timestep, args.timemin, args.timemax, args.timedays
-    )
-    assert args.timemin is not None
-    assert args.timemax is not None
+    # locals, not a write-back onto args: this function runs once for each model, and a range that
+    # one model resolved would then reach the next one. get_time_range refuses a timemin that sits
+    # after the last timestep, thus a shorter model was dropped with one line
+    (_, _, timemin, timemax) = get_time_range(modelpath, args.timestep, args.timemin, args.timemax, args.timedays)
+    assert timemin is not None
+    assert timemax is not None
 
-    timeavg_float = (args.timemin + args.timemax) / 2.0
+    timeavg_float = (timemin + timemax) / 2.0
 
     def timedistance(timestr: str) -> float:
         return abs(float(timestr) - timeavg_float)
@@ -491,12 +493,15 @@ def plot_artis_spectrum(
 
     for axindex, axis in enumerate(axes):
         assert isinstance(axis, mplax.Axes)
+        # locals, not a write-back onto args: this function runs once for each model and once for
+        # each axis. A range that one of them resolved would reach the next one, and get_time_range
+        # then drops a model whose last timestep ends before that range
         if args.multispecplot:
-            (timestepmin, timestepmax, args.timemin, args.timemax) = get_time_range(
+            (timestepmin, timestepmax, timemin, timemax) = get_time_range(
                 modelpath, timedays_range_str=args.timedayslist[axindex], clamp_to_timesteps=clamp_to_timesteps
             )
         else:
-            (timestepmin, timestepmax, args.timemin, args.timemax) = get_time_range(
+            (timestepmin, timestepmax, timemin, timemax) = get_time_range(
                 modelpath,
                 args.timestep,
                 args.timemin,
@@ -508,10 +513,10 @@ def plot_artis_spectrum(
         if timestepmin == timestepmax == -1:
             return None
 
-        assert args.timemin is not None
-        assert args.timemax is not None
-        timeavg = (args.timemin + args.timemax) / 2.0
-        timedelta = (args.timemax - args.timemin) / 2
+        assert timemin is not None
+        assert timemax is not None
+        timeavg = (timemin + timemax) / 2.0
+        timedelta = (timemax - timemin) / 2
         linelabel_is_custom = linelabel is not None
         if linelabel is None:
             modelname = get_model_name(modelpath)
@@ -526,12 +531,12 @@ def plot_artis_spectrum(
         # the label carries LaTeX for the figure, thus the log line shows the plain form
         print_heading(
             f"'{plain_label(linelabel)}' timesteps {timestepmin} to {timestepmax} "
-            f"({args.timemin:.3f} to {args.timemax:.3f}d"
+            f"({timemin:.3f} to {timemax:.3f}d"
             f"{'' if clamp_to_timesteps else ' not necessarily clamped to timestep start/end'})"
         )
         print_detail(f"modelpath: {modelpath}")
 
-        check_time_range_is_valid(modelpath, args.timemin, args.timemax, args.plotinvalidpart)
+        check_time_range_is_valid(modelpath, timemin, timemax, args.plotinvalidpart)
 
         xmin, xmax = axis.get_xlim()
         if from_packets:
@@ -548,8 +553,8 @@ def plot_artis_spectrum(
 
             viewinganglespectra = atspectra.get_from_packets(
                 modelpath,
-                timelowdays=args.timemin,
-                timehighdays=args.timemax,
+                timelowdays=timemin,
+                timehighdays=timemax,
                 lambda_bin_edges=lambda_bin_edges,
                 use_time=use_time,
                 maxpacketfiles=maxpacketfiles,
@@ -565,7 +570,7 @@ def plot_artis_spectrum(
             # read virtual packet files (after running plotartisspectrum --makevspecpol)
             vpkt_config = get_vpkt_config(modelpath)
             if vpkt_config["time_limits_enabled"] and (
-                args.timemin < vpkt_config["initial_time"] or args.timemax > vpkt_config["final_time"]
+                timemin < vpkt_config["initial_time"] or timemax > vpkt_config["final_time"]
             ):
                 print(
                     f"Timestep out of range of virtual packets: start time {vpkt_config['initial_time']} days "
@@ -575,13 +580,7 @@ def plot_artis_spectrum(
 
             viewinganglespectra = {
                 dirbin: atspectra.get_vspecpol_spectrum(
-                    modelpath,
-                    timeavg,
-                    dirbin,
-                    args,
-                    fluxfilterfunc=filterfunc,
-                    timemin=args.timemin,
-                    timemax=args.timemax,
+                    modelpath, timeavg, dirbin, args, fluxfilterfunc=filterfunc, timemin=timemin, timemax=timemax
                 )
                 for dirbin in directionbins
                 if dirbin >= 0
@@ -724,9 +723,7 @@ def make_spectrum_plot(
                     plot_reference_spectrum_for_args(specpath, axis, args, filterfunc, scale_to_peak, **plotkwargs)
             refspecindex += 1
         elif path_is_codecomparison(specpath):
-            (_timestepmin, _timestepmax, args.timemin, args.timemax) = get_time_range(
-                specpath, args.timestep, args.timemin, args.timemax, args.timedays
-            )
+            get_time_range(specpath, args.timestep, args.timemin, args.timemax, args.timedays)
             timeavg = args.timedays
             from artistools.codecomparison import plot_spectrum
 
@@ -815,6 +812,8 @@ def get_emission_contributions(
     xmax: float,
     timestepmin: int,
     timestepmax: int,
+    timemin: float,
+    timemax: float,
     dirbin: int | None,
 ) -> tuple[list[atspectra.FluxContributionTuple], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
     """Return the flux contribution of each series, the total emitted flux, and the wavelength grid.
@@ -869,8 +868,8 @@ def get_emission_contributions(
 
     return atspectra.get_flux_contributions_from_packets(
         modelpath,
-        timelowdays=args.timemin,
-        timehighdays=args.timemax,
+        timelowdays=timemin,
+        timehighdays=timemax,
         lambda_bin_edges=lambda_bin_edges,
         getemission=args.showemission,
         getabsorption=args.showabsorption,
@@ -1067,12 +1066,14 @@ def plot_reference_spectra(
     return plotobjects, plotobjectlabels, ymaxrefall
 
 
-def get_emission_plot_label(modelpath: Path, args: argparse.Namespace, modelname: str, dirbin: int | None) -> str:
+def get_emission_plot_label(
+    modelpath: Path, args: argparse.Namespace, modelname: str, dirbin: int | None, timemin: float, timemax: float
+) -> str:
     """Return the title of the plot, which names the model, the time range, and the direction bin."""
     if args.title:
         return str(args.title)
 
-    plotlabel = f"{modelname} [{args.timemin:.2f}d to {args.timemax:.2f}d]"
+    plotlabel = f"{modelname} [{timemin:.2f}d to {timemax:.2f}d]"
     if not (args.plotviewingangle or args.plotvspecpol):
         return plotlabel
 
@@ -1105,7 +1106,8 @@ def make_emissionabsorption_plot(
     print_heading(modelname)
     clamp_to_timesteps = not args.notimeclamp
 
-    (timestepmin, timestepmax, args.timemin, args.timemax) = get_time_range(
+    # locals, not a write-back onto args, for the reason given in plot_artis_spectrum
+    (timestepmin, timestepmax, timemin, timemax) = get_time_range(
         modelpath, args.timestep, args.timemin, args.timemax, args.timedays, clamp_to_timesteps=clamp_to_timesteps
     )
 
@@ -1113,7 +1115,7 @@ def make_emissionabsorption_plot(
         print(f"Can't plot {modelname}...skipping")
         return [], [], pl.DataFrame()
 
-    check_time_range_is_valid(modelpath, args.timemin, args.timemax, args.plotinvalidpart)
+    check_time_range_is_valid(modelpath, timemin, timemax, args.plotinvalidpart)
 
     if args.plotvspecpol and not args.frompackets:
         args.frompackets = True
@@ -1126,11 +1128,12 @@ def make_emissionabsorption_plot(
     if args.groupby is None:
         args.groupby = "nuc" if args.gamma else "ion"
 
-    assert args.timemin is not None
-    assert args.timemax is not None
+    assert timemin is not None
+    assert timemax is not None
 
     print(
-        f"Plotting {modelname} timesteps {timestepmin} to {timestepmax} ({args.timemin:.3f} to {args.timemax:.3f}d{'' if clamp_to_timesteps else ' not necessarily clamped to timestep start/end'})"
+        f"Plotting {modelname} timesteps {timestepmin} to {timestepmax} ({timemin:.3f} to {timemax:.3f}d"
+        f"{'' if clamp_to_timesteps else ' not necessarily clamped to timestep start/end'})"
     )
 
     xmin, xmax = axis.get_xlim()
@@ -1138,7 +1141,7 @@ def make_emissionabsorption_plot(
     dirbin = args.plotviewingangle[0] if args.plotviewingangle else args.plotvspecpol[0] if args.plotvspecpol else None
 
     contribution_list, array_flambda_emission_total, arraylambda_angstroms = get_emission_contributions(
-        modelpath, args, filterfunc, xmin, xmax, timestepmin, timestepmax, dirbin
+        modelpath, args, filterfunc, xmin, xmax, timestepmin, timestepmax, timemin, timemax, dirbin
     )
 
     atspectra.print_integrated_flux(array_flambda_emission_total, arraylambda_angstroms)
@@ -1199,7 +1202,7 @@ def make_emissionabsorption_plot(
 
     axis.axhline(color="black", linewidth=1)
 
-    set_plot_title(axis, get_emission_plot_label(modelpath, args, modelname, dirbin), args)
+    set_plot_title(axis, get_emission_plot_label(modelpath, args, modelname, dirbin, timemin, timemax), args)
 
     if args.ymax is None:
         axis.set_ylim(top=max(ymaxrefall, scalefactor * max_f_emission_total * 1.2))
@@ -1274,8 +1277,6 @@ def make_plot(args: argparse.Namespace) -> tuple[mplfig.Figure, npt.NDArray[np.o
         dfalldata = make_spectrum_plot(args.specpath, specaxes, filterfunc, args, scale_to_peak=scale_to_peak)
         plotobjects, plotobjectlabels = specaxes[0].get_legend_handles_labels()
 
-    # the annotation comes after the plot calls, because those calls resolve args.timemin and
-    # args.timemax when the command line gave the time as -timedays or -timestep
     if args.showtime:
         for index, axis in enumerate(axes):
             if args.multispecplot:
@@ -1620,6 +1621,17 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     if args.timedayslist:
         args.multispecplot = True
         args.timedays = args.timedayslist[0]
+
+    # one time axis serves every model, thus the range resolves one time and before any plot runs.
+    # The plot functions used to write it back onto args as they drew, thus the range of one model
+    # reached the next one and get_time_range then dropped a model whose run ends earlier
+    apply_time_range_args(args, args.specpath)
+    if args.timemin is None and args.timedays is not None:
+        # a single -timedays names one time, thus apply_time_range_args leaves it alone. The output
+        # file name and the time annotation still need the timestep window that holds it
+        artispaths = [get_model_folder(path) for path in args.specpath if path_is_artis_model(path)]
+        if artispaths:
+            (_, _, args.timemin, args.timemax) = get_time_range(artispaths[0], timedays_range_str=args.timedays)
 
     # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
     args.color = resolve_series_styles(

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1422,6 +1422,10 @@ def addargs(parser: argparse.ArgumentParser) -> None:
         "--notimeclamp", action="store_true", help="When plotting from packets, don't clamp to timestep start/end"
     )
 
+    # no code reads this for plotspectra. It stays accepted, because a script holds the spelling,
+    # and SUPPRESS keeps it out of the help text
+    parser.add_argument("--classicartis", action="store_true", help=argparse.SUPPRESS)
+
     parser.add_argument(
         "-xunit",
         dest="xunit",
@@ -1622,16 +1626,30 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         args.multispecplot = True
         args.timedays = args.timedayslist[0]
 
+    if args.classicartis:
+        print_warning(
+            "plotspectra ignores --classicartis. A spectrum comes from spec.out or from the packets,"
+            " and not from the estimators"
+        )
+
     # one time axis serves every model, thus the range resolves one time and before any plot runs.
     # The plot functions used to write it back onto args as they drew. The range of one model then
-    # reached the next one, and get_time_range dropped a model whose run ends earlier
-    apply_time_range_args(args, args.specpath)
-    if args.timemin is None and args.timedays is not None:
-        # a single -timedays names one time, thus apply_time_range_args leaves it alone. The output
-        # file name and the time annotation still need the timestep window that holds it
-        artispaths = [get_model_folder(path) for path in args.specpath if path_is_artis_model(path)]
-        if artispaths:
-            (_, _, args.timemin, args.timemax) = get_time_range(artispaths[0], timedays_range_str=args.timedays)
+    # reached the next one, and get_time_range dropped a model whose run ends earlier.
+    # A reference spectrum can carry the .out suffix of ARTIS, thus the reference predicate decides
+    # which of the paths hold ARTIS timesteps
+    modelspecpaths = [path for path in args.specpath if not path_is_reference_spectrum(path)]
+    apply_time_range_args(args, modelspecpaths)
+
+    gave_a_time = any(value is not None for value in (args.timestep, args.timedays, args.timemin, args.timemax))
+    artispaths = [get_model_folder(path) for path in modelspecpaths if path_is_artis_model(path)]
+    if gave_a_time and artispaths and (args.timemin is None or args.timemax is None):
+        # the output file name and the time annotation need both bounds. A single -timedays names one
+        # time, and a -timemin or a -timemax on its own leaves the other side open
+        (_, _, rangemin, rangemax) = get_time_range(
+            artispaths[0], args.timestep, args.timemin, args.timemax, args.timedays
+        )
+        if math.isfinite(rangemin) and math.isfinite(rangemax):
+            args.timemin, args.timemax = rangemin, rangemax
 
     # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
     args.color = resolve_series_styles(

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1647,12 +1647,22 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     timesteppaths = artispaths or [path for path in modelspecpaths if path_is_codecomparison(path)]
     if gave_a_time and timesteppaths and (args.timemin is None or args.timemax is None):
         # the output file name and the time annotation need both bounds. A single -timedays names one
-        # time, and a -timemin or a -timemax on its own leaves the other side open
-        (_, _, rangemin, rangemax) = get_time_range(
-            timesteppaths[0], args.timestep, args.timemin, args.timemax, args.timedays
-        )
-        if math.isfinite(rangemin) and math.isfinite(rangemax):
-            args.timemin, args.timemax = rangemin, rangemax
+        # time, and a -timemin or a -timemax on its own leaves the other side open.
+        # -timedayslist names one epoch for each subplot, thus the range spans the whole list. The
+        # first epoch alone would give one name to two lists that share it
+        timedaysvalues = args.timedayslist or [args.timedays]
+        resolvedranges = [
+            get_time_range(timesteppaths[0], args.timestep, args.timemin, args.timemax, timedays)[2:]
+            for timedays in timedaysvalues
+        ]
+        finiteranges = [
+            (rangemin, rangemax)
+            for rangemin, rangemax in resolvedranges
+            if math.isfinite(rangemin) and math.isfinite(rangemax)
+        ]
+        if finiteranges:
+            args.timemin = min(rangemin for rangemin, _ in finiteranges)
+            args.timemax = max(rangemax for _, rangemax in finiteranges)
 
     # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
     args.color = resolve_series_styles(

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1635,7 +1635,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
     # one time axis serves every model, thus the range resolves one time and before any plot runs.
     # The plot functions used to write it back onto args as they drew. The range of one model then
     # reached the next one, and get_time_range dropped a model whose run ends earlier.
-    # A reference spectrum can carry the .out suffix of ARTIS, thus the reference predicate decides
+    # A reference spectrum can hold the .out suffix of ARTIS, thus the reference predicate decides
     # which of the paths hold ARTIS timesteps
     modelspecpaths = [path for path in args.specpath if not path_is_reference_spectrum(path)]
     apply_time_range_args(args, modelspecpaths)
@@ -1663,6 +1663,22 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
         if finiteranges:
             args.timemin = min(rangemin for rangemin, _ in finiteranges)
             args.timemax = max(rangemax for _, rangemax in finiteranges)
+
+    if args.multispecplot and not args.timedayslist:
+        # every later step reads one epoch of the list for each subplot, thus an absent list gave a
+        # TypeError on len(None). -timedayslist sets --multispecplot, thus the flag alone reaches here
+        exit_with_error(
+            "--multispecplot draws one subplot for each epoch of -timedayslist, and no such list was given",
+            "Give the epochs with -timedayslist, e.g. -timedayslist 260 280 300",
+        )
+
+    if args.showtime and not args.multispecplot and (args.timemin is None or args.timemax is None):
+        # the annotation writes the middle of the range, thus a missing bound gave a TypeError here.
+        # A reference spectrum has no timesteps, thus no path can resolve a range for it
+        exit_with_error(
+            "--showtime writes the middle of the plotted time range, and no time range was given",
+            "Give -timedays (e.g. -t 300 or -t 290-320), -timestep (e.g. -ts 40), or -timemin and -timemax",
+        )
 
     # the reference spectra get black and greys, and the ARTIS models get the colours of the cycle
     args.color = resolve_series_styles(

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -1642,11 +1642,14 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
     gave_a_time = any(value is not None for value in (args.timestep, args.timedays, args.timemin, args.timemax))
     artispaths = [get_model_folder(path) for path in modelspecpaths if path_is_artis_model(path)]
-    if gave_a_time and artispaths and (args.timemin is None or args.timemax is None):
+    # a code comparison path carries timesteps of its own, thus it resolves the range when no ARTIS
+    # model does. The plot code no longer writes the range back, thus nothing else would resolve it
+    timesteppaths = artispaths or [path for path in modelspecpaths if path_is_codecomparison(path)]
+    if gave_a_time and timesteppaths and (args.timemin is None or args.timemax is None):
         # the output file name and the time annotation need both bounds. A single -timedays names one
         # time, and a -timemin or a -timemax on its own leaves the other side open
         (_, _, rangemin, rangemax) = get_time_range(
-            artispaths[0], args.timestep, args.timemin, args.timemax, args.timedays
+            timesteppaths[0], args.timestep, args.timemin, args.timemax, args.timedays
         )
         if math.isfinite(rangemin) and math.isfinite(rangemax):
             args.timemin, args.timemax = rangemin, rangemax

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -659,11 +659,13 @@ def plot_artis_spectrum(
 
             if args.binflux:
                 assert args.xunit.lower() == "angstroms"
+                # f_lambda is binned as well, because --write_data returns that column. The earlier
+                # code gave it the value of y, which holds the selected y variable
                 dfspectrum = (
                     atspectra
-                    .bin_spectrum(dfspectrum, 5, "lambda_angstroms", "y")
+                    .bin_spectrum(dfspectrum, 5, "lambda_angstroms", ["y", "f_lambda"])
                     .rename({"lambda_angstroms": "x"})
-                    .with_columns(lambda_angstroms=pl.col("x"), f_lambda=pl.col("y"))
+                    .with_columns(lambda_angstroms=pl.col("x"))
                 )
 
             axis.plot(
@@ -783,7 +785,7 @@ def make_spectrum_plot(
 
         # make_plot has already applied args.ymax, thus reading the top back would inflate the value
         # that the user asked for by five percent
-        if args.stokesparam == "I" and not args.logscaley and args.ymax is None:
+        if args.stokesparam == "I" and not args.logscaley and args.ymax is None and args.ymin is None:
             # the axes carry no y margin, thus the top would sit on the tallest peak and clip it
             _, datatop = axis.get_ylim()
             axis.set_ylim(bottom=0.0, top=datatop * 1.05)
@@ -1012,7 +1014,7 @@ def plot_contributions_stacked(
         if not args.showemission:
             plotobjects.extend(absstackplot)
 
-        max_absorption = (
+        summed_absorption = (
             pl
             .DataFrame({
                 f"y{i}": df.filter(pl.col("x").is_between(xmin, xmax)).get_column("y")
@@ -1021,6 +1023,8 @@ def plot_contributions_stacked(
             .select(pl.sum_horizontal(pl.all()).max())
             .item()
         )
+        # a narrow x range can filter every series to no row, thus the maximum is null
+        max_absorption = summed_absorption if summed_absorption is not None else 0.0
 
     return plotobjects, max_absorption
 
@@ -1045,6 +1049,9 @@ def plot_reference_spectra(
 
         if index < len(args.color):
             plotkwargs["color"] = args.color[index]
+            # the dict is shared across the loop, thus a spectrum with no -label must not keep the
+            # label of the spectrum before it. Its own metadata names it instead
+            plotkwargs.pop("label", None)
             if args.label[index] is not None:
                 plotkwargs["label"] = args.label[index]
             plotkwargs["alpha"] = args.linealpha[index]
@@ -1261,12 +1268,11 @@ def make_plot(args: argparse.Namespace) -> tuple[mplfig.Figure, npt.NDArray[np.o
         legendncol = 1
         defaultoutputfile = Path("plotspectra_{timemin:.2f}d-{timemax:.2f}d.pdf")
 
-        if args.multispecplot:
-            dfalldata = make_spectrum_plot(args.specpath, axes, filterfunc, args, scale_to_peak=scale_to_peak)
-            plotobjects, plotobjectlabels = axes[0].get_legend_handles_labels()
-        else:
-            dfalldata = make_spectrum_plot(args.specpath, [axes[-1]], filterfunc, args, scale_to_peak=scale_to_peak)
-            plotobjects, plotobjectlabels = axes[-1].get_legend_handles_labels()
+        # the legend comes from the first of the axes that were drawn on, which is axes[0] for
+        # --multispecplot and axes[-1] otherwise
+        specaxes = list(axes) if args.multispecplot else [axes[-1]]
+        dfalldata = make_spectrum_plot(args.specpath, specaxes, filterfunc, args, scale_to_peak=scale_to_peak)
+        plotobjects, plotobjectlabels = specaxes[0].get_legend_handles_labels()
 
     # the annotation comes after the plot calls, because those calls resolve args.timemin and
     # args.timemax when the command line gave the time as -timedays or -timestep
@@ -1576,10 +1582,6 @@ def addargs(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("-timedayslist", nargs="+", help="List of times in days for time sequence subplots")
 
     parser.add_argument("--showtime", action="store_true", help="Write time on plot")
-
-    parser.add_argument(
-        "--classicartis", action="store_true", help="Flag to show using output from classic ARTIS branch"
-    )
 
     parser.add_argument(
         "--vpkt_match_emission_exclusion_to_opac",

--- a/artistools/spectra/plotspectra.py
+++ b/artistools/spectra/plotspectra.py
@@ -785,7 +785,7 @@ def make_spectrum_plot(
 
         # make_plot has already applied args.ymax, thus reading the top back would inflate the value
         # that the user asked for by five percent
-        if args.stokesparam == "I" and not args.logscaley and args.ymax is None and args.ymin is None:
+        if args.stokesparam == "I" and not args.logscaley and args.ymax is args.ymin is None:
             # the axes carry no y margin, thus the top would sit on the tallest peak and clip it
             _, datatop = axis.get_ylim()
             axis.set_ylim(bottom=0.0, top=datatop * 1.05)

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -387,11 +387,15 @@ def weighted_average_spectra(
     return np.average(spectra, axis=0, weights=factors)
 
 
-def bin_spectrum(dfspectrum: pl.DataFrame, nbins: int, xcol: str, ycol: str) -> pl.DataFrame:
-    """Return the mean x and the mean y of each group of nbins consecutive rows. The last group can be smaller."""
+def bin_spectrum(dfspectrum: pl.DataFrame, nbins: int, xcol: str, ycols: str | Sequence[str]) -> pl.DataFrame:
+    """Return the mean x and the mean of each y column, for each group of nbins consecutive rows.
+
+    The last group can be smaller than nbins.
+    """
+    ycollist = [ycols] if isinstance(ycols, str) else list(ycols)
     return (
         dfspectrum
-        .select(xcol, ycol)
+        .select(xcol, *ycollist)
         .with_row_index("bin")
         .group_by(pl.col("bin") // nbins, maintain_order=True)
         .mean()
@@ -485,29 +489,23 @@ def filter_packets_by_time(
     timehighdays: float,
     use_time: t.Literal["arrival", "emission", "escape"],
     gamma: bool,
-) -> tuple[pl.LazyFrame, float | None]:
-    """Filter packets with the selected time and return the escape correction when applicable."""
+) -> pl.LazyFrame:
+    """Return the packets that the selected time keeps."""
     if use_time == "arrival":
-        return dfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays)), None
+        return dfpackets.filter(pl.col("t_arrive_d").is_between(timelowdays, timehighdays))
 
     if use_time == "escape":
         escapesurfacegamma = get_escape_surface_gamma(modelpath)
-        return (
-            dfpackets.filter(
-                (pl.col("escape_time") * escapesurfacegamma / const.day_to_s).is_between(timelowdays, timehighdays)
-            ),
-            escapesurfacegamma,
+        return dfpackets.filter(
+            (pl.col("escape_time") * escapesurfacegamma / const.day_to_s).is_between(timelowdays, timehighdays)
         )
 
     col_emit_time = "tdecay" if gamma else "em_time"
     mean_correction = (pl.col(col_emit_time) - pl.col("t_arrive_d") * const.day_to_s).mean()
-    return (
-        dfpackets.filter(
-            pl.col(col_emit_time).is_between(
-                timelowdays * const.day_to_s + mean_correction, timehighdays * const.day_to_s + mean_correction
-            )
-        ),
-        None,
+    return dfpackets.filter(
+        pl.col(col_emit_time).is_between(
+            timelowdays * const.day_to_s + mean_correction, timehighdays * const.day_to_s + mean_correction
+        )
     )
 
 
@@ -599,7 +597,7 @@ def get_from_packets(
         energy_column = "e_cmf" if use_time == "escape" else "e_rf"
 
         if not packets_are_time_filtered:
-            dfpackets, _ = filter_packets_by_time(dfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
+            dfpackets = filter_packets_by_time(dfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
 
         dfpackets = dfpackets.filter(pl.col(lambda_column).is_between(lambda_bin_edges[0], lambda_bin_edges[-1]))
 
@@ -1332,7 +1330,7 @@ def get_flux_contributions_from_packets(
         )
         dirbin_nu_column = "nu_rf"
 
-        lzdfpackets, _ = filter_packets_by_time(lzdfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
+        lzdfpackets = filter_packets_by_time(lzdfpackets, modelpath, timelowdays, timehighdays, use_time, gamma)
 
         lzdfpackets, _ = atpackets.filter_packets_dirbin(
             lzdfpackets, directionbin, average_over_phi=average_over_phi, average_over_theta=average_over_theta

--- a/artistools/spectra/spectra.py
+++ b/artistools/spectra/spectra.py
@@ -168,8 +168,9 @@ def get_exspec_lambda_bin_edges(modelpath: str | Path, gamma: bool = False) -> n
         nu_centre_min = dfspec.item(0, 0)
         nu_centre_max = dfspec.item(dfspec.height - 1, 0)
 
-        # This is not an exact solution for dlognu since we're assuming the bin centre spacing matches the bin edge spacing
-        # but it's close enough for our purposes and avoids the difficulty of finding the exact solution (lots more algebra)
+        # this is not the exact dlognu, because it assumes that the spacing of the bin centres
+        # matches the spacing of the bin edges. The difference is small, and the exact solution
+        # needs much more algebra
         dlognu = math.log(dfspec.item(1, 0) / dfspec.item(0, 0))  # second nu value divided by the first nu value
         nu_min_r = nu_centre_min / (1 + 0.5 * dlognu)
         nu_max_r = nu_centre_max * (1 + 0.5 * dlognu)
@@ -204,7 +205,7 @@ def get_lambda_bin_edges(
             # a bin edge of zero stays at zero after each multiplication, thus the loop below does not stop
             msg = f"deltalogx needs a positive lower x limit, got {xmin_plot}"
             raise ValueError(msg)
-        # xmin_plot is the centre of the first bin, so we need to subtract half a bin width to get the lower edge of the first bin
+        # xmin_plot is the centre of the first bin. Subtract half a bin width to get its lower edge
         xbin_lower = xmin_plot / (1 + deltalogx) ** 0.5
         xmax = xmax_plot * (1 + deltalogx) ** 0.5
         list_x_bin_edges = [xbin_lower]

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -932,3 +932,34 @@ def test_plotspectra_accepts_classicartis_and_says_it_does_nothing(
     at.spectra.plot(argsraw=["--classicartis", "-timedays", "260-300", str(modelpath), "-outputfile", str(tmp_path)])
 
     assert "ignores --classicartis" in capsys.readouterr().err
+
+
+def test_plotspectra_timedayslist_names_the_whole_range(tmp_path: Path) -> None:
+    """-timedayslist names one epoch for each subplot, thus the file name must span the whole list.
+
+    The resolution took args.timedays, which holds the first epoch alone, thus two lists that share
+    their first epoch wrote one file name and the second plot overwrote the first.
+    """
+    names = []
+    for lastday in ("300", "330"):
+        outputfolder = tmp_path / lastday
+        outputfolder.mkdir()
+        at.spectra.plot(
+            argsraw=[
+                "-timedayslist",
+                "260",
+                lastday,
+                "--plotinvalidpart",
+                str(modelpath),
+                "-outputfile",
+                str(outputfolder),
+            ]
+        )
+        pdfnames = [path.name for path in outputfolder.glob("*.pdf")]
+        assert len(pdfnames) == 1
+        names.append(pdfnames[0])
+
+    assert names[0] != names[1], "two lists that differ in the last epoch must not share one file name"
+    # the upper bound follows the last epoch of the list, not the first
+    assert "300." in names[0]
+    assert "330." in names[1]

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -963,3 +963,31 @@ def test_plotspectra_timedayslist_names_the_whole_range(tmp_path: Path) -> None:
     # the upper bound follows the last epoch of the list, not the first
     assert "300." in names[0]
     assert "330." in names[1]
+
+
+def test_plotspectra_showtime_needs_a_time_range(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--showtime writes the middle of the time range, thus it needs both bounds.
+
+    A reference spectrum has no timesteps, thus no path could resolve a range. The annotation then
+    added two None values and raised TypeError.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        at.spectra.plot(argsraw=["--showtime", "2003du_20031213_3219_8822_00.txt", "-outputfile", str(tmp_path)])
+
+    assert excinfo.value.code == 1
+    assert "--showtime" in capsys.readouterr().err
+    assert not list(tmp_path.glob("*.pdf"))
+
+
+def test_plotspectra_multispecplot_needs_an_epoch_list(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """--multispecplot draws one subplot for each epoch of -timedayslist, thus it needs that list.
+
+    The row count read len(None) and raised TypeError. -timedayslist sets --multispecplot, thus only
+    the flag on its own reaches this case.
+    """
+    with pytest.raises(SystemExit) as excinfo:
+        at.spectra.plot(argsraw=["--multispecplot", "-timedays", "260", str(modelpath), "-outputfile", str(tmp_path)])
+
+    assert excinfo.value.code == 1
+    assert "-timedayslist" in capsys.readouterr().err
+    assert not list(tmp_path.glob("*.pdf"))

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -869,3 +869,24 @@ def test_output_spectra_rejects_a_file_name_for_the_output(tmp_path: Path) -> No
     """--output_spectra writes a folder of files, thus -o with a file suffix is an error and not a fallback."""
     with pytest.raises(ValueError, match="must name a folder"):
         at.spectra.plot(argsraw=[], specpath=[modelpath], output_spectra=True, outputfile=tmp_path / "spectra.txt")
+
+
+def test_plotspectra_refuses_two_models_whose_timestep_grids_disagree(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The plot functions wrote the resolved range back onto args, thus one model's range reached the next.
+
+    get_time_range refuses a timemin that sits after the last timestep of a model, thus the second
+    model was dropped with one printed line. One -timestep that names different days on two grids is
+    now an error, as it already is for the light curve command.
+    """
+    classic1dpath = at.get_path("testdata") / "test-classicmode_1d"
+
+    with pytest.raises(SystemExit):
+        at.spectra.plotspectra.main(
+            argsraw=["-timestep", "30", str(modelpath), str(classic1dpath), "-outputfile", str(tmp_path)]
+        )
+
+    message = capsys.readouterr().err
+    assert "timestep grids differ" in message
+    assert "-timedays" in message, "the message must name the argument that works for both models"

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -891,3 +891,44 @@ def test_plotspectra_refuses_two_models_whose_timestep_grids_disagree(
     message = capsys.readouterr().err
     assert "timestep grids differ" in message
     assert "-timedays" in message, "the message must name the argument that works for both models"
+
+
+def test_plotspectra_resolves_both_bounds_of_a_one_sided_time_range(tmp_path: Path) -> None:
+    """-timemin alone left timemax as None, thus the output file name raised TypeError on the format."""
+    at.spectra.plot(argsraw=["-timemin", "260", "--plotinvalidpart", str(modelpath), "-outputfile", str(tmp_path)])
+
+    pdfnames = [path.name for path in tmp_path.glob("*.pdf")]
+    assert len(pdfnames) == 1
+    # both bounds reach the name, thus neither side formats a None
+    assert pdfnames[0].startswith("plotspectra_260.")
+    assert "None" not in pdfnames[0]
+
+
+def test_plotspectra_takes_a_reference_named_out_before_a_model(tmp_path: Path) -> None:
+    """A reference spectrum can carry the .out suffix of ARTIS, thus its folder holds no timesteps.
+
+    The time range resolution asked such a folder for the timesteps of a run and raised
+    FileNotFoundError before any plot ran.
+    """
+    import shutil
+
+    source = at.get_path("artistools_dir") / "data" / "refspectra" / "2003du_20031213_3219_8822_00.txt"
+    shutil.copy(source, tmp_path / "myref.out")
+    shutil.copy(f"{source}.meta.yml", tmp_path / "myref.out.meta.yml")
+
+    outputfolder = tmp_path / "out"
+    outputfolder.mkdir()
+    at.spectra.plot(
+        argsraw=["-timedays", "260-300", str(tmp_path / "myref.out"), str(modelpath), "-outputfile", str(outputfolder)]
+    )
+
+    assert len(list(outputfolder.glob("*.pdf"))) == 1
+
+
+def test_plotspectra_accepts_classicartis_and_says_it_does_nothing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A script holds the spelling, thus the argument stays accepted. No code reads it for this command."""
+    at.spectra.plot(argsraw=["--classicartis", "-timedays", "260-300", str(modelpath), "-outputfile", str(tmp_path)])
+
+    assert "ignores --classicartis" in capsys.readouterr().err

--- a/artistools/spectra/test_spectra.py
+++ b/artistools/spectra/test_spectra.py
@@ -874,11 +874,12 @@ def test_output_spectra_rejects_a_file_name_for_the_output(tmp_path: Path) -> No
 def test_plotspectra_refuses_two_models_whose_timestep_grids_disagree(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The plot functions wrote the resolved range back onto args, thus one model's range reached the next.
+    """Refuse one -timestep that names different days on two timestep grids.
 
-    get_time_range refuses a timemin that sits after the last timestep of a model, thus the second
-    model was dropped with one printed line. One -timestep that names different days on two grids is
-    now an error, as it already is for the light curve command.
+    The plot functions wrote the resolved range back onto args, thus the range of one model reached
+    the next one. get_time_range refuses a timemin that sits after the last timestep of a model,
+    thus it dropped the second model and printed one line. This is now an error, as it already is
+    for the light curve command.
     """
     classic1dpath = at.get_path("testdata") / "test-classicmode_1d"
 

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -2585,3 +2585,26 @@ def test_writecomparisondata_rejects_an_empty_timestep_list(tmp_path: Path) -> N
     """An empty timestep list wrote files that hold a header and no data."""
     with pytest.raises(ValueError, match="selected_timesteps"):
         at.writecomparisondata.main(argsraw=[], modelpath=modelpath, outputpath=tmp_path, selected_timesteps=[])
+
+
+def test_ionfrac_header_names_the_ion_stage(tmp_path: Path) -> None:
+    """The header numbered the columns from zero, thus every column carried the stage below its own."""
+    at.writecomparisondata.main(
+        argsraw=[], modelpath=modelpath, outputpath=tmp_path, selected_timesteps=list(range(10))
+    )
+
+    ionfracfiles = sorted(tmp_path.glob("ionfrac_*_artisnebular.txt"))
+    assert ionfracfiles, "the run wrote no ion fraction file"
+
+    elementlist = at.get_composition_data(modelpath)
+    lowermost_of_elsymbol = {
+        at.get_elsymbol(row["Z"]).lower(): row["lowermost_ion_stage"] for row in elementlist.iter_rows(named=True)
+    }
+
+    for ionfracfile in ionfracfiles:
+        elsymbol = ionfracfile.name.split("_")[1]
+        headers = [line for line in ionfracfile.read_text(encoding="utf-8").splitlines() if "#vel_mid" in line]
+        assert headers
+        for header in headers:
+            firstioncolumn = header.split()[1]
+            assert firstioncolumn == f"{elsymbol}{lowermost_of_elsymbol[elsymbol]}"

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -656,6 +656,17 @@ def test_get_atomic_number_and_elsymbol() -> None:
     assert at.get_atomic_number("X_Fe") == 26
     assert at.get_atomic_number("UnknownXYZ") == -1
 
+    # the free neutron "n" and nitrogen "N" differ only in case, thus a title-case lookup confused them
+    assert at.get_atomic_number("n") == 0
+    assert at.get_atomic_number("N") == 7
+    assert at.get_atomic_number("X_n1") == 0
+    assert at.get_atomic_number("X_N14") == 7
+    assert at.get_z_a_nucname("X_n1") == (0, 1)
+    assert at.get_z_a_nucname("X_N14") == (7, 14)
+
+    # a symbol that the caller gave in the wrong case still resolves
+    assert at.get_atomic_number("fe") == 26
+
     assert at.get_elsymbol(26) == "Fe"
     assert at.get_elsymbol(28) == "Ni"
     assert at.get_elsymbol(1) == "H"

--- a/artistools/test_artistools.py
+++ b/artistools/test_artistools.py
@@ -1145,7 +1145,7 @@ def test_kurucz_transitions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
     dftransitions, ionlist = at.transitions.get_kurucz_transitions()
 
-    assert ionlist == [at.transitions.IonTuple(44, 1)]
+    assert ionlist == [(44, 1)]
     assert len(dftransitions) == 1
     transition = dftransitions.row(0, named=True)
     assert transition["lambda_angstroms"] == pytest.approx(7155.170)

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -38,14 +38,7 @@ if t.TYPE_CHECKING:
 defaultoutputfile = "plottransitions_cell{cell:05d}_ts{timestep:03d}_{timedays:.2f}d.pdf"
 
 
-class IonTuple(t.NamedTuple):
-    """An ion, identified by its atomic number and ion stage."""
-
-    Z: int
-    ion_stage: int
-
-
-def get_kurucz_transitions() -> tuple[pl.DataFrame, list[IonTuple]]:
+def get_kurucz_transitions() -> tuple[pl.DataFrame, list[tuple[int, int]]]:
     """Return the transitions from the bundled Kurucz gfall line list, and the ions they cover."""
 
     class KuruczTransitionTuple(t.NamedTuple):
@@ -59,7 +52,7 @@ def get_kurucz_transitions() -> tuple[pl.DataFrame, list[IonTuple]]:
         upper_statweight: float
 
     translist = []
-    ionlist: list[IonTuple] = []
+    ionlist: list[tuple[int, int]] = []
     with Path("gfall.dat").open(encoding="utf-8") as fnist:
         for line in fnist:
             row = line.split()
@@ -87,8 +80,8 @@ def get_kurucz_transitions() -> tuple[pl.DataFrame, list[IonTuple]]:
                     )
                 )
 
-                if IonTuple(Z, ion_stage) not in ionlist:
-                    ionlist.append(IonTuple(Z, ion_stage))
+                if (Z, ion_stage) not in ionlist:
+                    ionlist.append((Z, ion_stage))
 
     dftransitions = pl.DataFrame(translist, orient="row", schema=list(KuruczTransitionTuple._fields))
     return dftransitions, ionlist
@@ -174,8 +167,8 @@ def make_plot(
     yvalues: npt.NDArray[np.floating],
     temperature_list: Sequence[str],
     vardict: Mapping[str, float],
-    ionlist: Sequence[IonTuple],
-    ionpopdict: Mapping[IonTuple, float],
+    ionlist: Sequence[tuple[int, int]],
+    ionpopdict: Mapping[tuple[int, int], float],
     xmin: float,
     xmax: float,
     figure_title: str,
@@ -198,7 +191,7 @@ def make_plot(
             set_legend(axis, args, loc="upper left", handlelength=1)
 
     axislabels = [
-        f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[IonTuple(Z, ion_stage)]:.1e}/cm³)"
+        f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[Z, ion_stage]:.1e}/cm³)"
         for (Z, ion_stage) in ionlist
     ]
 
@@ -310,34 +303,34 @@ class PlotConditions:
     A temperature name of "NOTEMPNLTE" selects the NLTE populations in place of an LTE calculation.
     """
 
-    ionpopdict: Mapping[IonTuple, float]
+    ionpopdict: Mapping[tuple[int, int], float]
     temperature_list: Sequence[str]
     vardict: Mapping[str, float]
     figure_title: str
     dfnltepops: pl.DataFrame | None = None
 
 
-def get_ionlist() -> list[IonTuple]:
+def get_ionlist() -> list[tuple[int, int]]:
     """Return the ions that the plot shows.
 
     The commented lines are further ions that a user can select in place of these.
     """
     return [
-        IonTuple(26, 1),
-        IonTuple(26, 2),
-        IonTuple(26, 3),
-        IonTuple(27, 2),
-        IonTuple(27, 3),
-        IonTuple(28, 2),
-        IonTuple(28, 3),
-        # IonTuple(45, 1),
-        # IonTuple(54, 1),
-        # IonTuple(54, 2),
-        # IonTuple(55, 1),
-        # IonTuple(55, 2),
-        # IonTuple(58, 1),
-        # IonTuple(79, 1),
-        # IonTuple(83, 1),
+        (26, 1),
+        (26, 2),
+        (26, 3),
+        (27, 2),
+        (27, 3),
+        (28, 2),
+        (28, 3),
+        # (45, 1),
+        # (54, 1),
+        # (54, 2),
+        # (55, 1),
+        # (55, 2),
+        # (58, 1),
+        # (79, 1),
+        # (83, 1),
     ]
 
 
@@ -367,7 +360,7 @@ def get_cell_conditions(modelpath: Path, args: argparse.Namespace) -> CellCondit
     )
 
 
-def get_model_conditions(modelpath: Path, cell: CellConditions, ionlist: Sequence[IonTuple]) -> PlotConditions:
+def get_model_conditions(modelpath: Path, cell: CellConditions, ionlist: Sequence[tuple[int, int]]) -> PlotConditions:
     """Return the NLTE populations and the temperatures of one cell of a model."""
     dfnltepops = at.nltepops.read_files(modelpath, modelgridindex=cell.modelgridindex, timestep=cell.timestep)
 
@@ -386,7 +379,7 @@ def get_model_conditions(modelpath: Path, cell: CellConditions, ionlist: Sequenc
 
     return PlotConditions(
         ionpopdict={
-            IonTuple(Z, ion_stage): float(
+            (Z, ion_stage): float(
                 dfnltepops.filter((pl.col("Z") == Z) & (pl.col("ion_stage") == ion_stage))["n_NLTE"].sum()
             )
             for Z, ion_stage in ionlist
@@ -398,7 +391,7 @@ def get_model_conditions(modelpath: Path, cell: CellConditions, ionlist: Sequenc
     )
 
 
-def get_fixed_temperature_conditions(args: argparse.Namespace, ionlist: Sequence[IonTuple]) -> PlotConditions:
+def get_fixed_temperature_conditions(args: argparse.Namespace, ionlist: Sequence[tuple[int, int]]) -> PlotConditions:
     """Return one series for each temperature that -T names, with the same population for every ion."""
     if not args.T:
         args.T = [2000]
@@ -411,7 +404,7 @@ def get_fixed_temperature_conditions(args: argparse.Namespace, ionlist: Sequence
         temperature_list.append(tlabel)
 
     return PlotConditions(
-        ionpopdict={IonTuple(Z, ionstage): 1.0 for Z, ionstage in ionlist},
+        ionpopdict=dict.fromkeys(ionlist, 1.0),
         temperature_list=temperature_list,
         vardict=vardict,
         figure_title=f"Te = {args.T[0]:.1f}" if len(args.T) == 1 else "",
@@ -459,20 +452,20 @@ def add_artis_transition_columns(pldftransitions: pl.DataFrame, pldflevels: pl.D
 
 def get_ion_spectra(
     xvalues: npt.NDArray[np.floating],
-    ionlist: Sequence[IonTuple],
+    ionlist: Sequence[tuple[int, int]],
     conditions: PlotConditions,
     adata: pl.DataFrame | None,
     dftransgfall: pl.DataFrame | None,
     plot_resolution: int,
     args: argparse.Namespace,
-) -> tuple[npt.NDArray[np.floating], dict[IonTuple, float]]:
+) -> tuple[npt.NDArray[np.floating], dict[tuple[int, int], float]]:
     """Return the spectrum of each ion at each temperature, and the departure coefficient of two lines.
 
     The plot marks the departure coefficient of the Fe II 7155 line and of the Ni II 7378 line, thus
     this function gives back both.
     """
     yvalues = np.zeros((len(conditions.temperature_list), len(ionlist), len(xvalues)))
-    depcoeffs: dict[IonTuple, float] = {}
+    depcoeffs: dict[tuple[int, int], float] = {}
 
     iterdict: Iterable[Mapping[str, t.Any]] = (
         adata.iter_rows(named=True)
@@ -482,7 +475,7 @@ def get_ion_spectra(
     for ion in iterdict:
         assert isinstance(ion["Z"], int)
         assert isinstance(ion["ion_stage"], int)
-        ionid = IonTuple(ion["Z"], ion["ion_stage"])
+        ionid = (ion["Z"], ion["ion_stage"])
         if ionid not in ionlist:
             continue
 
@@ -491,7 +484,7 @@ def get_ion_spectra(
 
         print()
         at.print_heading(
-            f"{at.get_elsymbol(ionid.Z)} {at.roman_numerals[ionid.ion_stage]:3s} "
+            f"{at.get_ionstring(ionid[0], ionid[1], style='spectral'):8s} "
             f"(pop={conditions.ionpopdict[ionid]:.2e} / cm3, {pldftransitions.height:6d} transitions)"
         )
 
@@ -572,12 +565,10 @@ def get_ion_spectra(
     return yvalues, depcoeffs
 
 
-def add_nlte_pop(pldftransitions: pl.DataFrame, conditions: PlotConditions, ionid: IonTuple) -> pl.DataFrame:
+def add_nlte_pop(pldftransitions: pl.DataFrame, conditions: PlotConditions, ionid: tuple[int, int]) -> pl.DataFrame:
     """Add the NLTE population of the upper level, its flux factor, and its departure coefficient."""
     assert conditions.dfnltepops is not None
-    dfnltepops_thision = conditions.dfnltepops.filter(
-        (pl.col("Z") == ionid.Z) & (pl.col("ion_stage") == ionid.ion_stage)
-    )
+    dfnltepops_thision = conditions.dfnltepops.filter((pl.col("Z") == ionid[0]) & (pl.col("ion_stage") == ionid[1]))
     nltepopdict = dict(zip(dfnltepops_thision["level"], dfnltepops_thision["n_NLTE"], strict=True))
 
     return pldftransitions.with_columns(
@@ -588,9 +579,9 @@ def add_nlte_pop(pldftransitions: pl.DataFrame, conditions: PlotConditions, ioni
     )
 
 
-def get_line_departure_coeffs(dftransitions: pl.DataFrame, ionid: IonTuple) -> dict[IonTuple, float]:
+def get_line_departure_coeffs(dftransitions: pl.DataFrame, ionid: tuple[int, int]) -> dict[tuple[int, int], float]:
     """Return the departure coefficient of the Fe II 7155 line or of the Ni II 7378 line."""
-    upperlower = {IonTuple(26, 2): (16, 5), IonTuple(28, 2): (6, 0)}.get(ionid)
+    upperlower = {(26, 2): (16, 5), (28, 2): (6, 0)}.get(ionid)
     if upperlower is None:
         return {}
 
@@ -603,7 +594,7 @@ def get_line_departure_coeffs(dftransitions: pl.DataFrame, ionid: IonTuple) -> d
     return {ionid: float(departure.item(0))}
 
 
-def print_ionisation_table(cell: CellConditions, depcoeffs: Mapping[IonTuple, float]) -> None:
+def print_ionisation_table(cell: CellConditions, depcoeffs: Mapping[tuple[int, int], float]) -> None:
     """Print the ionisation fractions of iron and of nickel, beside two departure coefficients."""
     estimators = cell.estimators
 
@@ -619,7 +610,7 @@ def print_ionisation_table(cell: CellConditions, depcoeffs: Mapping[IonTuple, fl
 
         return strions, ionfracs_str
 
-    def departure(ionid: IonTuple, width: int) -> str:
+    def departure(ionid: tuple[int, int], width: int) -> str:
         """Give the departure coefficient of one line, or a mark when the run covered no such line."""
         value = depcoeffs.get(ionid)
 
@@ -633,8 +624,8 @@ def print_ionisation_table(cell: CellConditions, depcoeffs: Mapping[IonTuple, fl
         "      T_e    Fe III/II       Ni III/II"
     )
     print(
-        f"{cell.velocity:5.0f} km/s({cell.modelgridindex})      {departure(IonTuple(26, 2), 5)}                   "
-        f"{departure(IonTuple(28, 2), 0)}        "
+        f"{cell.velocity:5.0f} km/s({cell.modelgridindex})      {departure((26, 2), 5)}                   "
+        f"{departure((28, 2), 0)}        "
         f"{est_fe_ionfracs_str}   /  {est_ni_ionfracs_str}      {estimators['Te']:.0f}    "
         f"{estimators['nnion_Fe_III'] / estimators['nnion_Fe_II']:.2f}          "
         f"{estimators['nnion_Ni_III'] / estimators['nnion_Ni_II']:5.2f}"

--- a/artistools/transitions.py
+++ b/artistools/transitions.py
@@ -191,7 +191,7 @@ def make_plot(
             set_legend(axis, args, loc="upper left", handlelength=1)
 
     axislabels = [
-        f"{at.get_elsymbol(Z)} {at.roman_numerals[ion_stage]}\n(pop={ionpopdict[Z, ion_stage]:.1e}/cm³)"
+        f"{at.get_ionstring(Z, ion_stage, style='spectral')}\n(pop={ionpopdict[Z, ion_stage]:.1e}/cm³)"
         for (Z, ion_stage) in ionlist
     ]
 

--- a/artistools/writecomparisondata.py
+++ b/artistools/writecomparisondata.py
@@ -72,7 +72,7 @@ def write_single_estimator(
     allnonemptymgilist: Sequence[int],
     outfile: Path,
 ) -> None:
-    """Write the deposition of every cell at the selected timesteps, in code comparison workshop format."""
+    """Write the deposition of every cell at the selected timesteps, in the format of the workshop."""
     modeldata, _ = get_nonempty_cells(modelpath, allnonemptymgilist)
     with Path(outfile).open("w", encoding="utf-8") as f:
         write_ntimes_nvel(f, selected_timesteps, modelpath)

--- a/artistools/writecomparisondata.py
+++ b/artistools/writecomparisondata.py
@@ -60,7 +60,8 @@ def get_nonempty_cells(
     modelpath: str | Path, allnonemptymgilist: Sequence[int]
 ) -> tuple[pl.DataFrame, dict[str, t.Any]]:
     """Return the model data of the cells that hold estimator data, with the mid-point velocity of each one."""
-    lzmodeldata, modelmeta = at.inputmodel.get_modeldata(modelpath, derived_cols=["vel_r_mid"])
+    # write_phys reads logrho, which a 3D model.txt does not carry. The reader derives it from rho
+    lzmodeldata, modelmeta = at.inputmodel.get_modeldata(modelpath, derived_cols=["vel_r_mid", "logrho"])
     return lzmodeldata.filter(pl.col("modelgridindex").is_in(allnonemptymgilist)).collect(), modelmeta
 
 
@@ -70,22 +71,16 @@ def write_single_estimator(
     estimators: dict[tuple[int, int], dict[str, t.Any]],
     allnonemptymgilist: Sequence[int],
     outfile: Path,
-    keyname: str,
 ) -> None:
-    """Write one estimator's value in every cell at the selected timesteps, in code comparison workshop format."""
+    """Write the deposition of every cell at the selected timesteps, in code comparison workshop format."""
     modeldata, _ = get_nonempty_cells(modelpath, allnonemptymgilist)
     with Path(outfile).open("w", encoding="utf-8") as f:
         write_ntimes_nvel(f, selected_timesteps, modelpath)
-        if keyname == "total_dep":
-            f.write("#vel_mid[km/s] Edep_t0[erg/s/cm^3] Edep_t1[erg/s/cm^3] ... Edep_tn[erg/s/cm^3]\n")
-        elif keyname == "nne":
-            f.write("#vel_mid[km/s] ne_t0[/cm^3] ne_t1[/cm^3] … ne_tn[/cm^3]\n")
-        elif keyname == "Te":
-            f.write("#vel_mid[km/s] Tgas_t0[K] Tgas_t1[K] ... Tgas_tn[K]\n")
+        f.write("#vel_mid[km/s] Edep_t0[erg/s/cm^3] Edep_t1[erg/s/cm^3] ... Edep_tn[erg/s/cm^3]\n")
         for modelgridindex, vel_r_mid in modeldata.select("modelgridindex", "vel_r_mid").iter_rows():
             f.write(f"{vel_r_mid / km_to_cm:.2f}")
             for timestep in selected_timesteps:
-                cellvalue = estimators[timestep, modelgridindex][keyname]
+                cellvalue = estimators[timestep, modelgridindex]["total_dep"]
                 f.write(f" {cellvalue:.4e}")
             f.write("\n")
 
@@ -108,6 +103,11 @@ def write_ionfracts(
         atomic_number = elementlist["Z"].item(elementindex)
         elsymb = at.get_elsymbol(atomic_number)
         nions = elementlist["nions"].item(elementindex)
+        lowermost_ion_stage = elementlist["lowermost_ion_stage"].item(elementindex)
+        # the header must name the ion stage that each column holds. A count from zero made every
+        # reader, this repository included, attribute each column to the stage below it
+        ion_stages = [lowermost_ion_stage + ion for ion in range(nions)]
+        ionstrs = [at.get_ionstring(atomic_number, ion_stage, sep="_", style="spectral") for ion_stage in ion_stages]
         pathfileout = Path(outputpath, f"ionfrac_{elsymb.lower()}_{model_id}_artisnebular.txt")
         fileisallzeros = True  # will be changed when a non-zero is encountered
         with pathfileout.open("w", encoding="utf-8") as f:
@@ -118,13 +118,11 @@ def write_ionfracts(
             for timestep in selected_timesteps:
                 f.write(f"#TIME: {times[timestep]:.2f}\n")
                 f.write(f"#NVEL: {len(allnonemptymgilist)}\n")
-                f.write(f"#vel_mid[km/s] {' '.join([f'{elsymb.lower()}{ion}' for ion in range(nions)])}\n")
+                f.write(f"#vel_mid[km/s] {' '.join([f'{elsymb.lower()}{ion_stage}' for ion_stage in ion_stages])}\n")
                 for modelgridindex, vel_r_mid in cellrows:
                     f.write(f"{vel_r_mid / km_to_cm:.2f}")
                     elabund = estimators[timestep, modelgridindex].get(f"nnelement_{elsymb}", 0)
-                    for ion in range(nions):
-                        ion_stage = ion + elementlist["lowermost_ion_stage"].item(elementindex)
-                        ionstr = at.get_ionstring(atomic_number, ion_stage, sep="_", style="spectral")
+                    for ionstr in ionstrs:
                         ionabund = estimators[timestep, modelgridindex].get(f"nnion_{ionstr}", 0)
                         ionfrac = ionabund / elabund if elabund > 0 else 0
                         if ionfrac > 0.0:
@@ -247,7 +245,6 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
             estimators,
             allnonemptymgilist,
             Path(args.outputfile, f"edep_{model_id}_artisnebular.txt"),
-            keyname="total_dep",
         )
 
         write_phys(modelpath, model_id, selected_timesteps, estimators, allnonemptymgilist, args.outputfile)

--- a/artistools/writecomparisondata.py
+++ b/artistools/writecomparisondata.py
@@ -65,7 +65,7 @@ def get_nonempty_cells(
     return lzmodeldata.filter(pl.col("modelgridindex").is_in(allnonemptymgilist)).collect(), modelmeta
 
 
-def write_single_estimator(
+def write_edep(
     modelpath: str | Path,
     selected_timesteps: Sequence[int],
     estimators: dict[tuple[int, int], dict[str, t.Any]],
@@ -239,7 +239,7 @@ def main(args: argparse.Namespace | None = None, argsraw: Sequence[str] | None =
 
         write_spectra(modelpath, selected_timesteps, Path(args.outputfile, f"spectra_{model_id}_artisnebular.txt"))
 
-        write_single_estimator(
+        write_edep(
             modelpath,
             selected_timesteps,
             estimators,

--- a/rust/src/estimators.rs
+++ b/rust/src/estimators.rs
@@ -1,5 +1,6 @@
 use crate::parse::malformed;
 use crate::parse::open_decompressed;
+use crate::parse::parse_f32_field;
 use crate::parse::parse_field;
 use polars::prelude::*;
 use pyo3::prelude::*;
@@ -184,7 +185,7 @@ impl EstimatorColumns {
             let ionstage = ionstage.strip_suffix(':').ok_or_else(|| {
                 malformed(format!("ion stage {ionstage:?} has no trailing colon"))
             })?;
-            let colvalue: f32 = parse_field(value, "a number")?;
+            let colvalue = parse_f32_field(value, "a number")?;
 
             if variablename == "populations" {
                 if ionstage == "SUM" {

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -44,6 +44,29 @@ pub fn parse_field<T: FromStr>(token: &str, expected: &str) -> PolarsResult<T> {
         .map_err(|_| malformed(format!("could not parse {token:?} as {expected}")))
 }
 
+/// Parse a measured value into f32, refusing a number that f32 cannot hold
+///
+/// ARTIS writes a rate far below the smallest f32, e.g. "5.313e-95" in the `gamma_R` row of the test
+/// model. Rust parses such a token to 0.0 with no error, which is the right value for a rate that
+/// small. A token above the largest f32 parses to infinity, which would spread through every mean
+/// and sum that reads the column, thus this function rejects it instead.
+pub fn parse_f32_field(token: &str, expected: &str) -> PolarsResult<f32> {
+    let value: f64 = parse_field(token, expected)?;
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "the check below rejects a value that f32 cannot hold"
+    )]
+    let value_f32 = value as f32;
+
+    if value.is_finite() && !value_f32.is_finite() {
+        return Err(malformed(format!(
+            "{token:?} is outside the range that f32 holds"
+        )));
+    }
+
+    Ok(value_f32)
+}
+
 /// Take the next token of a line and parse it, failing if the line ends first
 pub fn next_field<'a, T: FromStr>(
     tokens: &mut impl Iterator<Item = &'a str>,

--- a/rust/src/parse.rs
+++ b/rust/src/parse.rs
@@ -44,12 +44,12 @@ pub fn parse_field<T: FromStr>(token: &str, expected: &str) -> PolarsResult<T> {
         .map_err(|_| malformed(format!("could not parse {token:?} as {expected}")))
 }
 
-/// Parse a measured value into f32, refusing a number that f32 cannot hold
+/// Parse a measured value into f32 and reject a number that f32 cannot hold
 ///
 /// ARTIS writes a rate far below the smallest f32, e.g. "5.313e-95" in the `gamma_R` row of the test
 /// model. Rust parses such a token to 0.0 with no error, which is the right value for a rate that
-/// small. A token above the largest f32 parses to infinity, which would spread through every mean
-/// and sum that reads the column, thus this function rejects it instead.
+/// small. A token above the largest f32 parses to infinity. Such a value spreads through every mean
+/// and sum that reads the column, thus this function rejects it.
 pub fn parse_f32_field(token: &str, expected: &str) -> PolarsResult<f32> {
     let value: f64 = parse_field(token, expected)?;
     #[allow(


### PR DESCRIPTION
This branch corrects the defects that a review of the whole codebase found. It also makes the commands for large models faster. Each commit message gives the reason and the measurements for its changes.

## Corrections that change a result

- `get_atomic_number("n")` gave 7 (nitrogen) and not 0 for the free neutron.
- `write_ionfracts` numbered the ion stages of the header from zero and not from `lowermost_ion_stage`.
- `from_e2e_model` replaced the dynamical ejecta in the adjacent cell, because it compared a 0-based index with a 1-based column.
- `-mergecells` wrote the particle contributions of the fine grid.
- `make1dslicefrom3d` put each shell boundary one cell width too near the centre.
- `get_cone_shells` counted X_Ni57 and X_Co57 twice.
- `maptogrid` ignored part of each kernel.
- These gave incorrect values or read an incorrect file: `--binflux --write_data`, `plotlinefluxes`, `-plotvspecpol`, the direction-resolved gamma-ray light curve, and the angle average.
- `plotspectra` did not plot one model, and a reference spectrum took the label of the one before it.

Other commits prevent a crash or the use of an old cache, e.g. for a run with 10 000 or more MPI ranks, an old `.bak` file, an empty cell, or a code comparison file of one epoch.

## Performance on a full kilonova run

These measurements used a 3D SFHo_long run with 125 000 cells, 1957 particles, and 10⁸ packets, on macOS with 14 cores.

| command | before | after |
| --- | --- | --- |
| `maptogrid -ncoordgrid 100` | 13.7 s, 1.47 GB | 4.3 s, 1.07 GB |
| `gsinetworkdecayproducts` (2015 trajectories) | 54.8 s | 21.0 s |
| `comparetogsinetwork -modelgridindex -1` | 61.6 s, 10.3 GB | 24.3 s, 4.5 GB |
| same, with polars 2.0.0rc1 | more than 600 s | 23.5 s, 4.2 GB |

Polars 2.0 uses the streaming engine by default. The estimator scan now removes the repeated rows of a restarted run with a semi join and not with `unique()`. Thus a query of the estimators can stream. `plotlightcurves -topnucs` and the global heating query needed no change at this scale.

## Not in this branch

- Design changes that affect many call sites: the `derived_cols` parameter, the direction-bin count for each model, the plot items of `plotestimators`, and the `main` of `solvespencerfano`.
- The `import artistools as at` lines of nine package modules.

## Verification

CI passes on `d4869050`. Locally, the full test suite passes on polars 1.44.2 and on 2.0.0rc1 (659 passed, 1 skipped), and ruff, pyrefly, ty and refurb pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
